### PR TITLE
Make Pathpoints hidden by default.

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -495,7 +495,7 @@ public class ModelVisualizationJson extends JSONObject {
         Vec3 location = pathPoint.getLocation(state);
         localTransform.setP(location);
         bpptInBodyJson.put("matrix", JSONUtilities.createMatrixFromTransform(localTransform, new Vec3(1.0), visScaleFactor));
-        bpptInBodyJson.put("visible", true);
+        bpptInBodyJson.put("visible", false);
         children.add(bpptInBodyJson);
         return ppoint_uuid;
     }


### PR DESCRIPTION
Pathpoints don't need to be visible and managed for appearance all the time. They can still be selectable  and graphically movable from Path Editor .