### PR TITLE
Temporarily disable setting integratorSettingsPanel from tools 

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
@@ -601,7 +601,7 @@ public class AnalyzeAndForwardToolPanel extends BaseToolPanel implements Observe
       maxDT.setText(numFormat.format(toolModel.getMaxDT()));
       minDT.setText(numFormat.format(toolModel.getMinDT()));
       errorTolerance.setText(numFormat.format(toolModel.getErrorTolerance()));
-      useSpecifiedDtActionPerformed(null);
+      //useSpecifiedDtActionPerformed(null);
    }
 
    //------------------------------------------------------------------------


### PR DESCRIPTION
This should not affect ForwardTool but may break integrator settings other than default for CMC, RRA. Opened issue to track.