### PR TITLE
Allow only values in range for Display preference edit from Properties

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneComponentWithGeometryNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneComponentWithGeometryNode.java
@@ -140,7 +140,8 @@ public abstract class OneComponentWithGeometryNode extends OneComponentNode impl
 
     @Override
     public void setDisplayPreference(int pref) {
-        setAppearanceDisplayPrefProperty(pref);
+        if (pref ==2 || pref ==3)
+            setAppearanceDisplayPrefProperty(pref);
     }
 
     private void setAppearanceDisplayPrefProperty(int pref) {


### PR DESCRIPTION
Avoid setting values outside the integer range for DisplayPreference