### PR TITLE
Replace TreeTableModel(Adapter).java

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/editors/TreeTableModel.java
+++ b/Gui/opensim/view/src/org/opensim/view/editors/TreeTableModel.java
@@ -1,6 +1,6 @@
 /*
  * TreeTableModel.java
- * 
+ *
  * Copyright 1998 Sun Microsystems, Inc.  All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,13 +36,13 @@ import javax.swing.tree.TreeModel;
 
 /**
  * TreeTableModel is the model used by a JTreeTable. It extends TreeModel
- * to add methods for getting inforamtion about the set of columns each 
- * node in the TreeTableModel may have. Each column, like a column in 
- * a TableModel, has a name and a type associated with it. Each node in 
- * the TreeTableModel can return a value for each of the columns and 
- * set that value if isCellEditable() returns true. 
+ * to add methods for getting inforamtion about the set of columns each
+ * node in the TreeTableModel may have. Each column, like a column in
+ * a TableModel, has a name and a type associated with it. Each node in
+ * the TreeTableModel can return a value for each of the columns and
+ * set that value if isCellEditable() returns true.
  *
- * @author Philip Milne 
+ * @author Philip Milne
  * @author Scott Violet
  */
 public interface TreeTableModel extends TreeModel
@@ -63,19 +63,19 @@ public interface TreeTableModel extends TreeModel
     public Class getColumnClass(int column);
 
     /**
-     * Returns the value to be displayed for node <code>node</code>, 
+     * Returns the value to be displayed for node <code>node</code>,
      * at column number <code>column</code>.
      */
     public Object getValueAt(Object node, int column);
 
     /**
-     * Indicates whether the the value for node <code>node</code>, 
+     * Indicates whether the the value for node <code>node</code>,
      * at column number <code>column</code> is editable.
      */
     public boolean isCellEditable(Object node, int column);
 
     /**
-     * Sets the value for node <code>node</code>, 
+     * Sets the value for node <code>node</code>,
      * at column number <code>column</code>.
      */
     public void setValueAt(Object aValue, Object node, int column);

--- a/Gui/opensim/view/src/org/opensim/view/editors/TreeTableModelAdapter.java
+++ b/Gui/opensim/view/src/org/opensim/view/editors/TreeTableModelAdapter.java
@@ -42,10 +42,10 @@ import javax.swing.event.TreeModelEvent;
 import javax.swing.event.TreeModelListener;
 
 /**
- * This is a wrapper class takes a TreeTableModel and implements 
- * the table model interface. The implementation is trivial, with 
- * all of the event dispatching support provided by the superclass: 
- * the AbstractTableModel. 
+ * This is a wrapper class takes a TreeTableModel and implements
+ * the table model interface. The implementation is trivial, with
+ * all of the event dispatching support provided by the superclass:
+ * the AbstractTableModel.
  *
  * @version 1.2 10/27/98
  *
@@ -63,12 +63,12 @@ public class TreeTableModelAdapter extends AbstractTableModel
 
         tree.addTreeExpansionListener(new TreeExpansionListener() {
             // Don't use fireTableRowsInserted() here; the selection model
-            // would get updated twice. 
-            public void treeExpanded(TreeExpansionEvent event) {  
-              fireTableDataChanged(); 
+            // would get updated twice.
+            public void treeExpanded(TreeExpansionEvent event) {
+              fireTableDataChanged();
             }
-            public void treeCollapsed(TreeExpansionEvent event) {  
-              fireTableDataChanged(); 
+            public void treeCollapsed(TreeExpansionEvent event) {
+              fireTableDataChanged();
             }
         });
 
@@ -95,7 +95,7 @@ public class TreeTableModelAdapter extends AbstractTableModel
         });
     }
 
-    // Wrappers, implementing TableModel interface. 
+    // Wrappers, implementing TableModel interface.
 
     public int getColumnCount() {
         return treeTableModel.getColumnCount();
@@ -116,7 +116,7 @@ public class TreeTableModelAdapter extends AbstractTableModel
     // Made public -- Eran 07/2007
     public Object nodeForRow(int row) {
         TreePath treePath = tree.getPathForRow(row);
-        return treePath.getLastPathComponent();         
+        return treePath.getLastPathComponent();
     }
 
     public Object getValueAt(int row, int column) {
@@ -124,7 +124,7 @@ public class TreeTableModelAdapter extends AbstractTableModel
     }
 
     public boolean isCellEditable(int row, int column) {
-         return treeTableModel.isCellEditable(nodeForRow(row), column); 
+         return treeTableModel.isCellEditable(nodeForRow(row), column);
     }
 
     public void setValueAt(Object value, int row, int column) {


### PR DESCRIPTION
This PR replaces the TreeTableModel files from versions I found online that have a permissive license.

After replacing these files, I compiled the GUI on my mac and was able to load a model.