### PR TITLE
Restore app.name to OpenSim

### DIFF
--- a/Gui/opensim/nbproject/project.properties
+++ b/Gui/opensim/nbproject/project.properties
@@ -1,6 +1,6 @@
 app.icon=branding/core/core.jar/org/netbeans/core/startup/frame48.gif
 app.icon.icns=installer_files/OSX/opensim.icns
-app.name=${branding.token}
+app.name=OpenSim
 app.title=OpenSim
 app.version=4.0
 auxiliary.org-netbeans-modules-apisupport-installer.license-type=no


### PR DESCRIPTION
NetBeans automatically resets `app.name` to `opensim`, which causes minor issues with the Mac release (the app icon no longer appears properly).