### PR TITLE
Purge results file on start of ForwardTool run from running_dude 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
@@ -263,6 +263,8 @@ public class JavaMotionDisplayerCallback extends AnalysisWrapperWithTimer {
 
     public int step(State s, int stepNumber) {
         int retValue=0;
+        if (ownsStorage && stepNumber==0)
+            storage.purge();
         //retValue = super.step(s, stepNumber);
         processStep(s, stepNumber);
         /*


### PR DESCRIPTION
Analysis begin() method was not get called by the API when invoking forward tool from running dude.