### PR TITLE
Improve formatting of Mac installer license.

### DIFF
--- a/Installer/macOS/Resources/license.txt
+++ b/Installer/macOS/Resources/license.txt
@@ -1,22 +1,9 @@
-OpenSim is a toolkit for musculoskeletal modeling and simulation,         
-developed as an open source project by a worldwide community. Development 
-and support is coordinated from Stanford University, with funding from the
-U.S. NIH and DARPA. See http://opensim.stanford.edu and the README file   
-for more information including specific grant numbers.                    
-                                                                          
-Copyright (c) 2005-2017 Stanford University and the Authors               
-                                                                          
-Licensed under the Apache License, Version 2.0 (the "License"); you may   
-not use this file except in compliance with the License. You may obtain a 
-copy of the License at http://www.apache.org/licenses/LICENSE-2.0         
-                                                                          
-Unless required by applicable law or agreed to in writing, software       
-distributed under the License is distributed on an "AS IS" BASIS,         
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  
-See the License for the specific language governing permissions and       
-limitations under the License.                                            
+OpenSim is a toolkit for musculoskeletal modeling and simulation, developed as an open source project by a worldwide community. Development and support is coordinated from Stanford University, with funding from the U.S. NIH and DARPA. See http://opensim.stanford.edu and the README file for more information including specific grant numbers.
 
-OpenSim includes a number of subcomponents with separate copyright notices and
-license terms. Your use of these components is subject to the terms and
-conditions of their respective licenses, which can be found in the LICENSE.txt
-and NOTICE.txt files in the installation (<.app>/Contents/Resources/OpenSim).
+Copyright (c) 2005-2017 Stanford University and the Authors
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+
+OpenSim includes a number of subcomponents with separate copyright notices and license terms. Your use of these components is subject to the terms and conditions of their respective licenses, which can be found in the LICENSE.txt and NOTICE.txt files in the installation (<.app>/Contents/Resources/OpenSim).


### PR DESCRIPTION
This PR improves the apperance of the OpenSim license in the Mac installer by avoiding hard line wraps.