### PR TITLE
Visualize frames and joints

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
@@ -247,7 +247,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("uuid", geomID.toString());
         dg_json.put("type", "Frame");
         //dg_json.put("radius", .00005*visualizerScaleFactor);
-        //dg_json.put("size", arg0.getAxisLength()*visualizerScaleFactor);
+        dg_json.put("size", arg0.getAxisLength()*visualizerScaleFactor);
         jsonArr.add(dg_json);    
         //createMaterialJson(arg0, false);
     }

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1055,7 +1055,7 @@ public class ModelVisualizationJson extends JSONObject {
         frame_json.put("size", visScaleFactor);
         frame_json.put("visible", false);
         frame_json.put("name", frameObject.getAbsolutePathString());
-        frame_json.put("matrix", JSONUtilities.createMatrixFromTransform(new Transform(), frameObject.get_scale_factors(), visScaleFactor));
+        frame_json.put("matrix", JSONUtilities.createMatrixFromTransform(dg.getTransform(), frameObject.get_scale_factors(), visScaleFactor));
         // insert frame_json as child of BodyObject based on dg.getBodyId
         JSONObject bodyJson = mapBodyIndicesToJson.get(dg.getBodyId());
         if (bodyJson.get("children")==null)
@@ -1250,7 +1250,7 @@ public class ModelVisualizationJson extends JSONObject {
     public Boolean componentHasVisuals(Component comp){
         ArrayList<UUID> uuids = mapComponentToUUID.get(comp);
         // Component has no visible representation, pass
-        return (uuids.size() > 0);
+        return (uuids != null && uuids.size() > 0);
 
     }
 }

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -125,6 +125,10 @@ public class ModelVisualizationJson extends JSONObject {
         }
     }
 
