### PR TITLE
Remove need for external model file to read mocap data

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ModelForExperimentalData.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ModelForExperimentalData.java
@@ -57,7 +57,7 @@ public class ModelForExperimentalData extends Model{
      * Creates a new instance of ModelForExperimentalData
      */
     public ModelForExperimentalData(int i, AnnotatedMotion motionData) throws IOException {
-        super(TheApp.getInstallDir()+File.separatorChar+"Models"+File.separatorChar+"Internal"+File.separatorChar+"_openSimlab.osim");
+        super();
         setName("ExperimentalData_"+i);
         this.motionData=motionData;
         //setup();


### PR DESCRIPTION
In the past we used a file to create a model for visualizing experimental data. Not necessary anymore.