### PR TITLE
Fix copy resources dialog

### DIFF
--- a/Gui/opensim/utils/nbproject/project.xml
+++ b/Gui/opensim/utils/nbproject/project.xml
@@ -103,6 +103,14 @@
                         <specification-version>6.5.1</specification-version>
                     </run-dependency>
                 </dependency>
+                <dependency>
+                    <code-name-base>org.opensim.logger</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <specification-version>1.0</specification-version>
+                    </run-dependency>
+                </dependency>
             </module-dependencies>
             <public-packages>
                 <package>org.opensim.swingui</package>

--- a/Gui/opensim/utils/src/org/opensim/utils/Bundle.properties
+++ b/Gui/opensim/utils/src/org/opensim/utils/Bundle.properties
@@ -3,4 +3,4 @@ OpenIDE-Module-Long-Description=\
     File managment and low level GUI utilities
 OpenIDE-Module-Name=utils
 OpenIDE-Module-Short-Description=File managment and low level GUI utilities
-CTL_BuildDate=20171204
+CTL_BuildDate=20171205

--- a/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
@@ -43,9 +43,12 @@ import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import java.nio.file.StandardCopyOption;
 import javax.swing.JButton;
+import javax.swing.SwingUtilities;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
+import org.openide.windows.WindowManager;
+import org.opensim.swingui.FileTextFieldAndChooser;
 /**
  *
  * @author Ayman, a convenience class used for now as a place holder for common utilities/helper functions used
@@ -192,22 +195,18 @@ public final class TheApp {
         String userHome = System.getProperty("user.home")+File.separator+"Documents"+File.separator+"OpenSim40";
         FileUtils.getInstance().setWorkingDirectoryPreference(userHome);
         String userSelection = "";
-        NotifyDescriptor.InputLine dlg = new NotifyDescriptor.InputLine("Enter folder to install models and scripts:", "Select Folder for User Resources");
-        dlg.setInputText(userHome);
-        dlg.setOptions(new Object[]{DialogDescriptor.OK_OPTION, DialogDescriptor.CANCEL_OPTION, new JButton("Customize")});
-        Object userChoice = DialogDisplayer.getDefault().notify(dlg);
-        if(userChoice==NotifyDescriptor.OK_OPTION){
-            userSelection = userHome;
-        }
-        else if (userChoice==NotifyDescriptor.CANCEL_OPTION){
-            userSelection = null;
-            return userSelection;
-        }
-        else {
-            userSelection = FileUtils.getInstance().browseForFolder("Choose a folder to install models and scripts:", true);
-        }
+        FileTextFieldAndChooser destDirectoryPanel = new org.opensim.swingui.FileTextFieldAndChooser();
+        destDirectoryPanel.setDirectoriesOnly(true);
+        destDirectoryPanel.setFileName(userHome, false);
+        destDirectoryPanel.isSaveMode();
+        destDirectoryPanel.setCheckIfFileExists(false);
+        DialogDescriptor dd = new DialogDescriptor(destDirectoryPanel, "Folder to install models and scripts:");
+        // Create a Dialog to contain the chooser
+        DialogDisplayer.getDefault().createDialog(dd).setVisible(true);
+        userSelection = destDirectoryPanel.getFileName();
         String[] subdirs = new String[]{"Models"}; // Add more folders here as needed
         if (userSelection != null){
+            FileUtils.getInstance().setWorkingDirectoryPreference(userSelection);
             String src = getPlatformSpecificInstallDir();
             String dest = userSelection;
             System.out.println("copy resources from "+src+" to "+dest);

--- a/Gui/opensim/view/src/org/opensim/view/Installer.java
+++ b/Gui/opensim/view/src/org/opensim/view/Installer.java
@@ -31,6 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.prefs.Preferences;
 import javax.swing.JPopupMenu;
+import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 import org.openide.modules.ModuleInstall;
@@ -134,23 +135,19 @@ public class Installer extends ModuleInstall {
          String savedVersionStr = Preferences.userNodeForPackage(TheApp.class).get("BuildDate", null);
          if (!currentVersionStr.equalsIgnoreCase(savedVersionStr)){
              // First launch, copy resources to User selected folder and save that as OpenSimUserDir
-             String userDir = TheApp.installResources();
-             Preferences.userNodeForPackage(TheApp.class).put("OpenSimResourcesDir", userDir);
+            SwingUtilities.invokeLater( new Runnable(){
+                public void run() {
+                 String userDir = TheApp.installResources();
+                 Preferences.userNodeForPackage(TheApp.class).put("OpenSimResourcesDir", userDir);
+               }
+            });
+            Preferences.userNodeForPackage(TheApp.class).put("BuildDate", currentVersionStr);
          }
-         Preferences.userNodeForPackage(TheApp.class).put("BuildDate", currentVersionStr);
-         
-         String AAFRamesDefaultStr = NbBundle.getMessage(OpenSimBaseCanvas.class, "CTL_AAFrames");        
-         String saved=Preferences.userNodeForPackage(TheApp.class).get("AntiAliasingFrames", AAFRamesDefaultStr);
-         Preferences.userNodeForPackage(TheApp.class).put("AntiAliasingFrames", saved);
          
          String defaultOffsetDirection = NbBundle.getMessage(ViewDB.class,"CTL_DisplayOffsetDir");
-         saved=Preferences.userNodeForPackage(TheApp.class).get("DisplayOffsetDir", defaultOffsetDirection);
+         String saved=Preferences.userNodeForPackage(TheApp.class).get("DisplayOffsetDir", defaultOffsetDirection);
          Preferences.userNodeForPackage(TheApp.class).put("DisplayOffsetDir", saved);
          
-         String nonCurrentModelOpacityStr = NbBundle.getMessage(ViewDB.class,"CTL_NonCurrentModelOpacity");
-         saved = Preferences.userNodeForPackage(TheApp.class).get("NonCurrentModelOpacity", nonCurrentModelOpacityStr);
-         Preferences.userNodeForPackage(TheApp.class).put("NonCurrentModelOpacity", saved);
-
          String defaultGeometryPath = TheApp.getDefaultGeometrySearchPath();
          saved=Preferences.userNodeForPackage(TheApp.class).get("Geometry Path", defaultGeometryPath);
          if (saved.isEmpty()||saved.equalsIgnoreCase("")){
@@ -159,6 +156,7 @@ public class Installer extends ModuleInstall {
          else if (!saved.contains(defaultGeometryPath))
              saved.concat(File.pathSeparator+defaultGeometryPath);
          Preferences.userNodeForPackage(TheApp.class).put("Geometry Path", saved);
+         System.out.println("Default Geometry Search path is:"+saved);
 
          String defaultBgColor = NbBundle.getMessage(OpenSimBaseCanvas.class, "CTL_BackgroundColorRGB");        
          saved = Preferences.userNodeForPackage(TheApp.class).get("BackgroundColor", defaultBgColor);


### PR DESCRIPTION
Copy resources dialog now copies Models, Scripts and APIExamples to new default folder or user specified one and warns if directory exists.