### PR TITLE
Fix stretching of plot text (axis labels, title).

### DIFF
--- a/Gui/opensim/plotter/src/org/opensim/plotter/Plot.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/Plot.java
@@ -115,6 +115,10 @@ public class Plot {
       new JOpenSimChartMouseListener(chartPanel);
       chartPanel.setDisplayToolTips(true);
       chartPanel.setInitialDelay(0);
+      // Prevent text (axis labels, title) from stretching when enlarging
+      // the plot window.
+      chartPanel.setMaximumDrawWidth(3000);
+      chartPanel.setMaximumDrawHeight(3000);
       
       // Add Export Data option
       JPopupMenu stdPopup = chartPanel.getPopupMenu();


### PR DESCRIPTION
This PR prevents the stretching of text on the plot when the plot is resized.

Before:
<img width="1438" alt="stretched" src="https://cloud.githubusercontent.com/assets/846001/11911289/1a1864f2-a5c6-11e5-8b5d-1d953af0470b.png">

After:
<img width="1432" alt="untitled" src="https://cloud.githubusercontent.com/assets/846001/11911290/1f284eda-a5c6-11e5-83e8-d4c167460987.png">

Note that the stretching will still occur for figures with dimensions greater
than 3000 x 3000 pixels, but I don't think monitors are really that big.

@aseth1, Merry Christmas :christmas_tree: !

Fixes #8.
