### PR TITLE
Add method to check that some models are already loaded in GUI. 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/pub/OpenSimDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/OpenSimDB.java
@@ -106,6 +106,10 @@ public class OpenSimDB extends Observable implements Externalizable{
     public Model getModelByIndex(int i) {
         return models.get(i);
     }
+
+    public boolean hasModels() {
+        return getInstance().getCurrentModel()!= null;
+    }
     public enum CloseModelDefaultAction {
         SAVE,
         DISCARD,


### PR DESCRIPTION
Used to reduce coupling between GUI modules to avoid dependency on org.opensim.modeling