### PR TITLE
Handle objects that appear more than once in navigator

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/ObjectDisplayShowOnlyAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/ObjectDisplayShowOnlyAction.java
@@ -101,6 +101,7 @@ public final class ObjectDisplayShowOnlyAction extends ObjectAppearanceChangeAct
           }
       }
         descendents.clear();
+        osimObjects.clear();
         for (int i = 0; i < selected.length; i++) {
             if (!(selected[i] instanceof OpenSimObjectNode)) {
                 continue;


### PR DESCRIPTION
Make sure these objects end up "shown" rather than hidden.