+    public FrameGeometry getGeometryForFrame(Frame frame) {
+        return visualizerFrames.get(frame).fg;
+    }
+
      // The following inner class and Map are used to cache "computed" pathpoints to speed up 
     // recomputation on the fly
     class ComputedPathPointInfo {

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -49,6 +49,7 @@ import org.opensim.modeling.ComponentIterator;
 import org.opensim.modeling.ComponentsList;
 import org.opensim.modeling.ConditionalPathPoint;
 import org.opensim.modeling.DecorativeGeometry;
+import org.opensim.modeling.Frame;
 import org.opensim.modeling.FrameGeometry;
 import org.opensim.modeling.GeometryPath;
 import org.opensim.modeling.Marker;
@@ -112,6 +113,10 @@ public class ModelVisualizationJson extends JSONObject {
     // When wrapping comes in/out
     private final HashMap<GeometryPath, JSONArray> pathsWithWrapping = new HashMap<GeometryPath, JSONArray>();
 
+    public Boolean getFrameVisibility(Frame b) {
+        return false;
+    }
+
      // The following inner class and Map are used to cache "computed" pathpoints to speed up 
     // recomputation on the fly
     class ComputedPathPointInfo {
@@ -143,6 +148,7 @@ public class ModelVisualizationJson extends JSONObject {
         modelGroundJson = processGroundFrame(model);
         state = model.getWorkingState();
         mdh = model.getDisplayHints();
+        mdh.set_show_frames(true);
         ComponentsList mcList = model.getComponentsList();
         ComponentIterator mcIter = mcList.begin();
         
@@ -177,7 +183,15 @@ public class ModelVisualizationJson extends JSONObject {
     }
 
     private void processDecorationsForComponent(Component comp) {
-        //System.out.println("Processing:"+comp.getAbsolutePathName()+" Type:"+comp.getConcreteClassName());
+        if (verbose){
+            System.out.println("Processing:"+comp.getAbsolutePathString()+" Type:"+comp.getConcreteClassName());
+            if (FrameGeometry.safeDownCast(comp)!= null){
+                if (comp.hasOwner() && Frame.safeDownCast(comp.getOwner())!=null){
+                    System.out.println("Using FrameGeometry to visualize Frame"+
+                            comp.getAbsolutePathString()+":"+comp.getOwner().getAbsolutePathString());
+                }
+            }
+        }
         ArrayDecorativeGeometry adg = new ArrayDecorativeGeometry();
         comp.generateDecorations(true, mdh, state, adg);
         if (adg.size() > 0) {
@@ -223,8 +237,6 @@ public class ModelVisualizationJson extends JSONObject {
         ArrayList<UUID> comp_uuids = new ArrayList<UUID>();
         comp_uuids.add(groupUuid);
         mapComponentToUUID.put(comp, comp_uuids);
-        if (verbose)
-            System.out.println("Map component="+comp.getAbsolutePathString()+" to "+comp_uuids.size());   
         
     }
     // This method handles the DecorativeGeometry array produced by the component. It does special

--- a/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
@@ -31,6 +31,7 @@ import org.opensim.modeling.Body;
 import org.opensim.modeling.Frame;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
+import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.view.nodes.OneFrameNode;
 import org.opensim.view.pub.ViewDB;
 
@@ -43,8 +44,9 @@ public final class FrameToggleVisibilityAction extends BooleanStateAction {
         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
         // TODO implement action body
         OneFrameNode dNode = (OneFrameNode)selected[0];
-        boolean newState = super.getBooleanState();
-        FrameToggleVisibilityAction.ShowAxesForBody( dNode.getOpenSimObject(), newState, false );
+        boolean newState = getBooleanState();
+        FrameToggleVisibilityAction.ShowFrame( Frame.safeDownCast(dNode.getOpenSimObject()),
+                dNode.getModelForNode(), newState);
     }
     
     
@@ -88,38 +90,33 @@ public final class FrameToggleVisibilityAction extends BooleanStateAction {
         for( int i=0;  i<selected.length;  i++ ){
             Node selectedNode = selected[i];
             if( selectedNode instanceof OneFrameNode ){
-                Model frameModel = ((OneFrameNode) selectedNode).getModelForNode();
-                FrameToggleVisibilityAction.ShowAxesForOneBodyNode( (OneFrameNode)selectedNode, newState, false );
+                OneFrameNode frameNode = (OneFrameNode)selectedNode;
+                Model frameModel = frameNode.getModelForNode();
+                FrameToggleVisibilityAction.setFrameVisibility(frameNode, newState);
             }
         }
         super.setBooleanState( newState );
         ViewDB.ViewDBGetInstanceRenderAll();
     }
-  
-     
-    //-------------------------------------------------------------------------
-    public static boolean  IsShowAxesForBody( OpenSimObject openSimObjectAssociatedWithBody )
-    {
-        return false;
-        /*
-       BodyDisplayer rep = FrameToggleVisibilityAction.GetBodyDisplayerForBody( openSimObjectAssociatedWithBody );  
-       return rep==null ? false : rep.isShowAxes();*/
-    }
-    
     
     //----------------------------------------------------------------------------- 
-    static public void  ShowAxesForOneBodyNode( OneFrameNode frameNode, boolean showAxesTrueHideIsFalse, boolean renderAll )
+    static public void  setFrameVisibility( OneFrameNode frameNode, boolean showAxesTrueHideIsFalse)
     {
        if( frameNode == null ) return; 
-       FrameToggleVisibilityAction.ShowAxesForBody(frameNode.getOpenSimObject(), showAxesTrueHideIsFalse, renderAll );
+       FrameToggleVisibilityAction.ShowFrame(Frame.safeDownCast(frameNode.getOpenSimObject()), 
+               frameNode.getModelForNode(),
+               showAxesTrueHideIsFalse);
     }
     
     //-------------------------------------------------------------------------
-    public static void  ShowAxesForBody( OpenSimObject openSimObjectAssociatedWithBody, boolean showAxesTrueHideIsFalse, boolean renderAll )
+    public static void  ShowFrame( Frame frame, 
+            Model model, 
+            boolean showAxesTrueHideIsFalse)
     {
- 
+        ModelVisualizationJson viz = ViewDB.getInstance().getModelVisualizationJson(model);
+        viz.setFrameVisibility(frame, showAxesTrueHideIsFalse);
+        ViewDB.getInstance().toggleObjectDisplay(frame, showAxesTrueHideIsFalse);
     }
-    
     
     //-------------------------------------------------------------------------
     /*

--- a/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- * OpenSim: BodyToggleFrameAction.java                                        *
+ * OpenSim: FrameToggleVisibilityAction.java                                        *
  * -------------------------------------------------------------------------- *
  * OpenSim is a toolkit for musculoskeletal modeling and simulation,          *
  * developed as an open source project by a worldwide community. Development  *
@@ -28,27 +28,27 @@ import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.BooleanStateAction;
 import org.opensim.modeling.Body;
+import org.opensim.modeling.Frame;
 import org.opensim.modeling.OpenSimObject;
-import org.opensim.view.nodes.OneBodyNode;
+import org.opensim.view.nodes.OneFrameNode;
 import org.opensim.view.pub.ViewDB;
-import vtk.vtkProp3D;
 
-public final class BodyToggleFrameAction extends BooleanStateAction {
+public final class FrameToggleVisibilityAction extends BooleanStateAction {
     
-    public BodyToggleFrameAction(){
+    public FrameToggleVisibilityAction(){
     }
     
     public void performAction() {
         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
         // TODO implement action body
-        OneBodyNode dNode = (OneBodyNode)selected[0];
+        OneFrameNode dNode = (OneFrameNode)selected[0];
         boolean newState = super.getBooleanState();
-        BodyToggleFrameAction.ShowAxesForBody( dNode.getOpenSimObject(), newState, false );
+        FrameToggleVisibilityAction.ShowAxesForBody( dNode.getOpenSimObject(), newState, false );
     }
     
     
     public String getName() {
-        return NbBundle.getMessage(BodyToggleFrameAction.class, "CTL_BodyToggleFrameAction");
+        return NbBundle.getMessage(FrameToggleVisibilityAction.class, "CTL_BodyToggleFrameAction");
     }
     
     protected void initialize() {
@@ -69,9 +69,9 @@ public final class BodyToggleFrameAction extends BooleanStateAction {
         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
         //if(selected.length!=1) return false; // only if a single item is selected
         // Action shouldn't be available otherwise
-        if( selected[0] instanceof OneBodyNode ){
-            OneBodyNode dNode = (OneBodyNode)selected[0];
-            Body b = Body.safeDownCast( dNode.getOpenSimObject() );
+        if( selected[0] instanceof OneFrameNode ){
+            OneFrameNode dNode = (OneFrameNode)selected[0];
+            Frame b = Frame.safeDownCast( dNode.getOpenSimObject() );
 //            super.setBooleanState( b.getDisplayer().getShowAxes() );
             return true;
         }
@@ -85,8 +85,8 @@ public final class BodyToggleFrameAction extends BooleanStateAction {
         boolean newState = !super.getBooleanState();
         for( int i=0;  i<selected.length;  i++ ){
             Node selectedNode = selected[i];
-            if( selectedNode instanceof OneBodyNode )
-                 BodyToggleFrameAction.ShowAxesForOneBodyNode( (OneBodyNode)selectedNode, newState, false );
+            if( selectedNode instanceof OneFrameNode )
+                 FrameToggleVisibilityAction.ShowAxesForOneBodyNode( (OneFrameNode)selectedNode, newState, false );
         }
         super.setBooleanState( newState );
         ViewDB.ViewDBGetInstanceRenderAll();
@@ -98,23 +98,23 @@ public final class BodyToggleFrameAction extends BooleanStateAction {
     {
         return false;
         /*
-       BodyDisplayer rep = BodyToggleFrameAction.GetBodyDisplayerForBody( openSimObjectAssociatedWithBody );  
+       BodyDisplayer rep = FrameToggleVisibilityAction.GetBodyDisplayerForBody( openSimObjectAssociatedWithBody );  
        return rep==null ? false : rep.isShowAxes();*/
     }
     
     
     //----------------------------------------------------------------------------- 
-    static public void  ShowAxesForOneBodyNode( OneBodyNode oneBodyNode, boolean showAxesTrueHideIsFalse, boolean renderAll )
+    static public void  ShowAxesForOneBodyNode( OneFrameNode oneBodyNode, boolean showAxesTrueHideIsFalse, boolean renderAll )
     {
        if( oneBodyNode == null ) return; 
-       BodyToggleFrameAction.ShowAxesForBody( oneBodyNode.getOpenSimObject(), showAxesTrueHideIsFalse, renderAll );
+       FrameToggleVisibilityAction.ShowAxesForBody( oneBodyNode.getOpenSimObject(), showAxesTrueHideIsFalse, renderAll );
     }
     
     //-------------------------------------------------------------------------
     public static void  ShowAxesForBody( OpenSimObject openSimObjectAssociatedWithBody, boolean showAxesTrueHideIsFalse, boolean renderAll )
     {
         /*
-       BodyDisplayer rep = BodyToggleFrameAction.GetBodyDisplayerForBody( openSimObjectAssociatedWithBody );
+       BodyDisplayer rep = FrameToggleVisibilityAction.GetBodyDisplayerForBody( openSimObjectAssociatedWithBody );
        if( rep != null )
        {
            rep.setShowAxes( showAxesTrueHideIsFalse );

--- a/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
@@ -29,6 +29,7 @@ import org.openide.util.NbBundle;
 import org.openide.util.actions.BooleanStateAction;
 import org.opensim.modeling.Body;
 import org.opensim.modeling.Frame;
+import org.opensim.modeling.FrameGeometry;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.threejs.ModelVisualizationJson;
@@ -115,7 +116,8 @@ public final class FrameToggleVisibilityAction extends BooleanStateAction {
     {
         ModelVisualizationJson viz = ViewDB.getInstance().getModelVisualizationJson(model);
         viz.setFrameVisibility(frame, showAxesTrueHideIsFalse);
-        ViewDB.getInstance().toggleObjectDisplay(frame, showAxesTrueHideIsFalse);
+        FrameGeometry fg = viz.getGeometryForFrame(frame);
+        ViewDB.getInstance().toggleObjectDisplay(fg, showAxesTrueHideIsFalse);
     }
     
     //-------------------------------------------------------------------------

--- a/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
@@ -29,6 +29,7 @@ import org.openide.util.NbBundle;
 import org.openide.util.actions.BooleanStateAction;
 import org.opensim.modeling.Body;
 import org.opensim.modeling.Frame;
+import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.view.nodes.OneFrameNode;
 import org.opensim.view.pub.ViewDB;
@@ -83,11 +84,13 @@ public final class FrameToggleVisibilityAction extends BooleanStateAction {
         //super.actionPerformed(actionEvent);
         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
         // TODO implement action body
-        boolean newState = !super.getBooleanState();
+        boolean newState = !(super.getBooleanState());
         for( int i=0;  i<selected.length;  i++ ){
             Node selectedNode = selected[i];
-            if( selectedNode instanceof OneFrameNode )
-                 FrameToggleVisibilityAction.ShowAxesForOneBodyNode( (OneFrameNode)selectedNode, newState, false );
+            if( selectedNode instanceof OneFrameNode ){
+                Model frameModel = ((OneFrameNode) selectedNode).getModelForNode();
+                FrameToggleVisibilityAction.ShowAxesForOneBodyNode( (OneFrameNode)selectedNode, newState, false );
+            }
         }
         super.setBooleanState( newState );
         ViewDB.ViewDBGetInstanceRenderAll();
@@ -105,22 +108,16 @@ public final class FrameToggleVisibilityAction extends BooleanStateAction {
     
     
     //----------------------------------------------------------------------------- 
-    static public void  ShowAxesForOneBodyNode( OneFrameNode oneBodyNode, boolean showAxesTrueHideIsFalse, boolean renderAll )
+    static public void  ShowAxesForOneBodyNode( OneFrameNode frameNode, boolean showAxesTrueHideIsFalse, boolean renderAll )
     {
-       if( oneBodyNode == null ) return; 
-       FrameToggleVisibilityAction.ShowAxesForBody( oneBodyNode.getOpenSimObject(), showAxesTrueHideIsFalse, renderAll );
+       if( frameNode == null ) return; 
+       FrameToggleVisibilityAction.ShowAxesForBody(frameNode.getOpenSimObject(), showAxesTrueHideIsFalse, renderAll );
     }
     
     //-------------------------------------------------------------------------
     public static void  ShowAxesForBody( OpenSimObject openSimObjectAssociatedWithBody, boolean showAxesTrueHideIsFalse, boolean renderAll )
     {
-        /*
-       BodyDisplayer rep = FrameToggleVisibilityAction.GetBodyDisplayerForBody( openSimObjectAssociatedWithBody );
-       if( rep != null )
-       {
-           rep.setShowAxes( showAxesTrueHideIsFalse );
-           if( renderAll ) ViewDB.ViewDBGetInstanceRenderAll();
-       }    */ 
+ 
     }
     
     

--- a/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
@@ -72,7 +72,8 @@ public final class FrameToggleVisibilityAction extends BooleanStateAction {
         if( selected[0] instanceof OneFrameNode ){
             OneFrameNode dNode = (OneFrameNode)selected[0];
             Frame b = Frame.safeDownCast( dNode.getOpenSimObject() );
-//            super.setBooleanState( b.getDisplayer().getShowAxes() );
+            Boolean curStatus = ViewDB.getInstance().getModelVisualizationJson(dNode.getModelForNode()).getFrameVisibility(b);
+            super.setBooleanState(curStatus );
             return true;
         }
         return false;

--- a/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FrameToggleVisibilityAction.java
@@ -119,16 +119,5 @@ public final class FrameToggleVisibilityAction extends BooleanStateAction {
         FrameGeometry fg = viz.getGeometryForFrame(frame);
         ViewDB.getInstance().toggleObjectDisplay(fg, showAxesTrueHideIsFalse);
     }
-    
-    //-------------------------------------------------------------------------
-    /*
-    public static BodyDisplayer  GetBodyDisplayerForBody( OpenSimObject openSimObjectAssociatedWithBody )
-    {
-       Body b = Body.safeDownCast( openSimObjectAssociatedWithBody );
-       SingleModelVisuals viz = ViewDB.getInstance().getModelVisuals( b.getModel() );
-       if (viz == null) return null;
-       vtkProp3D visuals = viz.getVtkRepForObject(b);
-       return ( visuals instanceof BodyDisplayer ) ? (BodyDisplayer)visuals : null;
-    }
-    */
+
 }

--- a/Gui/opensim/view/src/org/opensim/view/layer.xml
+++ b/Gui/opensim/view/src/org/opensim/view/layer.xml
@@ -3,7 +3,7 @@
 <filesystem>
     <folder name="Actions">
         <folder name="Edit">
-            <file name="org-opensim-view-BodyToggleFrameAction.instance"/>
+            <file name="org-opensim-view-FrameToggleVisibilityAction.instance"/>
             <file name="org-opensim-view-FileOpenOsimModelAction.instance"/>
             <file name="org-opensim-view-experimentaldata-AnnotateMotionObjectsAction.instance"/>
             <file name="org-opensim-view-experimentaldata-MotionReclassifyAction.instance"/>

--- a/Gui/opensim/view/src/org/opensim/view/nodes/BodiesNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/BodiesNode.java
@@ -33,7 +33,7 @@ import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
 import org.opensim.modeling.Body;
 import org.opensim.modeling.BodySet;
-import org.opensim.view.BodyToggleFrameAction;
+import org.opensim.view.FrameToggleVisibilityAction;
 import org.opensim.view.nodes.OpenSimObjectNode.displayOption;
 
 /**

--- a/Gui/opensim/view/src/org/opensim/view/nodes/BodyToggleCOMAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/BodyToggleCOMAction.java
@@ -30,7 +30,7 @@ import org.openide.util.actions.BooleanStateAction;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.view.BodyDisplayer;
-import org.opensim.view.BodyToggleFrameAction;
+//import org.opensim.view.FrameToggleVisibilityAction;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.pub.ViewDB;
 

--- a/Gui/opensim/view/src/org/opensim/view/nodes/GroundNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/GroundNode.java
@@ -38,7 +38,6 @@ import org.opensim.modeling.Ground;
 import org.opensim.modeling.WrapObject;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.WrapObjectSet;
-import org.opensim.view.BodyToggleFrameAction;
 import org.opensim.view.nodes.OpenSimObjectNode.displayOption;
 
 /** Node class to wrap Body objects */

--- a/Gui/opensim/view/src/org/opensim/view/nodes/JointToggleChildFrameAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/JointToggleChildFrameAction.java
@@ -30,11 +30,16 @@ import org.openide.util.actions.BooleanStateAction;
 import org.opensim.modeling.ComponentIterator;
 import org.opensim.modeling.ComponentsList;
 import org.opensim.modeling.DecorativeGeometry;
+import org.opensim.modeling.Frame;
 import org.opensim.modeling.FrameGeometry;
 import org.opensim.modeling.Joint;
+import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PhysicalFrame;
+import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.view.ExplorerTopComponent;
+import org.opensim.view.FrameToggleVisibilityAction;
+import org.opensim.view.pub.ViewDB;
 
 public final class JointToggleChildFrameAction extends BooleanStateAction {
     
@@ -49,27 +54,14 @@ public final class JointToggleChildFrameAction extends BooleanStateAction {
         for(int i=0;i<selected.length;i++){
             Node selectedNode = selected[i];
             if (selectedNode instanceof OneJointNode){
-                OpenSimObject object=((OneJointNode) selectedNode).getOpenSimObject();
+                OneJointNode jn = ((OneJointNode) selectedNode);
+                OpenSimObject object=jn.getOpenSimObject();
                 Joint jnt = Joint.safeDownCast(object);
                 PhysicalFrame b = jnt.getChildFrame();
-                ComponentsList clist = b.getComponentsList();
-                ComponentIterator mcIter = clist.begin();
-                boolean found = false;
-                while (!mcIter.equals(clist.end())&&!found){
-                    if (mcIter.__deref__() instanceof FrameGeometry){
-                        found = true;
-                        FrameGeometry fg = ((FrameGeometry) mcIter.__deref__());
-                        DecorativeGeometry.Representation oldRep = fg.getRepresentation();
-                        if (oldRep == DecorativeGeometry.Representation.Hide)
-                            fg.setRepresentation(DecorativeGeometry.Representation.DrawSurface);
-                        else
-                            fg.setRepresentation(DecorativeGeometry.Representation.Hide);
-                    }
-                    mcIter.next(); 
-                }
+                Model model = jn.getModelForNode();
+                FrameToggleVisibilityAction.ShowFrame(b, model, newState);
                 setBooleanState(newState);
-                PropertyEditorAdaptor pea = new PropertyEditorAdaptor(jnt.getModel());
-                pea.handleModelChange();
+                
             }
         }
    }
@@ -94,20 +86,18 @@ public final class JointToggleChildFrameAction extends BooleanStateAction {
     
     public boolean isEnabled() {
         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
-        //if(selected.length!=1) return false; // only if a single item is selected
+        if(selected.length!=1) return false; // only if a single item is selected
         // Action shouldn't be available otherwise
-        /*
+        
         if (selected[0] instanceof OneJointNode){
             OneJointNode dNode = (OneJointNode)selected[0];
             Joint jnt = Joint.safeDownCast(dNode.getOpenSimObject());
-            Body b = jnt.getChildBody();
-            vtkProp3D visuals=ViewDB.getInstance().getModelVisuals(b.getModel()).getVtkRepForObject(b);
-            if (visuals instanceof BodyDisplayer){
-               BodyDisplayer rep = (BodyDisplayer) visuals;
-               setBooleanState(rep.isShowJointBFrame());
-            }
+            Frame b = jnt.getChildFrame();
+            ModelVisualizationJson visuals=ViewDB.getInstance().getModelVisualizationJson(b.getModel());
+            Boolean curStatus = visuals.getFrameVisibility(b);
+            super.setBooleanState(curStatus );
             return true;
-        }*/
+        }
         return false;
     }
 }

--- a/Gui/opensim/view/src/org/opensim/view/nodes/JointToggleParentFrameAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/JointToggleParentFrameAction.java
@@ -30,11 +30,17 @@ import org.openide.util.actions.BooleanStateAction;
 import org.opensim.modeling.ComponentIterator;
 import org.opensim.modeling.ComponentsList;
 import org.opensim.modeling.DecorativeGeometry;
+import org.opensim.modeling.Frame;
 import org.opensim.modeling.FrameGeometry;
 import org.opensim.modeling.Joint;
+import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PhysicalFrame;
+import org.opensim.threejs.ModelVisualizationJson;
+import org.opensim.view.BodyDisplayer;
 import org.opensim.view.ExplorerTopComponent;
+import org.opensim.view.FrameToggleVisibilityAction;
+import org.opensim.view.pub.ViewDB;
 
 public final class JointToggleParentFrameAction extends BooleanStateAction {
     
@@ -49,28 +55,14 @@ public final class JointToggleParentFrameAction extends BooleanStateAction {
         for(int i=0;i<selected.length;i++){
             Node selectedNode = selected[i];
             if (selectedNode instanceof OneJointNode){
-                OpenSimObject object=((OneJointNode) selectedNode).getOpenSimObject();
+                OneJointNode jn = ((OneJointNode) selectedNode);
+                OpenSimObject object=jn.getOpenSimObject();
                 Joint jnt = Joint.safeDownCast(object);
                 
                 PhysicalFrame b = jnt.getParentFrame();
-                ComponentsList clist = b.getComponentsList();
-                ComponentIterator mcIter = clist.begin();
-                boolean found = false;
-                while (!mcIter.equals(clist.end())&&!found){
-                    if (mcIter.__deref__() instanceof FrameGeometry){
-                        found = true;
-                        FrameGeometry fg = ((FrameGeometry) mcIter.__deref__());
-                        DecorativeGeometry.Representation oldRep = fg.getRepresentation();
-                        if (oldRep == DecorativeGeometry.Representation.Hide)
-                            fg.setRepresentation(DecorativeGeometry.Representation.DrawSurface);
-                        else
-                            fg.setRepresentation(DecorativeGeometry.Representation.Hide);
-                    }
-                    mcIter.next(); 
-                }
+                Model model = jn.getModelForNode();
+                FrameToggleVisibilityAction.ShowFrame(b, model, newState);
                 setBooleanState(newState);
-                PropertyEditorAdaptor pea = new PropertyEditorAdaptor(jnt.getModel());
-                pea.handleModelChange();
             }
         }
    }
@@ -95,22 +87,17 @@ public final class JointToggleParentFrameAction extends BooleanStateAction {
     
     public boolean isEnabled() {
         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
-        //if(selected.length!=1) return false; // only if a single item is selected
-        // Action shouldn't be available otherwise
-        // FIX40 
-        /*
+        if(selected.length!=1) return false; // only if a single item is selected
         if (selected[0] instanceof OneJointNode){
             OneJointNode dNode = (OneJointNode)selected[0];
             Joint jnt = Joint.safeDownCast(dNode.getOpenSimObject());
-            Body pb = jnt.getParentBody();
-            Body b = jnt.getChildBody();
-            vtkProp3D visuals=ViewDB.getInstance().getModelVisuals(pb.getModel()).getVtkRepForObject(pb);
-            if (visuals instanceof BodyDisplayer){
-              BodyDisplayer rep = (BodyDisplayer) visuals;
-              setBooleanState(rep.isShowJointPFrame(b));
-            }
+            Frame pb = jnt.getParentFrame();
+            Frame b = jnt.getChildFrame();
+            ModelVisualizationJson visuals=ViewDB.getInstance().getModelVisualizationJson(pb.getModel());
+            Boolean curStatus = visuals.getFrameVisibility(pb);
+            super.setBooleanState(curStatus );
             return true;
-        }*/
+        }
         return false;
     }
     

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneBodyNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneBodyNode.java
@@ -37,7 +37,7 @@ import org.opensim.modeling.Geometry;
 import org.opensim.modeling.WrapObject;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.WrapObjectSet;
-import org.opensim.view.BodyToggleFrameAction;
+
 import org.opensim.view.nodes.OpenSimObjectNode.displayOption;
 
 /** Node class to wrap Body objects */

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -30,19 +30,22 @@ package org.opensim.view.nodes;
 
 import java.awt.Image;
 import java.net.URL;
+import java.util.List;
 import java.util.ResourceBundle;
 import javax.swing.ImageIcon;
+import javax.swing.Action;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
 import org.opensim.modeling.Frame;
 import org.opensim.modeling.Geometry;
+import org.opensim.view.FrameToggleVisibilityAction;
 
 /**
  *
  * @author Ayman
  */
-class OneFrameNode extends OneModelComponentNode {
+public class OneFrameNode extends OneModelComponentNode {
    private static ResourceBundle bundle = NbBundle.getBundle(OneFrameNode.class);
    Frame frame;
     public OneFrameNode(Frame comp) {
@@ -88,4 +91,21 @@ class OneFrameNode extends OneModelComponentNode {
         return getIcon(i);
     }
     
+   @Override
+    public Action[] getActions(boolean b) {
+        Action[] superActions = (Action[]) super.getActions(b);
+        // Arrays are fixed size, onvert to a List
+        List<Action> actions = java.util.Arrays.asList(superActions);
+        // Create new Array of proper size
+        Action[] retActions = new Action[actions.size() + 1];
+        actions.toArray(retActions);
+        try {
+            // append new command to the end of the list of actions
+            retActions[actions.size()] = (FrameToggleVisibilityAction) FrameToggleVisibilityAction.findObject(
+                    (Class) Class.forName("org.opensim.view.FrameToggleVisibilityAction"), true);
+        } catch (ClassNotFoundException ex) {
+            ex.printStackTrace();
+        }
+        return retActions;
+    }  
 }

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -137,6 +137,8 @@ public final class ViewDB extends Observable implements Observer, LookupListener
             if (modelJson.componentHasVisuals(mc)){
                 websocketdb.broadcastMessageJson(modelJson.updateComponentVisuals(mc, frame), null);
             }
+            else // just send frame in case xforms change
+                websocketdb.broadcastMessageJson(currentJson.createFrameMessageJson(false), null);
         }
     }
    

--- a/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
+++ b/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
@@ -84,10 +84,6 @@ public class WebSocketDB {
         }
         int i=0;
         for (VisWebSocket sock : sockets){
-            if (i==1){
-                i++;
-                continue;
-            }
             if (debug) System.out.println("Broadcast:"+msg.toJSONString()+"\n");
             sock.sendVisualizerMessage(msg);
             i++;


### PR DESCRIPTION
This PR restores the functionality to show Axes (off the Body context menu) as well as the (show Parent Frame, Child Frame) from the Joint context menus. In addition it fixes assertion/error thrown when editing Joint Connections