### PR TITLE
Turn off recording accelerations when using Kinematics analysis in GUI

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
@@ -104,6 +104,7 @@ public class JavaMotionDisplayerCallback extends AnalysisWrapperWithTimer {
          if (isCoordinatesOnly()){
             kinReporter = new Kinematics(get_model());
             kinReporter.setInDegrees(false);
+            kinReporter.setRecordAccelerations(false);
             kinReporter.begin(context.getCurrentStateRef());
             storage = kinReporter.getPositionStorage();
         }


### PR DESCRIPTION
When using kinematics internally to record states, no need to compute accelerations or realize higher then velocity.