### PR TITLE
Fix analysis edit crash

### DIFF
--- a/Gui/opensim/modeling/src/org/opensim/modeling/ActuatorIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/ActuatorIterator.java
@@ -125,15 +125,6 @@ public class ActuatorIterator {
     return new Model(opensimSimulationJNI.ActuatorIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.ActuatorIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.ActuatorIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.ActuatorIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/ArrayDecorativeGeometry.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/ArrayDecorativeGeometry.java
@@ -12,12 +12,12 @@ public class ArrayDecorativeGeometry {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected ArrayDecorativeGeometry(long cPtr, boolean cMemoryOwn) {
+  public ArrayDecorativeGeometry(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(ArrayDecorativeGeometry obj) {
+  public static long getCPtr(ArrayDecorativeGeometry obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/ArrayIndexInt.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/ArrayIndexInt.java
@@ -12,12 +12,12 @@ public class ArrayIndexInt {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected ArrayIndexInt(long cPtr, boolean cMemoryOwn) {
+  public ArrayIndexInt(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(ArrayIndexInt obj) {
+  public static long getCPtr(ArrayIndexInt obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/ArrayIndexUnsigned.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/ArrayIndexUnsigned.java
@@ -12,12 +12,12 @@ public class ArrayIndexUnsigned {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected ArrayIndexUnsigned(long cPtr, boolean cMemoryOwn) {
+  public ArrayIndexUnsigned(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(ArrayIndexUnsigned obj) {
+  public static long getCPtr(ArrayIndexUnsigned obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/BodyIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/BodyIterator.java
@@ -242,15 +242,6 @@ public class BodyIterator {
     return new Model(opensimSimulationJNI.BodyIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.BodyIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.BodyIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.BodyIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/CoordinateAxis.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/CoordinateAxis.java
@@ -12,12 +12,12 @@ public class CoordinateAxis {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected CoordinateAxis(long cPtr, boolean cMemoryOwn) {
+  public CoordinateAxis(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(CoordinateAxis obj) {
+  public static long getCPtr(CoordinateAxis obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/CoordinateDirection.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/CoordinateDirection.java
@@ -12,12 +12,12 @@ public class CoordinateDirection {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected CoordinateDirection(long cPtr, boolean cMemoryOwn) {
+  public CoordinateDirection(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(CoordinateDirection obj) {
+  public static long getCPtr(CoordinateDirection obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
@@ -39,12 +39,12 @@ public class CoordinateDirection {
     private transient long swigCPtr;
     protected transient boolean swigCMemOwn;
   
-    protected Negative(long cPtr, boolean cMemoryOwn) {
+    public Negative(long cPtr, boolean cMemoryOwn) {
       swigCMemOwn = cMemoryOwn;
       swigCPtr = cPtr;
     }
   
-    protected static long getCPtr(Negative obj) {
+    public static long getCPtr(Negative obj) {
       return (obj == null) ? 0 : obj.swigCPtr;
     }
   

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Decorations.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Decorations.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class Decorations extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected Decorations(long cPtr, boolean cMemoryOwn) {
+  public Decorations(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.Decorations_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Decorations obj) {
+  public static long getCPtr(Decorations obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeArrow.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeArrow.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeArrow extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeArrow(long cPtr, boolean cMemoryOwn) {
+  public DecorativeArrow(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeArrow_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeArrow obj) {
+  public static long getCPtr(DecorativeArrow obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeBrick.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeBrick.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeBrick extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeBrick(long cPtr, boolean cMemoryOwn) {
+  public DecorativeBrick(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeBrick_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeBrick obj) {
+  public static long getCPtr(DecorativeBrick obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeCircle.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeCircle.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeCircle extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeCircle(long cPtr, boolean cMemoryOwn) {
+  public DecorativeCircle(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeCircle_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeCircle obj) {
+  public static long getCPtr(DecorativeCircle obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeCone.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeCone.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeCone extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeCone(long cPtr, boolean cMemoryOwn) {
+  public DecorativeCone(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeCone_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeCone obj) {
+  public static long getCPtr(DecorativeCone obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeCylinder.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeCylinder.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeCylinder extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeCylinder(long cPtr, boolean cMemoryOwn) {
+  public DecorativeCylinder(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeCylinder_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeCylinder obj) {
+  public static long getCPtr(DecorativeCylinder obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeEllipsoid.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeEllipsoid.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeEllipsoid extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeEllipsoid(long cPtr, boolean cMemoryOwn) {
+  public DecorativeEllipsoid(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeEllipsoid_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeEllipsoid obj) {
+  public static long getCPtr(DecorativeEllipsoid obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeFrame.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeFrame.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeFrame extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeFrame(long cPtr, boolean cMemoryOwn) {
+  public DecorativeFrame(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeFrame_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeFrame obj) {
+  public static long getCPtr(DecorativeFrame obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeGeometry.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeGeometry.java
@@ -12,12 +12,12 @@ public class DecorativeGeometry {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected DecorativeGeometry(long cPtr, boolean cMemoryOwn) {
+  public DecorativeGeometry(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeGeometry obj) {
+  public static long getCPtr(DecorativeGeometry obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeGeometryImplementation.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeGeometryImplementation.java
@@ -12,12 +12,12 @@ public class DecorativeGeometryImplementation {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected DecorativeGeometryImplementation(long cPtr, boolean cMemoryOwn) {
+  public DecorativeGeometryImplementation(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeGeometryImplementation obj) {
+  public static long getCPtr(DecorativeGeometryImplementation obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeLine.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeLine.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeLine extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeLine(long cPtr, boolean cMemoryOwn) {
+  public DecorativeLine(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeLine_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeLine obj) {
+  public static long getCPtr(DecorativeLine obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeMesh.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeMesh.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeMesh extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeMesh(long cPtr, boolean cMemoryOwn) {
+  public DecorativeMesh(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeMesh_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeMesh obj) {
+  public static long getCPtr(DecorativeMesh obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeMeshFile.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeMeshFile.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeMeshFile extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeMeshFile(long cPtr, boolean cMemoryOwn) {
+  public DecorativeMeshFile(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeMeshFile_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeMeshFile obj) {
+  public static long getCPtr(DecorativeMeshFile obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativePoint.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativePoint.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativePoint extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativePoint(long cPtr, boolean cMemoryOwn) {
+  public DecorativePoint(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativePoint_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativePoint obj) {
+  public static long getCPtr(DecorativePoint obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeSphere.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeSphere.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeSphere extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeSphere(long cPtr, boolean cMemoryOwn) {
+  public DecorativeSphere(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeSphere_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeSphere obj) {
+  public static long getCPtr(DecorativeSphere obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeText.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeText.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeText extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeText(long cPtr, boolean cMemoryOwn) {
+  public DecorativeText(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeText_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeText obj) {
+  public static long getCPtr(DecorativeText obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeTorus.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DecorativeTorus.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class DecorativeTorus extends DecorativeGeometry {
   private transient long swigCPtr;
 
-  protected DecorativeTorus(long cPtr, boolean cMemoryOwn) {
+  public DecorativeTorus(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.DecorativeTorus_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DecorativeTorus obj) {
+  public static long getCPtr(DecorativeTorus obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/DontCopy.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/DontCopy.java
@@ -12,12 +12,12 @@ public class DontCopy {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected DontCopy(long cPtr, boolean cMemoryOwn) {
+  public DontCopy(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(DontCopy obj) {
+  public static long getCPtr(DontCopy obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/FalseType.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/FalseType.java
@@ -12,12 +12,12 @@ public class FalseType {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected FalseType(long cPtr, boolean cMemoryOwn) {
+  public FalseType(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(FalseType obj) {
+  public static long getCPtr(FalseType obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/FrameIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/FrameIterator.java
@@ -177,15 +177,6 @@ public class FrameIterator {
     return new Model(opensimSimulationJNI.FrameIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.FrameIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.FrameIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.FrameIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Inertia.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Inertia.java
@@ -12,12 +12,12 @@ public class Inertia {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Inertia(long cPtr, boolean cMemoryOwn) {
+  public Inertia(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Inertia obj) {
+  public static long getCPtr(Inertia obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/InverseRotation.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/InverseRotation.java
@@ -12,12 +12,12 @@ public class InverseRotation {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected InverseRotation(long cPtr, boolean cMemoryOwn) {
+  public InverseRotation(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(InverseRotation obj) {
+  public static long getCPtr(InverseRotation obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/JointIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/JointIterator.java
@@ -129,15 +129,6 @@ public class JointIterator {
     return new Model(opensimSimulationJNI.JointIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.JointIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.JointIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.JointIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MassProperties.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MassProperties.java
@@ -12,12 +12,12 @@ public class MassProperties {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected MassProperties(long cPtr, boolean cMemoryOwn) {
+  public MassProperties(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(MassProperties obj) {
+  public static long getCPtr(MassProperties obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Mat33.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Mat33.java
@@ -12,12 +12,12 @@ public class Mat33 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Mat33(long cPtr, boolean cMemoryOwn) {
+  public Mat33(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Mat33 obj) {
+  public static long getCPtr(Mat33 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Matrix.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Matrix.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class Matrix extends MatrixBaseDouble {
   private transient long swigCPtr;
 
-  protected Matrix(long cPtr, boolean cMemoryOwn) {
+  public Matrix(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.Matrix_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Matrix obj) {
+  public static long getCPtr(Matrix obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MatrixBaseDouble.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MatrixBaseDouble.java
@@ -12,12 +12,12 @@ public class MatrixBaseDouble {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected MatrixBaseDouble(long cPtr, boolean cMemoryOwn) {
+  public MatrixBaseDouble(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(MatrixBaseDouble obj) {
+  public static long getCPtr(MatrixBaseDouble obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MatrixBaseVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MatrixBaseVec3.java
@@ -12,12 +12,12 @@ public class MatrixBaseVec3 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected MatrixBaseVec3(long cPtr, boolean cMemoryOwn) {
+  public MatrixBaseVec3(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(MatrixBaseVec3 obj) {
+  public static long getCPtr(MatrixBaseVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MatrixOfSpatialVec.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MatrixOfSpatialVec.java
@@ -12,12 +12,12 @@ public class MatrixOfSpatialVec {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected MatrixOfSpatialVec(long cPtr, boolean cMemoryOwn) {
+  public MatrixOfSpatialVec(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(MatrixOfSpatialVec obj) {
+  public static long getCPtr(MatrixOfSpatialVec obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MatrixVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MatrixVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class MatrixVec3 extends MatrixBaseVec3 {
   private transient long swigCPtr;
 
-  protected MatrixVec3(long cPtr, boolean cMemoryOwn) {
+  public MatrixVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.MatrixVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(MatrixVec3 obj) {
+  public static long getCPtr(MatrixVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MatrixView.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MatrixView.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class MatrixView extends MatrixBaseDouble {
   private transient long swigCPtr;
 
-  protected MatrixView(long cPtr, boolean cMemoryOwn) {
+  public MatrixView(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.MatrixView_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(MatrixView obj) {
+  public static long getCPtr(MatrixView obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MatrixViewVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MatrixViewVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class MatrixViewVec3 extends MatrixBaseVec3 {
   private transient long swigCPtr;
 
-  protected MatrixViewVec3(long cPtr, boolean cMemoryOwn) {
+  public MatrixViewVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.MatrixViewVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(MatrixViewVec3 obj) {
+  public static long getCPtr(MatrixViewVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Millard2012EquilibriumMuscleIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Millard2012EquilibriumMuscleIterator.java
@@ -817,15 +817,6 @@ public class Millard2012EquilibriumMuscleIterator {
     return new Model(opensimSimulationJNI.Millard2012EquilibriumMuscleIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.Millard2012EquilibriumMuscleIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.Millard2012EquilibriumMuscleIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.Millard2012EquilibriumMuscleIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Model.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Model.java
@@ -28,6 +28,7 @@ public class Model extends ModelComponent {
     if (swigCPtr != 0) {
       if (swigCMemOwn) {
         swigCMemOwn = false;
+        String nm = this.getName();
         opensimSimulationJNI.delete_Model(swigCPtr);
       }
       swigCPtr = 0;

--- a/Gui/opensim/modeling/src/org/opensim/modeling/ModelComponent.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/ModelComponent.java
@@ -81,13 +81,4 @@ public class ModelComponent extends Component {
     opensimSimulationJNI.ModelComponent_postScale(swigCPtr, this, State.getCPtr(s), s, ScaleSet.getCPtr(scaleSet), scaleSet);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.ModelComponent_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public static Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.ModelComponent_InvalidScaleFactors_get();
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
 }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/ModelComponentIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/ModelComponentIterator.java
@@ -65,15 +65,6 @@ public class ModelComponentIterator {
     return new Model(opensimSimulationJNI.ModelComponentIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.ModelComponentIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.ModelComponentIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.ModelComponentIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MuscleIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MuscleIterator.java
@@ -605,15 +605,6 @@ public class MuscleIterator {
     return new Model(opensimSimulationJNI.MuscleIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.MuscleIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.MuscleIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.MuscleIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/PolygonalMesh.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/PolygonalMesh.java
@@ -12,12 +12,12 @@ public class PolygonalMesh {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected PolygonalMesh(long cPtr, boolean cMemoryOwn) {
+  public PolygonalMesh(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(PolygonalMesh obj) {
+  public static long getCPtr(PolygonalMesh obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Rotation.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Rotation.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class Rotation extends Mat33 {
   private transient long swigCPtr;
 
-  protected Rotation(long cPtr, boolean cMemoryOwn) {
+  public Rotation(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.Rotation_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Rotation obj) {
+  public static long getCPtr(Rotation obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/RowVector.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/RowVector.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class RowVector extends RowVectorBaseDouble {
   private transient long swigCPtr;
 
-  protected RowVector(long cPtr, boolean cMemoryOwn) {
+  public RowVector(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.RowVector_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(RowVector obj) {
+  public static long getCPtr(RowVector obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorBaseDouble.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorBaseDouble.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class RowVectorBaseDouble extends MatrixBaseDouble {
   private transient long swigCPtr;
 
-  protected RowVectorBaseDouble(long cPtr, boolean cMemoryOwn) {
+  public RowVectorBaseDouble(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.RowVectorBaseDouble_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(RowVectorBaseDouble obj) {
+  public static long getCPtr(RowVectorBaseDouble obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorBaseVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorBaseVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class RowVectorBaseVec3 extends MatrixBaseVec3 {
   private transient long swigCPtr;
 
-  protected RowVectorBaseVec3(long cPtr, boolean cMemoryOwn) {
+  public RowVectorBaseVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.RowVectorBaseVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(RowVectorBaseVec3 obj) {
+  public static long getCPtr(RowVectorBaseVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorOfVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorOfVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class RowVectorOfVec3 extends RowVectorBaseVec3 {
   private transient long swigCPtr;
 
-  protected RowVectorOfVec3(long cPtr, boolean cMemoryOwn) {
+  public RowVectorOfVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.RowVectorOfVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(RowVectorOfVec3 obj) {
+  public static long getCPtr(RowVectorOfVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorView.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorView.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class RowVectorView extends RowVectorBaseDouble {
   private transient long swigCPtr;
 
-  protected RowVectorView(long cPtr, boolean cMemoryOwn) {
+  public RowVectorView(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.RowVectorView_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(RowVectorView obj) {
+  public static long getCPtr(RowVectorView obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorViewVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/RowVectorViewVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class RowVectorViewVec3 extends RowVectorBaseVec3 {
   private transient long swigCPtr;
 
-  protected RowVectorViewVec3(long cPtr, boolean cMemoryOwn) {
+  public RowVectorViewVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.RowVectorViewVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(RowVectorViewVec3 obj) {
+  public static long getCPtr(RowVectorViewVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Segment.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Segment.java
@@ -12,12 +12,12 @@ public class Segment {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Segment(long cPtr, boolean cMemoryOwn) {
+  public Segment(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Segment obj) {
+  public static long getCPtr(Segment obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayDouble.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayDouble.java
@@ -12,12 +12,12 @@ public class SimTKArrayDouble {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimTKArrayDouble(long cPtr, boolean cMemoryOwn) {
+  public SimTKArrayDouble(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKArrayDouble obj) {
+  public static long getCPtr(SimTKArrayDouble obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayInt.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayInt.java
@@ -12,12 +12,12 @@ public class SimTKArrayInt {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimTKArrayInt(long cPtr, boolean cMemoryOwn) {
+  public SimTKArrayInt(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKArrayInt obj) {
+  public static long getCPtr(SimTKArrayInt obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayMobilizedBodyIndex.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayMobilizedBodyIndex.java
@@ -12,12 +12,12 @@ public class SimTKArrayMobilizedBodyIndex {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimTKArrayMobilizedBodyIndex(long cPtr, boolean cMemoryOwn) {
+  public SimTKArrayMobilizedBodyIndex(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKArrayMobilizedBodyIndex obj) {
+  public static long getCPtr(SimTKArrayMobilizedBodyIndex obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayString.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayString.java
@@ -12,12 +12,12 @@ public class SimTKArrayString {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimTKArrayString(long cPtr, boolean cMemoryOwn) {
+  public SimTKArrayString(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKArrayString obj) {
+  public static long getCPtr(SimTKArrayString obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKArrayVec3.java
@@ -12,12 +12,12 @@ public class SimTKArrayVec3 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimTKArrayVec3(long cPtr, boolean cMemoryOwn) {
+  public SimTKArrayVec3(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKArrayVec3 obj) {
+  public static long getCPtr(SimTKArrayVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKVisualizer.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKVisualizer.java
@@ -12,12 +12,12 @@ public class SimTKVisualizer {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimTKVisualizer(long cPtr, boolean cMemoryOwn) {
+  public SimTKVisualizer(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKVisualizer obj) {
+  public static long getCPtr(SimTKVisualizer obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 
@@ -299,12 +299,12 @@ public class SimTKVisualizer {
     private transient long swigCPtr;
     protected transient boolean swigCMemOwn;
   
-    protected FrameController(long cPtr, boolean cMemoryOwn) {
+    public FrameController(long cPtr, boolean cMemoryOwn) {
       swigCMemOwn = cMemoryOwn;
       swigCPtr = cPtr;
     }
   
-    protected static long getCPtr(FrameController obj) {
+    public static long getCPtr(FrameController obj) {
       return (obj == null) ? 0 : obj.swigCPtr;
     }
   
@@ -331,12 +331,12 @@ public class SimTKVisualizer {
   static public class BodyFollower extends SimTKVisualizer.FrameController {
     private transient long swigCPtr;
   
-    protected BodyFollower(long cPtr, boolean cMemoryOwn) {
+    public BodyFollower(long cPtr, boolean cMemoryOwn) {
       super(opensimSimbodyJNI.SimTKVisualizer_BodyFollower_SWIGUpcast(cPtr), cMemoryOwn);
       swigCPtr = cPtr;
     }
   
-    protected static long getCPtr(BodyFollower obj) {
+    public static long getCPtr(BodyFollower obj) {
       return (obj == null) ? 0 : obj.swigCPtr;
     }
   

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKVisualizerInputListener.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKVisualizerInputListener.java
@@ -12,12 +12,12 @@ public class SimTKVisualizerInputListener {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimTKVisualizerInputListener(long cPtr, boolean cMemoryOwn) {
+  public SimTKVisualizerInputListener(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKVisualizerInputListener obj) {
+  public static long getCPtr(SimTKVisualizerInputListener obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimTKVisualizerInputSilo.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimTKVisualizerInputSilo.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class SimTKVisualizerInputSilo extends SimTKVisualizerInputListener {
   private transient long swigCPtr;
 
-  protected SimTKVisualizerInputSilo(long cPtr, boolean cMemoryOwn) {
+  public SimTKVisualizerInputSilo(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.SimTKVisualizerInputSilo_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimTKVisualizerInputSilo obj) {
+  public static long getCPtr(SimTKVisualizerInputSilo obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SimbodyMatterSubsystem.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SimbodyMatterSubsystem.java
@@ -12,12 +12,12 @@ public class SimbodyMatterSubsystem {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SimbodyMatterSubsystem(long cPtr, boolean cMemoryOwn) {
+  public SimbodyMatterSubsystem(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SimbodyMatterSubsystem obj) {
+  public static long getCPtr(SimbodyMatterSubsystem obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/SpatialVec.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/SpatialVec.java
@@ -12,12 +12,12 @@ public class SpatialVec {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected SpatialVec(long cPtr, boolean cMemoryOwn) {
+  public SpatialVec(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(SpatialVec obj) {
+  public static long getCPtr(SpatialVec obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Stage.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Stage.java
@@ -12,12 +12,12 @@ public class Stage {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Stage(long cPtr, boolean cMemoryOwn) {
+  public Stage(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Stage obj) {
+  public static long getCPtr(Stage obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/State.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/State.java
@@ -12,12 +12,12 @@ public class State {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected State(long cPtr, boolean cMemoryOwn) {
+  public State(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(State obj) {
+  public static long getCPtr(State obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorDouble.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorDouble.java
@@ -12,12 +12,12 @@ public class StdVectorDouble {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected StdVectorDouble(long cPtr, boolean cMemoryOwn) {
+  public StdVectorDouble(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(StdVectorDouble obj) {
+  public static long getCPtr(StdVectorDouble obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorInt.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorInt.java
@@ -12,12 +12,12 @@ public class StdVectorInt {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected StdVectorInt(long cPtr, boolean cMemoryOwn) {
+  public StdVectorInt(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(StdVectorInt obj) {
+  public static long getCPtr(StdVectorInt obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorState.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorState.java
@@ -12,12 +12,12 @@ public class StdVectorState {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected StdVectorState(long cPtr, boolean cMemoryOwn) {
+  public StdVectorState(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(StdVectorState obj) {
+  public static long getCPtr(StdVectorState obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorString.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorString.java
@@ -12,12 +12,12 @@ public class StdVectorString {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected StdVectorString(long cPtr, boolean cMemoryOwn) {
+  public StdVectorString(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(StdVectorString obj) {
+  public static long getCPtr(StdVectorString obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorUnsigned.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorUnsigned.java
@@ -12,12 +12,12 @@ public class StdVectorUnsigned {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected StdVectorUnsigned(long cPtr, boolean cMemoryOwn) {
+  public StdVectorUnsigned(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(StdVectorUnsigned obj) {
+  public static long getCPtr(StdVectorUnsigned obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/StdVectorVec3.java
@@ -12,12 +12,12 @@ public class StdVectorVec3 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected StdVectorVec3(long cPtr, boolean cMemoryOwn) {
+  public StdVectorVec3(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(StdVectorVec3 obj) {
+  public static long getCPtr(StdVectorVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Thelen2003MuscleIterator.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Thelen2003MuscleIterator.java
@@ -765,15 +765,6 @@ public class Thelen2003MuscleIterator {
     return new Model(opensimSimulationJNI.Thelen2003MuscleIterator_getModel(swigCPtr, this), false);
   }
 
-  public Vec3 getScaleFactors(ScaleSet scaleSet, Frame frame) {
-    return new Vec3(opensimSimulationJNI.Thelen2003MuscleIterator_getScaleFactors(swigCPtr, this, ScaleSet.getCPtr(scaleSet), scaleSet, Frame.getCPtr(frame), frame), false);
-  }
-
-  public Vec3 getInvalidScaleFactors() {
-    long cPtr = opensimSimulationJNI.Thelen2003MuscleIterator_InvalidScaleFactors_get(swigCPtr, this);
-    return (cPtr == 0) ? null : new Vec3(cPtr, false);
-  }
-
   public void addToSystem(SWIGTYPE_p_SimTK__MultibodySystem system) {
     opensimSimulationJNI.Thelen2003MuscleIterator_addToSystem(swigCPtr, this, SWIGTYPE_p_SimTK__MultibodySystem.getCPtr(system));
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTable.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTable.java
@@ -61,6 +61,14 @@ public class TimeSeriesTable extends DataTable {
     this(opensimCommonJNI.new_TimeSeriesTable__SWIG_5(filename, tablename), true);
   }
 
+  public long getNearestRowIndexForTime(double time, boolean restrictToTimeRange) {
+    return opensimCommonJNI.TimeSeriesTable_getNearestRowIndexForTime__SWIG_0(swigCPtr, this, time, restrictToTimeRange);
+  }
+
+  public long getNearestRowIndexForTime(double time) {
+    return opensimCommonJNI.TimeSeriesTable_getNearestRowIndexForTime__SWIG_1(swigCPtr, this, time);
+  }
+
   public RowVectorView getNearestRow(double time, boolean restrictToTimeRange) {
     return new RowVectorView(opensimCommonJNI.TimeSeriesTable_getNearestRow__SWIG_0(swigCPtr, this, time, restrictToTimeRange), true);
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableQuaternion.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableQuaternion.java
@@ -61,6 +61,14 @@ public class TimeSeriesTableQuaternion extends DataTableQuaternion {
     this(opensimCommonJNI.new_TimeSeriesTableQuaternion__SWIG_5(filename, tablename), true);
   }
 
+  public long getNearestRowIndexForTime(double time, boolean restrictToTimeRange) {
+    return opensimCommonJNI.TimeSeriesTableQuaternion_getNearestRowIndexForTime__SWIG_0(swigCPtr, this, time, restrictToTimeRange);
+  }
+
+  public long getNearestRowIndexForTime(double time) {
+    return opensimCommonJNI.TimeSeriesTableQuaternion_getNearestRowIndexForTime__SWIG_1(swigCPtr, this, time);
+  }
+
   public SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__Quaternion_t getNearestRow(double time, boolean restrictToTimeRange) {
     return new SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__Quaternion_t(opensimCommonJNI.TimeSeriesTableQuaternion_getNearestRow__SWIG_0(swigCPtr, this, time, restrictToTimeRange), true);
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableSpatialVec.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableSpatialVec.java
@@ -61,6 +61,14 @@ public class TimeSeriesTableSpatialVec extends DataTableSpatialVec {
     this(opensimCommonJNI.new_TimeSeriesTableSpatialVec__SWIG_5(filename, tablename), true);
   }
 
+  public long getNearestRowIndexForTime(double time, boolean restrictToTimeRange) {
+    return opensimCommonJNI.TimeSeriesTableSpatialVec_getNearestRowIndexForTime__SWIG_0(swigCPtr, this, time, restrictToTimeRange);
+  }
+
+  public long getNearestRowIndexForTime(double time) {
+    return opensimCommonJNI.TimeSeriesTableSpatialVec_getNearestRowIndexForTime__SWIG_1(swigCPtr, this, time);
+  }
+
   public SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__VecT_2_SimTK__Vec3_1_t_t getNearestRow(double time, boolean restrictToTimeRange) {
     return new SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__VecT_2_SimTK__Vec3_1_t_t(opensimCommonJNI.TimeSeriesTableSpatialVec_getNearestRow__SWIG_0(swigCPtr, this, time, restrictToTimeRange), true);
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableUnitVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableUnitVec3.java
@@ -61,6 +61,14 @@ public class TimeSeriesTableUnitVec3 extends DataTableUnitVec3 {
     this(opensimCommonJNI.new_TimeSeriesTableUnitVec3__SWIG_5(filename, tablename), true);
   }
 
+  public long getNearestRowIndexForTime(double time, boolean restrictToTimeRange) {
+    return opensimCommonJNI.TimeSeriesTableUnitVec3_getNearestRowIndexForTime__SWIG_0(swigCPtr, this, time, restrictToTimeRange);
+  }
+
+  public long getNearestRowIndexForTime(double time) {
+    return opensimCommonJNI.TimeSeriesTableUnitVec3_getNearestRowIndexForTime__SWIG_1(swigCPtr, this, time);
+  }
+
   public SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__UnitVecT_double_1_t_t getNearestRow(double time, boolean restrictToTimeRange) {
     return new SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__UnitVecT_double_1_t_t(opensimCommonJNI.TimeSeriesTableUnitVec3_getNearestRow__SWIG_0(swigCPtr, this, time, restrictToTimeRange), true);
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableVec3.java
@@ -61,6 +61,14 @@ public class TimeSeriesTableVec3 extends DataTableVec3 {
     this(opensimCommonJNI.new_TimeSeriesTableVec3__SWIG_5(filename, tablename), true);
   }
 
+  public long getNearestRowIndexForTime(double time, boolean restrictToTimeRange) {
+    return opensimCommonJNI.TimeSeriesTableVec3_getNearestRowIndexForTime__SWIG_0(swigCPtr, this, time, restrictToTimeRange);
+  }
+
+  public long getNearestRowIndexForTime(double time) {
+    return opensimCommonJNI.TimeSeriesTableVec3_getNearestRowIndexForTime__SWIG_1(swigCPtr, this, time);
+  }
+
   public RowVectorViewVec3 getNearestRow(double time, boolean restrictToTimeRange) {
     return new RowVectorViewVec3(opensimCommonJNI.TimeSeriesTableVec3_getNearestRow__SWIG_0(swigCPtr, this, time, restrictToTimeRange), true);
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableVec6.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TimeSeriesTableVec6.java
@@ -61,6 +61,14 @@ public class TimeSeriesTableVec6 extends DataTableVec6 {
     this(opensimCommonJNI.new_TimeSeriesTableVec6__SWIG_5(filename, tablename), true);
   }
 
+  public long getNearestRowIndexForTime(double time, boolean restrictToTimeRange) {
+    return opensimCommonJNI.TimeSeriesTableVec6_getNearestRowIndexForTime__SWIG_0(swigCPtr, this, time, restrictToTimeRange);
+  }
+
+  public long getNearestRowIndexForTime(double time) {
+    return opensimCommonJNI.TimeSeriesTableVec6_getNearestRowIndexForTime__SWIG_1(swigCPtr, this, time);
+  }
+
   public SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__VecT_6_double_1_t_t getNearestRow(double time, boolean restrictToTimeRange) {
     return new SWIGTYPE_p_SimTK__RowVectorView_T_SimTK__VecT_6_double_1_t_t(opensimCommonJNI.TimeSeriesTableVec6_getNearestRow__SWIG_0(swigCPtr, this, time, restrictToTimeRange), true);
   }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Transform.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Transform.java
@@ -12,12 +12,12 @@ public class Transform {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Transform(long cPtr, boolean cMemoryOwn) {
+  public Transform(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Transform obj) {
+  public static long getCPtr(Transform obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TrueType.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TrueType.java
@@ -12,12 +12,12 @@ public class TrueType {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected TrueType(long cPtr, boolean cMemoryOwn) {
+  public TrueType(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(TrueType obj) {
+  public static long getCPtr(TrueType obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/TrustMe.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/TrustMe.java
@@ -12,12 +12,12 @@ public class TrustMe {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected TrustMe(long cPtr, boolean cMemoryOwn) {
+  public TrustMe(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(TrustMe obj) {
+  public static long getCPtr(TrustMe obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/UnitVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/UnitVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class UnitVec3 extends Vec3 {
   private transient long swigCPtr;
 
-  protected UnitVec3(long cPtr, boolean cMemoryOwn) {
+  public UnitVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.UnitVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(UnitVec3 obj) {
+  public static long getCPtr(UnitVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Vec2.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Vec2.java
@@ -12,12 +12,12 @@ public class Vec2 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Vec2(long cPtr, boolean cMemoryOwn) {
+  public Vec2(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Vec2 obj) {
+  public static long getCPtr(Vec2 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Vec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Vec3.java
@@ -12,12 +12,12 @@ public class Vec3 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Vec3(long cPtr, boolean cMemoryOwn) {
+  public Vec3(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Vec3 obj) {
+  public static long getCPtr(Vec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Vec4.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Vec4.java
@@ -12,12 +12,12 @@ public class Vec4 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Vec4(long cPtr, boolean cMemoryOwn) {
+  public Vec4(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Vec4 obj) {
+  public static long getCPtr(Vec4 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Vec6.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Vec6.java
@@ -12,12 +12,12 @@ public class Vec6 {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected Vec6(long cPtr, boolean cMemoryOwn) {
+  public Vec6(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Vec6 obj) {
+  public static long getCPtr(Vec6 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/Vector.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Vector.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class Vector extends VectorBaseDouble {
   private transient long swigCPtr;
 
-  protected Vector(long cPtr, boolean cMemoryOwn) {
+  public Vector(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.Vector_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(Vector obj) {
+  public static long getCPtr(Vector obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/VectorBaseDouble.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/VectorBaseDouble.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class VectorBaseDouble extends MatrixBaseDouble {
   private transient long swigCPtr;
 
-  protected VectorBaseDouble(long cPtr, boolean cMemoryOwn) {
+  public VectorBaseDouble(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.VectorBaseDouble_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(VectorBaseDouble obj) {
+  public static long getCPtr(VectorBaseDouble obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/VectorBaseVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/VectorBaseVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class VectorBaseVec3 extends MatrixBaseVec3 {
   private transient long swigCPtr;
 
-  protected VectorBaseVec3(long cPtr, boolean cMemoryOwn) {
+  public VectorBaseVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.VectorBaseVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(VectorBaseVec3 obj) {
+  public static long getCPtr(VectorBaseVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/VectorOfSpatialVec.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/VectorOfSpatialVec.java
@@ -12,12 +12,12 @@ public class VectorOfSpatialVec {
   private transient long swigCPtr;
   protected transient boolean swigCMemOwn;
 
-  protected VectorOfSpatialVec(long cPtr, boolean cMemoryOwn) {
+  public VectorOfSpatialVec(long cPtr, boolean cMemoryOwn) {
     swigCMemOwn = cMemoryOwn;
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(VectorOfSpatialVec obj) {
+  public static long getCPtr(VectorOfSpatialVec obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/VectorOfVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/VectorOfVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class VectorOfVec3 extends VectorBaseVec3 {
   private transient long swigCPtr;
 
-  protected VectorOfVec3(long cPtr, boolean cMemoryOwn) {
+  public VectorOfVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.VectorOfVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(VectorOfVec3 obj) {
+  public static long getCPtr(VectorOfVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/VectorView.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/VectorView.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class VectorView extends VectorBaseDouble {
   private transient long swigCPtr;
 
-  protected VectorView(long cPtr, boolean cMemoryOwn) {
+  public VectorView(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.VectorView_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(VectorView obj) {
+  public static long getCPtr(VectorView obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/VectorViewVec3.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/VectorViewVec3.java
@@ -11,12 +11,12 @@ package org.opensim.modeling;
 public class VectorViewVec3 extends VectorBaseVec3 {
   private transient long swigCPtr;
 
-  protected VectorViewVec3(long cPtr, boolean cMemoryOwn) {
+  public VectorViewVec3(long cPtr, boolean cMemoryOwn) {
     super(opensimSimbodyJNI.VectorViewVec3_SWIGUpcast(cPtr), cMemoryOwn);
     swigCPtr = cPtr;
   }
 
-  protected static long getCPtr(VectorViewVec3 obj) {
+  public static long getCPtr(VectorViewVec3 obj) {
     return (obj == null) ? 0 : obj.swigCPtr;
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/opensimActuatorsAnalysesToolsJNI.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/opensimActuatorsAnalysesToolsJNI.java
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------------- */
 
 package org.opensim.modeling;
-import javax.swing.JOptionPane;
+import javax.swing.JOptionPane;import java.awt.GraphicsEnvironment;
 public class opensimActuatorsAnalysesToolsJNI {
 
   static {
@@ -16,9 +16,33 @@ public class opensimActuatorsAnalysesToolsJNI {
           System.loadLibrary("osimJavaJNI");
       }
       catch(UnsatisfiedLinkError e){
-          new JOptionPane("Required library failed to load. Check that the " +
-                          "dynamic library osimJavaJNI is in your PATH\n" + e, 
-        JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
+          String OS = System.getProperty("os.name").toLowerCase();
+          String tip = "";
+          if (OS.indexOf("win") >= 0) {
+              tip = "\nMake sure OpenSim's bin directory is on your PATH.";
+          } else if (OS.indexOf("mac") >= 0) {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          } else /* linux */ {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          }
+          String msg = new String(
+                  "Failed to load one or more dynamic libraries for OpenSim.\n"
+                  + e + tip);
+
+          String javaHome = System.getProperties().getProperty("java.home");
+          boolean inMatlab = javaHome.toLowerCase().indexOf("matlab") >= 0;
+          if (inMatlab) {
+              msg +=  "\nSee https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+with+Matlab";
+          }
+          
+          System.out.println(msg);
+          String title = "Error: Failed to load OpenSim libraries";
+          if (!GraphicsEnvironment.isHeadless()) {
+              new JOptionPane(msg, JOptionPane.ERROR_MESSAGE)
+                    .createDialog(null, title).setVisible(true);
+          }
       }
   }
 

--- a/Gui/opensim/modeling/src/org/opensim/modeling/opensimCommonJNI.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/opensimCommonJNI.java
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------------- */
 
 package org.opensim.modeling;
-import javax.swing.JOptionPane;
+import javax.swing.JOptionPane;import java.awt.GraphicsEnvironment;
 public class opensimCommonJNI {
 
   static {
@@ -16,9 +16,33 @@ public class opensimCommonJNI {
           System.loadLibrary("osimJavaJNI");
       }
       catch(UnsatisfiedLinkError e){
-          new JOptionPane("Required library failed to load. Check that the " +
-                          "dynamic library osimJavaJNI is in your PATH\n" + e, 
-        JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
+          String OS = System.getProperty("os.name").toLowerCase();
+          String tip = "";
+          if (OS.indexOf("win") >= 0) {
+              tip = "\nMake sure OpenSim's bin directory is on your PATH.";
+          } else if (OS.indexOf("mac") >= 0) {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          } else /* linux */ {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          }
+          String msg = new String(
+                  "Failed to load one or more dynamic libraries for OpenSim.\n"
+                  + e + tip);
+
+          String javaHome = System.getProperties().getProperty("java.home");
+          boolean inMatlab = javaHome.toLowerCase().indexOf("matlab") >= 0;
+          if (inMatlab) {
+              msg +=  "\nSee https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+with+Matlab";
+          }
+          
+          System.out.println(msg);
+          String title = "Error: Failed to load OpenSim libraries";
+          if (!GraphicsEnvironment.isHeadless()) {
+              new JOptionPane(msg, JOptionPane.ERROR_MESSAGE)
+                    .createDialog(null, title).setVisible(true);
+          }
       }
   }
 
@@ -2031,6 +2055,8 @@ public class opensimCommonJNI {
   public final static native long new_TimeSeriesTable__SWIG_3(long jarg1, DataTable jarg1_);
   public final static native long new_TimeSeriesTable__SWIG_4(String jarg1);
   public final static native long new_TimeSeriesTable__SWIG_5(String jarg1, String jarg2);
+  public final static native long TimeSeriesTable_getNearestRowIndexForTime__SWIG_0(long jarg1, TimeSeriesTable jarg1_, double jarg2, boolean jarg3);
+  public final static native long TimeSeriesTable_getNearestRowIndexForTime__SWIG_1(long jarg1, TimeSeriesTable jarg1_, double jarg2);
   public final static native long TimeSeriesTable_getNearestRow__SWIG_0(long jarg1, TimeSeriesTable jarg1_, double jarg2, boolean jarg3);
   public final static native long TimeSeriesTable_getNearestRow__SWIG_1(long jarg1, TimeSeriesTable jarg1_, double jarg2);
   public final static native long TimeSeriesTable_updNearestRow__SWIG_0(long jarg1, TimeSeriesTable jarg1_, double jarg2, boolean jarg3);
@@ -2052,6 +2078,8 @@ public class opensimCommonJNI {
   public final static native long new_TimeSeriesTableVec3__SWIG_3(long jarg1, DataTableVec3 jarg1_);
   public final static native long new_TimeSeriesTableVec3__SWIG_4(String jarg1);
   public final static native long new_TimeSeriesTableVec3__SWIG_5(String jarg1, String jarg2);
+  public final static native long TimeSeriesTableVec3_getNearestRowIndexForTime__SWIG_0(long jarg1, TimeSeriesTableVec3 jarg1_, double jarg2, boolean jarg3);
+  public final static native long TimeSeriesTableVec3_getNearestRowIndexForTime__SWIG_1(long jarg1, TimeSeriesTableVec3 jarg1_, double jarg2);
   public final static native long TimeSeriesTableVec3_getNearestRow__SWIG_0(long jarg1, TimeSeriesTableVec3 jarg1_, double jarg2, boolean jarg3);
   public final static native long TimeSeriesTableVec3_getNearestRow__SWIG_1(long jarg1, TimeSeriesTableVec3 jarg1_, double jarg2);
   public final static native long TimeSeriesTableVec3_updNearestRow__SWIG_0(long jarg1, TimeSeriesTableVec3 jarg1_, double jarg2, boolean jarg3);
@@ -2067,6 +2095,8 @@ public class opensimCommonJNI {
   public final static native long new_TimeSeriesTableUnitVec3__SWIG_3(long jarg1, DataTableUnitVec3 jarg1_);
   public final static native long new_TimeSeriesTableUnitVec3__SWIG_4(String jarg1);
   public final static native long new_TimeSeriesTableUnitVec3__SWIG_5(String jarg1, String jarg2);
+  public final static native long TimeSeriesTableUnitVec3_getNearestRowIndexForTime__SWIG_0(long jarg1, TimeSeriesTableUnitVec3 jarg1_, double jarg2, boolean jarg3);
+  public final static native long TimeSeriesTableUnitVec3_getNearestRowIndexForTime__SWIG_1(long jarg1, TimeSeriesTableUnitVec3 jarg1_, double jarg2);
   public final static native long TimeSeriesTableUnitVec3_getNearestRow__SWIG_0(long jarg1, TimeSeriesTableUnitVec3 jarg1_, double jarg2, boolean jarg3);
   public final static native long TimeSeriesTableUnitVec3_getNearestRow__SWIG_1(long jarg1, TimeSeriesTableUnitVec3 jarg1_, double jarg2);
   public final static native long TimeSeriesTableUnitVec3_updNearestRow__SWIG_0(long jarg1, TimeSeriesTableUnitVec3 jarg1_, double jarg2, boolean jarg3);
@@ -2082,6 +2112,8 @@ public class opensimCommonJNI {
   public final static native long new_TimeSeriesTableQuaternion__SWIG_3(long jarg1, DataTableQuaternion jarg1_);
   public final static native long new_TimeSeriesTableQuaternion__SWIG_4(String jarg1);
   public final static native long new_TimeSeriesTableQuaternion__SWIG_5(String jarg1, String jarg2);
+  public final static native long TimeSeriesTableQuaternion_getNearestRowIndexForTime__SWIG_0(long jarg1, TimeSeriesTableQuaternion jarg1_, double jarg2, boolean jarg3);
+  public final static native long TimeSeriesTableQuaternion_getNearestRowIndexForTime__SWIG_1(long jarg1, TimeSeriesTableQuaternion jarg1_, double jarg2);
   public final static native long TimeSeriesTableQuaternion_getNearestRow__SWIG_0(long jarg1, TimeSeriesTableQuaternion jarg1_, double jarg2, boolean jarg3);
   public final static native long TimeSeriesTableQuaternion_getNearestRow__SWIG_1(long jarg1, TimeSeriesTableQuaternion jarg1_, double jarg2);
   public final static native long TimeSeriesTableQuaternion_updNearestRow__SWIG_0(long jarg1, TimeSeriesTableQuaternion jarg1_, double jarg2, boolean jarg3);
@@ -2097,6 +2129,8 @@ public class opensimCommonJNI {
   public final static native long new_TimeSeriesTableVec6__SWIG_3(long jarg1, DataTableVec6 jarg1_);
   public final static native long new_TimeSeriesTableVec6__SWIG_4(String jarg1);
   public final static native long new_TimeSeriesTableVec6__SWIG_5(String jarg1, String jarg2);
+  public final static native long TimeSeriesTableVec6_getNearestRowIndexForTime__SWIG_0(long jarg1, TimeSeriesTableVec6 jarg1_, double jarg2, boolean jarg3);
+  public final static native long TimeSeriesTableVec6_getNearestRowIndexForTime__SWIG_1(long jarg1, TimeSeriesTableVec6 jarg1_, double jarg2);
   public final static native long TimeSeriesTableVec6_getNearestRow__SWIG_0(long jarg1, TimeSeriesTableVec6 jarg1_, double jarg2, boolean jarg3);
   public final static native long TimeSeriesTableVec6_getNearestRow__SWIG_1(long jarg1, TimeSeriesTableVec6 jarg1_, double jarg2);
   public final static native long TimeSeriesTableVec6_updNearestRow__SWIG_0(long jarg1, TimeSeriesTableVec6 jarg1_, double jarg2, boolean jarg3);
@@ -2112,6 +2146,8 @@ public class opensimCommonJNI {
   public final static native long new_TimeSeriesTableSpatialVec__SWIG_3(long jarg1, DataTableSpatialVec jarg1_);
   public final static native long new_TimeSeriesTableSpatialVec__SWIG_4(String jarg1);
   public final static native long new_TimeSeriesTableSpatialVec__SWIG_5(String jarg1, String jarg2);
+  public final static native long TimeSeriesTableSpatialVec_getNearestRowIndexForTime__SWIG_0(long jarg1, TimeSeriesTableSpatialVec jarg1_, double jarg2, boolean jarg3);
+  public final static native long TimeSeriesTableSpatialVec_getNearestRowIndexForTime__SWIG_1(long jarg1, TimeSeriesTableSpatialVec jarg1_, double jarg2);
   public final static native long TimeSeriesTableSpatialVec_getNearestRow__SWIG_0(long jarg1, TimeSeriesTableSpatialVec jarg1_, double jarg2, boolean jarg3);
   public final static native long TimeSeriesTableSpatialVec_getNearestRow__SWIG_1(long jarg1, TimeSeriesTableSpatialVec jarg1_, double jarg2);
   public final static native long TimeSeriesTableSpatialVec_updNearestRow__SWIG_0(long jarg1, TimeSeriesTableSpatialVec jarg1_, double jarg2, boolean jarg3);

--- a/Gui/opensim/modeling/src/org/opensim/modeling/opensimExampleComponentsJNI.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/opensimExampleComponentsJNI.java
@@ -7,8 +7,45 @@
  * ----------------------------------------------------------------------------- */
 
 package org.opensim.modeling;
-
+import javax.swing.JOptionPane;import java.awt.GraphicsEnvironment;
 public class opensimExampleComponentsJNI {
+
+  static {
+      try{
+          // All OpenSim classes required for GUI operation.
+          System.loadLibrary("osimJavaJNI");
+      }
+      catch(UnsatisfiedLinkError e){
+          String OS = System.getProperty("os.name").toLowerCase();
+          String tip = "";
+          if (OS.indexOf("win") >= 0) {
+              tip = "\nMake sure OpenSim's bin directory is on your PATH.";
+          } else if (OS.indexOf("mac") >= 0) {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          } else /* linux */ {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          }
+          String msg = new String(
+                  "Failed to load one or more dynamic libraries for OpenSim.\n"
+                  + e + tip);
+
+          String javaHome = System.getProperties().getProperty("java.home");
+          boolean inMatlab = javaHome.toLowerCase().indexOf("matlab") >= 0;
+          if (inMatlab) {
+              msg +=  "\nSee https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+with+Matlab";
+          }
+          
+          System.out.println(msg);
+          String title = "Error: Failed to load OpenSim libraries";
+          if (!GraphicsEnvironment.isHeadless()) {
+              new JOptionPane(msg, JOptionPane.ERROR_MESSAGE)
+                    .createDialog(null, title).setVisible(true);
+          }
+      }
+  }
+
   public final static native long ToyReflexController_safeDownCast(long jarg1, OpenSimObject jarg1_);
   public final static native void ToyReflexController_assign(long jarg1, ToyReflexController jarg1_, long jarg2, OpenSimObject jarg2_);
   public final static native String ToyReflexController_getClassName();

--- a/Gui/opensim/modeling/src/org/opensim/modeling/opensimSimbodyJNI.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/opensimSimbodyJNI.java
@@ -7,8 +7,45 @@
  * ----------------------------------------------------------------------------- */
 
 package org.opensim.modeling;
-
+import javax.swing.JOptionPane;import java.awt.GraphicsEnvironment;
 public class opensimSimbodyJNI {
+
+  static {
+      try{
+          // All OpenSim classes required for GUI operation.
+          System.loadLibrary("osimJavaJNI");
+      }
+      catch(UnsatisfiedLinkError e){
+          String OS = System.getProperty("os.name").toLowerCase();
+          String tip = "";
+          if (OS.indexOf("win") >= 0) {
+              tip = "\nMake sure OpenSim's bin directory is on your PATH.";
+          } else if (OS.indexOf("mac") >= 0) {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          } else /* linux */ {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          }
+          String msg = new String(
+                  "Failed to load one or more dynamic libraries for OpenSim.\n"
+                  + e + tip);
+
+          String javaHome = System.getProperties().getProperty("java.home");
+          boolean inMatlab = javaHome.toLowerCase().indexOf("matlab") >= 0;
+          if (inMatlab) {
+              msg +=  "\nSee https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+with+Matlab";
+          }
+          
+          System.out.println(msg);
+          String title = "Error: Failed to load OpenSim libraries";
+          if (!GraphicsEnvironment.isHeadless()) {
+              new JOptionPane(msg, JOptionPane.ERROR_MESSAGE)
+                    .createDialog(null, title).setVisible(true);
+          }
+      }
+  }
+
   public final static native long new_StdVectorUnsigned__SWIG_0();
   public final static native long new_StdVectorUnsigned__SWIG_1(long jarg1);
   public final static native long StdVectorUnsigned_size(long jarg1, StdVectorUnsigned jarg1_);

--- a/Gui/opensim/modeling/src/org/opensim/modeling/opensimSimulationJNI.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/opensimSimulationJNI.java
@@ -7,7 +7,7 @@
  * ----------------------------------------------------------------------------- */
 
 package org.opensim.modeling;
-import javax.swing.JOptionPane;
+import javax.swing.JOptionPane;import java.awt.GraphicsEnvironment;
 public class opensimSimulationJNI {
 
   static {
@@ -16,9 +16,33 @@ public class opensimSimulationJNI {
           System.loadLibrary("osimJavaJNI");
       }
       catch(UnsatisfiedLinkError e){
-          new JOptionPane("Required library failed to load. Check that the " +
-                          "dynamic library osimJavaJNI is in your PATH\n" + e,
-        JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
+          String OS = System.getProperty("os.name").toLowerCase();
+          String tip = "";
+          if (OS.indexOf("win") >= 0) {
+              tip = "\nMake sure OpenSim's bin directory is on your PATH.";
+          } else if (OS.indexOf("mac") >= 0) {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          } else /* linux */ {
+              // Nothing for now; our use of RPATH means we were probably able
+              // to locate the OpenSim dynamic libraries.
+          }
+          String msg = new String(
+                  "Failed to load one or more dynamic libraries for OpenSim.\n"
+                  + e + tip);
+
+          String javaHome = System.getProperties().getProperty("java.home");
+          boolean inMatlab = javaHome.toLowerCase().indexOf("matlab") >= 0;
+          if (inMatlab) {
+              msg +=  "\nSee https://simtk-confluence.stanford.edu/display/OpenSim/Scripting+with+Matlab";
+          }
+          
+          System.out.println(msg);
+          String title = "Error: Failed to load OpenSim libraries";
+          if (!GraphicsEnvironment.isHeadless()) {
+              new JOptionPane(msg, JOptionPane.ERROR_MESSAGE)
+                    .createDialog(null, title).setVisible(true);
+          }
       }
   }
 
@@ -406,8 +430,6 @@ public class opensimSimulationJNI {
   public final static native void ModelComponent_preScale(long jarg1, ModelComponent jarg1_, long jarg2, State jarg2_, long jarg3, ScaleSet jarg3_);
   public final static native void ModelComponent_scale(long jarg1, ModelComponent jarg1_, long jarg2, State jarg2_, long jarg3, ScaleSet jarg3_);
   public final static native void ModelComponent_postScale(long jarg1, ModelComponent jarg1_, long jarg2, State jarg2_, long jarg3, ScaleSet jarg3_);
-  public final static native long ModelComponent_getScaleFactors(long jarg1, ModelComponent jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long ModelComponent_InvalidScaleFactors_get();
   public final static native long SetModelComponents_safeDownCast(long jarg1, OpenSimObject jarg1_);
   public final static native void SetModelComponents_assign(long jarg1, SetModelComponents jarg1_, long jarg2, OpenSimObject jarg2_);
   public final static native String SetModelComponents_getClassName();
@@ -6375,8 +6397,6 @@ public class opensimSimulationJNI {
   public final static native long FrameIterator_findTransformInBaseFrame(long jarg1, FrameIterator jarg1_);
   public final static native long FrameIterator_getPositionInGround(long jarg1, FrameIterator jarg1_, long jarg2, State jarg2_);
   public final static native long FrameIterator_getModel(long jarg1, FrameIterator jarg1_);
-  public final static native long FrameIterator_getScaleFactors(long jarg1, FrameIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long FrameIterator_InvalidScaleFactors_get(long jarg1, FrameIterator jarg1_);
   public final static native void FrameIterator_addToSystem(long jarg1, FrameIterator jarg1_, long jarg2);
   public final static native void FrameIterator_initStateFromProperties(long jarg1, FrameIterator jarg1_, long jarg2, State jarg2_);
   public final static native void FrameIterator_generateDecorations(long jarg1, FrameIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);
@@ -6495,8 +6515,6 @@ public class opensimSimulationJNI {
   public final static native long BodyIterator_findTransformInBaseFrame(long jarg1, BodyIterator jarg1_);
   public final static native long BodyIterator_getPositionInGround(long jarg1, BodyIterator jarg1_, long jarg2, State jarg2_);
   public final static native long BodyIterator_getModel(long jarg1, BodyIterator jarg1_);
-  public final static native long BodyIterator_getScaleFactors(long jarg1, BodyIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long BodyIterator_InvalidScaleFactors_get(long jarg1, BodyIterator jarg1_);
   public final static native void BodyIterator_addToSystem(long jarg1, BodyIterator jarg1_, long jarg2);
   public final static native void BodyIterator_initStateFromProperties(long jarg1, BodyIterator jarg1_, long jarg2, State jarg2_);
   public final static native void BodyIterator_generateDecorations(long jarg1, BodyIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);
@@ -6706,8 +6724,6 @@ public class opensimSimulationJNI {
   public final static native boolean MuscleIterator_appliesForce(long jarg1, MuscleIterator jarg1_, long jarg2, State jarg2_);
   public final static native void MuscleIterator_setAppliesForce(long jarg1, MuscleIterator jarg1_, long jarg2, State jarg2_, boolean jarg3);
   public final static native long MuscleIterator_getModel(long jarg1, MuscleIterator jarg1_);
-  public final static native long MuscleIterator_getScaleFactors(long jarg1, MuscleIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long MuscleIterator_InvalidScaleFactors_get(long jarg1, MuscleIterator jarg1_);
   public final static native void MuscleIterator_addToSystem(long jarg1, MuscleIterator jarg1_, long jarg2);
   public final static native void MuscleIterator_initStateFromProperties(long jarg1, MuscleIterator jarg1_, long jarg2, State jarg2_);
   public final static native void MuscleIterator_generateDecorations(long jarg1, MuscleIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);
@@ -6782,8 +6798,6 @@ public class opensimSimulationJNI {
   public final static native long ModelComponentIterator_clone(long jarg1, ModelComponentIterator jarg1_);
   public final static native String ModelComponentIterator_getConcreteClassName(long jarg1, ModelComponentIterator jarg1_);
   public final static native long ModelComponentIterator_getModel(long jarg1, ModelComponentIterator jarg1_);
-  public final static native long ModelComponentIterator_getScaleFactors(long jarg1, ModelComponentIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long ModelComponentIterator_InvalidScaleFactors_get(long jarg1, ModelComponentIterator jarg1_);
   public final static native void ModelComponentIterator_addToSystem(long jarg1, ModelComponentIterator jarg1_, long jarg2);
   public final static native void ModelComponentIterator_initStateFromProperties(long jarg1, ModelComponentIterator jarg1_, long jarg2, State jarg2_);
   public final static native void ModelComponentIterator_generateDecorations(long jarg1, ModelComponentIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);
@@ -6874,8 +6888,6 @@ public class opensimSimulationJNI {
   public final static native long JointIterator_calcReactionOnChildExpressedInGround(long jarg1, JointIterator jarg1_, long jarg2, State jarg2_);
   public final static native double JointIterator_calcPower(long jarg1, JointIterator jarg1_, long jarg2, State jarg2_);
   public final static native long JointIterator_getModel(long jarg1, JointIterator jarg1_);
-  public final static native long JointIterator_getScaleFactors(long jarg1, JointIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long JointIterator_InvalidScaleFactors_get(long jarg1, JointIterator jarg1_);
   public final static native void JointIterator_addToSystem(long jarg1, JointIterator jarg1_, long jarg2);
   public final static native void JointIterator_initStateFromProperties(long jarg1, JointIterator jarg1_, long jarg2, State jarg2_);
   public final static native void JointIterator_generateDecorations(long jarg1, JointIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);
@@ -6965,8 +6977,6 @@ public class opensimSimulationJNI {
   public final static native long ActuatorIterator_getRecordValues(long jarg1, ActuatorIterator jarg1_, long jarg2, State jarg2_);
   public final static native boolean ActuatorIterator_hasGeometryPath(long jarg1, ActuatorIterator jarg1_);
   public final static native long ActuatorIterator_getModel(long jarg1, ActuatorIterator jarg1_);
-  public final static native long ActuatorIterator_getScaleFactors(long jarg1, ActuatorIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long ActuatorIterator_InvalidScaleFactors_get(long jarg1, ActuatorIterator jarg1_);
   public final static native void ActuatorIterator_addToSystem(long jarg1, ActuatorIterator jarg1_, long jarg2);
   public final static native void ActuatorIterator_initStateFromProperties(long jarg1, ActuatorIterator jarg1_, long jarg2, State jarg2_);
   public final static native void ActuatorIterator_generateDecorations(long jarg1, ActuatorIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);
@@ -8089,8 +8099,6 @@ public class opensimSimulationJNI {
   public final static native boolean Thelen2003MuscleIterator_appliesForce(long jarg1, Thelen2003MuscleIterator jarg1_, long jarg2, State jarg2_);
   public final static native void Thelen2003MuscleIterator_setAppliesForce(long jarg1, Thelen2003MuscleIterator jarg1_, long jarg2, State jarg2_, boolean jarg3);
   public final static native long Thelen2003MuscleIterator_getModel(long jarg1, Thelen2003MuscleIterator jarg1_);
-  public final static native long Thelen2003MuscleIterator_getScaleFactors(long jarg1, Thelen2003MuscleIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long Thelen2003MuscleIterator_InvalidScaleFactors_get(long jarg1, Thelen2003MuscleIterator jarg1_);
   public final static native void Thelen2003MuscleIterator_addToSystem(long jarg1, Thelen2003MuscleIterator jarg1_, long jarg2);
   public final static native void Thelen2003MuscleIterator_initStateFromProperties(long jarg1, Thelen2003MuscleIterator jarg1_, long jarg2, State jarg2_);
   public final static native void Thelen2003MuscleIterator_generateDecorations(long jarg1, Thelen2003MuscleIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);
@@ -8353,8 +8361,6 @@ public class opensimSimulationJNI {
   public final static native boolean Millard2012EquilibriumMuscleIterator_appliesForce(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_, long jarg2, State jarg2_);
   public final static native void Millard2012EquilibriumMuscleIterator_setAppliesForce(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_, long jarg2, State jarg2_, boolean jarg3);
   public final static native long Millard2012EquilibriumMuscleIterator_getModel(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_);
-  public final static native long Millard2012EquilibriumMuscleIterator_getScaleFactors(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_, long jarg2, ScaleSet jarg2_, long jarg3, Frame jarg3_);
-  public final static native long Millard2012EquilibriumMuscleIterator_InvalidScaleFactors_get(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_);
   public final static native void Millard2012EquilibriumMuscleIterator_addToSystem(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_, long jarg2);
   public final static native void Millard2012EquilibriumMuscleIterator_initStateFromProperties(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_, long jarg2, State jarg2_);
   public final static native void Millard2012EquilibriumMuscleIterator_generateDecorations(long jarg1, Millard2012EquilibriumMuscleIterator jarg1_, boolean jarg2, long jarg3, ModelDisplayHints jarg3_, long jarg4, State jarg4_, long jarg5, ArrayDecorativeGeometry jarg5_);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalysisSetPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalysisSetPanel.java
@@ -71,7 +71,11 @@ class AnalysisSetTableModel extends AbstractTableModel implements Observer {
    }
 
    public int getColumnCount() { return columnNames.length; }
-   public int getRowCount() { return toolModel.getAnalysisSet().getSize(); }
+   public int getRowCount() { 
+       assert(toolModel!=null);
+       assert(toolModel.getAnalysisSet()!=null);
+       return toolModel.getAnalysisSet().getSize(); 
+   }
    public String getColumnName(int col) { return columnNames[col]; }
 
    public Object getValueAt(int row, int col) {
@@ -250,12 +254,13 @@ public class AnalysisSetPanel extends javax.swing.JPanel implements Observer {
    private void editButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_editButtonActionPerformed
       if(currentSelectedRow>=0) {
          Analysis analysis = toolModel.getAnalysisSet().get(currentSelectedRow);
-         Analysis analysisCopy = Analysis.safeDownCast(analysis.clone()); // C++-side copy
-         ObjectEditDialogMaker editorDialog = new ObjectEditDialogMaker(analysisCopy, true, "OK");
-         if(editorDialog.process()) {
-            toolModel.replaceAnalysis(currentSelectedRow, analysisCopy);
+         Analysis analysisCopy = Analysis.safeDownCast(analysis.clone());
+         ObjectEditDialogMaker editorDialog = new ObjectEditDialogMaker(analysis, true, "OK");
+         if(!editorDialog.process()) {
+            analysis.assign(analysisCopy);
          } else {
-            // Do nothing if edit was canceled
+            // If edit was successful, notify observers to enable "Run"
+            toolModel.analysisModified(currentSelectedRow);
          }
       }
    }//GEN-LAST:event_editButtonActionPerformed

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
@@ -70,7 +70,7 @@ public class AnalyzeToolModel extends AbstractToolModelWithExternalLoads {
          MotionsDB.getInstance().clearCurrent();
 
          Model workersModel = new Model(getOriginalModel());
-         workersModel.setName("workerModel");
+         //workersModel.setName("workerModel");
          String tempFileName=getOriginalModel().getInputFileName();
          //int loc = tempFileName.lastIndexOf(".");
          workersModel.setInputFileName(tempFileName);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
@@ -176,8 +176,6 @@ public class AnalyzeToolModel extends AbstractToolModelWithExternalLoads {
          getModel().removeAnalysis(animationCallback, false);
          getModel().removeAnalysis(interruptingCallback, false);
          interruptingCallback = null;
-         model = null;
-         tool = null;
          if(result) resetModified();
 
          setExecuting(false);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
@@ -71,7 +71,7 @@ public class InverseDynamicsToolModel extends AbstractToolModelWithExternalLoads
 
          // Re-initialize our copy of the model
          Model workersModel = new Model(getOriginalModel());
-         workersModel.setName("workerModel");
+         //workersModel.setName("workerModel");
          String tempFileName=getOriginalModel().getInputFileName();
          //int loc = tempFileName.lastIndexOf(".");
          workersModel.setInputFileName(tempFileName);


### PR DESCRIPTION
Fix crash editing Analyses after executing AnalyzeTool GUI due to model's early garbage collection. Folded in this PR updating the Java bindings to latest opensim-core API