### PR TITLE
macOS: Change permissions of OpenSim installation.

### DIFF
--- a/Installer/macOS/Resources/conclusion.txt
+++ b/Installer/macOS/Resources/conclusion.txt
@@ -1,2 +1,9 @@
-OpenSim is now installed in either /Applications/ (if you installed
-system-wide) or ~/Applications/ (if you selected "Install for me only").
+OpenSim is now installed in either:
+
+  - /Applications/ (if you installed system-wide), or
+  - ~/Applications/ (if you selected "Install for me only").
+
+If you have installed OpenSim previously, you can run the following in a
+Terminal to clear previous OpenSim preferences:
+
+    defaults delete org.opensim.utils

--- a/Installer/macOS/Resources/welcome.txt
+++ b/Installer/macOS/Resources/welcome.txt
@@ -1,5 +1,3 @@
 You will be guided through the steps necessary to install this software.
 
-**IMPORTANT** This is a beta release, and you may encounter bugs.
-
-**IMPORTANT** This beta release will not work if installed system-wide. After agreeing to the license, click "Change Install Location..." and select "Install for me only." 
+**IMPORTANT** This is a preview release, and you may encounter bugs.

--- a/Installer/macOS/scripts/postinstall
+++ b/Installer/macOS/scripts/postinstall
@@ -1,10 +1,28 @@
 #!/bin/sh
 
-mkdir -p "$HOME/Library/Application Support/OpenSim/4.0.Beta/config/Windows2Local/Modes/"
+# Who's the current user running the installer?
+# https://apple.stackexchange.com/questions/144159/how-can-i-determine-the-invoking-user-in-an-apple-installer-postinstall-script
+INSTALLER_USER=$(stat -f '%Su' $HOME)
 
-# This script is a temporary hack to deal with
-# https://github.com/opensim-org/opensim-gui/issues/251
-cat > "$HOME/Library/Application Support/OpenSim/4.0.Beta/config/Windows2Local/Modes/editor.wsmode" <<EOF
+# TODO remove when we fix https://github.com/opensim-org/opensim-gui/issues/194
+# In case the user chose to install in the system-wide /Applications directory,
+# change the permissions of the threejs/editor so that the GUI can write *.json
+# files to this dir.
+# The argument $2 is the target install location for the app.
+# http://s.sudre.free.fr/Stuff/PackageMaker_Howto.html
+# If installed system-wide, the permissions group will be wheel; we need it to
+# be staff.
+THREEJS_EDITOR_DIR="$2/OpenSim 4.0.Beta/OpenSim 4.0.Beta.app/Contents/Resources/OpenSim/threejs/editor"
+chown $INSTALLER_USER:staff "$THREEJS_EDITOR_DIR"
+# Allow other users to also use OpenSim.
+chmod g+w "$THREEJS_EDITOR_DIR"
+
+# TODO The next two commands are a temporary hack to deal with
+# https://github.com/opensim-org/opensim-gui/issues/251.
+
+# The current user should be able to edit the app support dir; so use `-u`.
+sudo -u $INSTALLER_USER mkdir -p "$HOME/Library/Application Support/OpenSim/4.0.Beta/config/Windows2Local/Modes/"
+sudo -u $INSTALLER_USER cat > "$HOME/Library/Application Support/OpenSim/4.0.Beta/config/Windows2Local/Modes/editor.wsmode" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 
 <mode version="2.4">


### PR DESCRIPTION
@aymanhab , I don't think I'll be able to fix #194 by tomorrow.  This PR is a workaround that allows users to install into `/Applications` instead of `~/Applications` by changing certain file permissions after the installation.  I tested this locally.