### PR TITLE
Make paths absolute scale tool

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
@@ -914,6 +914,8 @@ public class ScaleToolModel extends Observable implements Observer {
       String parentDir = (new File(parentFileName)).getParent();
       scaleTool.getGenericModelMaker().setMarkerSetFileName(FileUtils.makePathAbsolute(scaleTool.getGenericModelMaker().getMarkerSetFileName(),parentDir));
       scaleTool.getModelScaler().setMarkerFileName(FileUtils.makePathAbsolute(scaleTool.getModelScaler().getMarkerFileName(),parentDir));
+      scaleTool.getModelScaler().setOutputModelFileName(FileUtils.makePathAbsolute(scaleTool.getModelScaler().getOutputModelFileName(),parentDir));
+      scaleTool.getModelScaler().setOutputScaleFileName(FileUtils.makePathAbsolute(scaleTool.getModelScaler().getOutputScaleFileName(),parentDir));
       scaleTool.getMarkerPlacer().setStaticPoseFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getStaticPoseFileName(),parentDir));
       scaleTool.getMarkerPlacer().setCoordinateFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getCoordinateFileName(),parentDir));
       scaleTool.getMarkerPlacer().setOutputModelFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getOutputModelFileName(),parentDir));
@@ -925,6 +927,8 @@ public class ScaleToolModel extends Observable implements Observer {
       String parentDir = (new File(parentFileName)).getParent();
       scaleTool.getGenericModelMaker().setMarkerSetFileName(FileUtils.makePathRelative(scaleTool.getGenericModelMaker().getMarkerSetFileName(),parentDir));
       scaleTool.getModelScaler().setMarkerFileName(FileUtils.makePathRelative(scaleTool.getModelScaler().getMarkerFileName(),parentDir));
+      scaleTool.getModelScaler().setOutputModelFileName(FileUtils.makePathRelative(scaleTool.getModelScaler().getOutputModelFileName(),parentDir));
+      scaleTool.getModelScaler().setOutputScaleFileName(FileUtils.makePathRelative(scaleTool.getModelScaler().getOutputScaleFileName(),parentDir));
       scaleTool.getMarkerPlacer().setStaticPoseFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getStaticPoseFileName(),parentDir));
       scaleTool.getMarkerPlacer().setCoordinateFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getCoordinateFileName(),parentDir));
       scaleTool.getMarkerPlacer().setOutputModelFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getOutputModelFileName(),parentDir));

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
@@ -916,6 +916,9 @@ public class ScaleToolModel extends Observable implements Observer {
       scaleTool.getModelScaler().setMarkerFileName(FileUtils.makePathAbsolute(scaleTool.getModelScaler().getMarkerFileName(),parentDir));
       scaleTool.getMarkerPlacer().setStaticPoseFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getStaticPoseFileName(),parentDir));
       scaleTool.getMarkerPlacer().setCoordinateFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getCoordinateFileName(),parentDir));
+      scaleTool.getMarkerPlacer().setOutputModelFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getOutputModelFileName(),parentDir));
+      scaleTool.getMarkerPlacer().setOutputMotionFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getOutputMotionFileName(),parentDir));
+      scaleTool.getMarkerPlacer().setOutputMarkerFileName(FileUtils.makePathAbsolute(scaleTool.getMarkerPlacer().getOutputMarkerFileName(),parentDir));
    }
 
    private void AbsoluteToRelativePaths(String parentFileName) {
@@ -924,6 +927,9 @@ public class ScaleToolModel extends Observable implements Observer {
       scaleTool.getModelScaler().setMarkerFileName(FileUtils.makePathRelative(scaleTool.getModelScaler().getMarkerFileName(),parentDir));
       scaleTool.getMarkerPlacer().setStaticPoseFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getStaticPoseFileName(),parentDir));
       scaleTool.getMarkerPlacer().setCoordinateFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getCoordinateFileName(),parentDir));
+      scaleTool.getMarkerPlacer().setOutputModelFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getOutputModelFileName(),parentDir));
+      scaleTool.getMarkerPlacer().setOutputMotionFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getOutputMotionFileName(),parentDir));
+      scaleTool.getMarkerPlacer().setOutputMarkerFileName(FileUtils.makePathRelative(scaleTool.getMarkerPlacer().getOutputMarkerFileName(),parentDir));
    }
 
    public boolean loadSettings(String fileName) {


### PR DESCRIPTION
ScaleTool handling of Paths doesn't work when files are specified in Absolute Path (concatenation results in invalid Path). What the GUI does as a workaround is to convert all file paths to Absolute so no concatenation is needed. This was not implemented for all files in the past, now it does.