### PR TITLE
Remove obsolete preferences

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/actions/EditPreferencesJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/actions/EditPreferencesJPanel.java
@@ -71,7 +71,6 @@ public class EditPreferencesJPanel extends javax.swing.JPanel {
        "Markers Color",
        "AntiAliasingFrames",
        "Marker Display Radius",
-       "Muscle Display Radius",
        "NonCurrentModelOpacity",
        "Refresh Rate (ms.)"
        


### PR DESCRIPTION
Some preferences from 3.3 do not apply anymore:
Background Color, Opacity of models, Marker Display Radius and a couple others. 