### PR TITLE
Use OpenSimConfig file to locate the Java src files

### DIFF
--- a/Gui/opensim/CMakeLists.txt
+++ b/Gui/opensim/CMakeLists.txt
@@ -22,7 +22,7 @@ message(STATUS "Replacing exising Java files with ones from opensim-core.")
 find_package(Ant REQUIRED)
 
 add_custom_target(CopyOpenSimCore ALL
-                  COMMAND ${Ant_EXECUTABLE} copy-java-bindings -Dapi.dir="${OpenSim_ROOT_DIR}"
+                  COMMAND ${Ant_EXECUTABLE} copy-java-bindings -DapiJava.dir="${OpenSim_JAVA_FILES_DIR}"
                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/build.xml"
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   COMMENT "Copy opensim-core Java Bindings to GUI.")

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -5,6 +5,7 @@
 <project name="opensim" basedir=".">
     <description>Builds the module suite opensim.</description>
     <property name="api.dir" value="C:/Dev/gui/opensim-gui/OpenSimAPI-install"/>
+    <property name="apiJava.dir" value="C:/Dev/gui/opensim-gui/OpenSimAPI-install/sdk/Java/org"/>
     <property name="models.dir" value="C:/Dev/gui/opensim-models"/>
     <property name="visualizer.dir" value="C:/Dev/opensim-threejs"/>
     <import file="nbproject/build-impl.xml"/>
@@ -13,7 +14,7 @@
     </target>
     <target name="copy-java-bindings" description="Copy results of builing opensim-core with Java Bindings to gui">
          <copy todir="modeling/src/org/opensim/modeling">
-            <fileset dir="${api.dir}/sdk/Java/org/opensim/modeling" />
+            <fileset dir="${apiJava.dir}/opensim/modeling" />
         </copy>
     </target>
     <target name="unzip-distro" depends="build-zip" 


### PR DESCRIPTION
Change build files to leverage variables in OpenSimConfig to make build scripts work cross platform regardless of API installation layout.
