### PR TITLE
Remove QuickSearch bar on macOS.

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/layer.xml
+++ b/Gui/opensim/view/src/org/opensim/view/layer.xml
@@ -742,6 +742,7 @@
         <file name="File_hidden"/>
         <file name="Memory_hidden"/>
         <file name="Standard.xml_hidden"/>
+        <file name="QuickSearch_hidden" />
     </folder>
     <folder name="Windows2">
         <folder name="Components">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/846001/26858012-c4e8fb80-4ae3-11e7-8346-e48ea657f3e8.png)

After:
![image](https://user-images.githubusercontent.com/846001/26858018-d5643808-4ae3-11e7-8614-a743c631bf7d.png)


I did not test on Windows.

Ignore the change of "Simulation" to "TODO"; I did not commit this change :).
