### PR TITLE
On Mac, allow installing multiple versions.

### DIFF
--- a/Gui/opensim/installer_files/OSX/Info.plist
+++ b/Gui/opensim/installer_files/OSX/Info.plist
@@ -17,6 +17,9 @@
     
     <key>CFBundleShortVersionString</key>
     <string>@VERSION@</string>
+
+    <key>CFBundleIdentifier</key>
+    <string>org.opensim.app.@VERSION@</string>
     
     <key>CFBundleSignature</key>
     <string>????</string>

--- a/Installer/macOS/Distribution.xml
+++ b/Installer/macOS/Distribution.xml
@@ -2,7 +2,7 @@
 <installer-gui-script minSpecVersion="1">
     <title>OpenSim</title>
     <background file="OpenSimLogoWhiteNoText.png" scaling="none" alignment="bottomleft"/>
-    <pkg-ref id="org.opensim.app.pkg"/>
+    <pkg-ref id="org.opensim.app.pkg.@VERSION@"/>
     <!--Users will need to choose the Home directory until we stop writing JSON
          files within the app. 
          https://stackoverflow.com/questions/12863944/how-do-you-specify-a-default-install-location-to-home-with-pkgbuild
@@ -14,12 +14,12 @@
     <options customize="never" require-scripts="false"/>
     <choices-outline>
         <line choice="default">
-            <line choice="org.opensim.app.pkg"/>
+            <line choice="org.opensim.app.pkg.@VERSION@"/>
         </line>
     </choices-outline>
     <choice id="default"/>
-    <choice id="org.opensim.app.pkg" visible="false">
-        <pkg-ref id="org.opensim.app.pkg"/>
+    <choice id="org.opensim.app.pkg.@VERSION@" visible="false">
+        <pkg-ref id="org.opensim.app.pkg.@VERSION@"/>
     </choice>
-    <pkg-ref id="org.opensim.app.pkg" version="@VERSION@" onConclusion="none">OpenSim-@VERSION@-App.pkg</pkg-ref>
+    <pkg-ref id="org.opensim.app.pkg.@VERSION@" version="@VERSION@" onConclusion="none">OpenSim-@VERSION@-App.pkg</pkg-ref>
 </installer-gui-script>

--- a/Installer/macOS/make_macOS_pkg.sh
+++ b/Installer/macOS/make_macOS_pkg.sh
@@ -13,7 +13,7 @@
 ## window to not function properly. 
 ## https://stackoverflow.com/questions/43031272/macos-installer-show-files-only-the-file-listing-isnt-available
 pkgbuild \
-    --identifier org.opensim.app.pkg \
+    --identifier org.opensim.app.pkg.@VERSION@ \
     --version @VERSION@ \
     --root '../../Gui/opensim/dist/pkgroot/' \
     --scripts './scripts' \


### PR DESCRIPTION
Without this change, Installer.app would delete previous versions of the app on the user's machine. By giving the pkg a unique identifier for each version, we no longer have that issue!

Fixes #426 