### PR TITLE
Whenever an IOException is caught, it's displayed in ErrorDialog

### DIFF
--- a/Gui/opensim/helpUtils/src/org/opensim/helputils/ToolsVersionUpgradeAction.java
+++ b/Gui/opensim/helpUtils/src/org/opensim/helputils/ToolsVersionUpgradeAction.java
@@ -32,6 +32,7 @@ import org.openide.util.actions.CallableSystemAction;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.Storage;
+import org.opensim.utils.ErrorDialog;
 
 public final class ToolsVersionUpgradeAction extends CallableSystemAction {
     
@@ -55,7 +56,7 @@ public final class ToolsVersionUpgradeAction extends CallableSystemAction {
                         mdl.clone().print(output);
                         OpenSimObject.setSerializeAllDefaults(saveDefaults);
                     } catch (IOException ex) {
-                        ex.printStackTrace();
+                        ErrorDialog.displayExceptionDialog(ex);
                     }
                 }
                else if (upgradePanel.getExtension().equalsIgnoreCase(".xml")){
@@ -80,7 +81,7 @@ public final class ToolsVersionUpgradeAction extends CallableSystemAction {
                         sto.setInDegrees(upgradePanel.isMarkInDegrees());
                         sto.print(output);
                     } catch (IOException ex) {
-                        ex.printStackTrace();
+                        ErrorDialog.displayExceptionDialog(ex);
                     }
                 }
             }

--- a/Gui/opensim/plotter/src/org/opensim/plotter/JPlotterPanel.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/JPlotterPanel.java
@@ -1179,7 +1179,7 @@ public class JPlotterPanel extends javax.swing.JPanel
             PlotterSourceFile src = new PlotterSourceFile(dataFilename);
             getPlotterModel().addSource(src);
          } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
          }
       }
    }//GEN-LAST:event_jLoadFileToPlotterMenuItemActionPerformed
@@ -1195,7 +1195,7 @@ public class JPlotterPanel extends javax.swing.JPanel
             getPlotterModel().addSource(src);
             return src;
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
         }
         return null;
    }
@@ -1701,7 +1701,7 @@ public class JPlotterPanel extends javax.swing.JPanel
       try {
          tool.run(true);
       } catch (IOException ex) {
-         ex.printStackTrace();
+         ErrorDialog.displayExceptionDialog(ex);
       }
       /*
         try {

--- a/Gui/opensim/plotter/src/org/opensim/plotter/Plot.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/Plot.java
@@ -57,6 +57,7 @@ import org.openide.NotifyDescriptor;
 import org.opensim.modeling.ArrayStr;
 import org.opensim.modeling.StateVector;
 import org.opensim.modeling.Storage;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 
 /**
@@ -279,7 +280,7 @@ public class Plot {
       }
         // out.close();
       } catch (IOException ex) {
-         ex.printStackTrace();   // Show error dialog that file could not be written
+         ErrorDialog.displayExceptionDialog(ex);
       }
    }
    

--- a/Gui/opensim/plotter/src/org/opensim/plotter/PlotterModel.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/PlotterModel.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Vector;
 import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.TreeModel;
 import javax.swing.tree.TreeNode;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
@@ -46,6 +45,7 @@ import org.opensim.modeling.ArrayStr;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.MuscleAnalysis;
 import org.opensim.modeling.Storage;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.experimentaldata.ModelForExperimentalData;
 
 /**
@@ -125,7 +125,7 @@ public class PlotterModel {
          sources.add(newSource);
          return newSource;
       } catch (IOException ex) {
-         ex.printStackTrace();
+         ErrorDialog.displayExceptionDialog(ex);
          return null;
       }
    }

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/JConsole.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/JConsole.java
@@ -33,13 +33,12 @@ import javax.swing.text.AbstractDocument;
 import javax.swing.text.AttributeSet;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.DocumentFilter;
+import org.opensim.utils.ErrorDialog;
 
 import org.python.core.Py;
 import org.python.core.PyException;
 import org.python.util.InteractiveConsole;
-import org.python.util.InteractiveInterpreter;
 import org.python.util.JLineConsole;
-import org.python.util.PythonInterpreter;
 
 /**
  *
@@ -224,7 +223,7 @@ public class JConsole extends JTextArea implements KeyListener {
                 input.close();
             }
         } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
         }
 
         return contents.toString();

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/OpenSimPlotter.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/OpenSimPlotter.java
@@ -40,6 +40,7 @@ import org.opensim.plotter.PlotCurve;
 import org.opensim.plotter.PlotterDB;
 import org.opensim.plotter.PlotterSourceFile;
 import org.opensim.plotter.PlotterSourceMotion;
+import org.opensim.utils.DialogUtils;
 import org.opensim.utils.ErrorDialog;
 import org.opensim.view.motions.FileLoadMotionAction;
 import org.opensim.view.motions.MotionsDB;
@@ -78,7 +79,7 @@ public final class OpenSimPlotter {
             plotter.getPlotterModel().addSource(src);
             return src;
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
         }
         return null;
     }

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/ScriptsRunBrowseAction.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/ScriptsRunBrowseAction.java
@@ -26,25 +26,16 @@
  */
 package org.opensim.console;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileFilter;
-import java.io.FileReader;
 import java.io.IOException;
-import java.util.prefs.Preferences;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
 import org.openide.cookies.OpenCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
-import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
 import org.openide.util.actions.CallableSystemAction;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
-import org.opensim.utils.TheApp;
 
 public final class ScriptsRunBrowseAction extends CallableSystemAction {
 
@@ -131,7 +122,7 @@ public final class ScriptsRunBrowseAction extends CallableSystemAction {
             open.open();
             MRUScriptsOptions.getInstance().addFile(scriptFilename);
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
         }
         
     }

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/ScriptsSaveAction.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/ScriptsSaveAction.java
@@ -35,8 +35,8 @@ import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionRegistration;
 import org.openide.cookies.SaveCookie;
 import org.openide.loaders.DataObject;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle.Messages;
+import org.opensim.utils.ErrorDialog;
 
 
 
@@ -64,7 +64,7 @@ public final class ScriptsSaveAction implements ActionListener {
             try {
                 sc.save();
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
             }
         }
         

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/ToolsOpenScriptAction.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/ToolsOpenScriptAction.java
@@ -26,25 +26,16 @@
  */
 package org.opensim.console;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileFilter;
-import java.io.FileReader;
 import java.io.IOException;
-import java.util.prefs.Preferences;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
 import org.openide.cookies.OpenCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
 import org.openide.loaders.DataObject;
-import org.openide.util.Exceptions;
 import org.openide.util.HelpCtx;
 import org.openide.util.actions.CallableSystemAction;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
-import org.opensim.utils.TheApp;
 
 public final class ToolsOpenScriptAction extends CallableSystemAction {
 
@@ -85,7 +76,7 @@ public final class ToolsOpenScriptAction extends CallableSystemAction {
             open.open();
             MRUScriptsOptions.getInstance().addFile(scriptFilename);
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
         }
         
     }

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/ToolsRunCurrentScriptAction.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/ToolsRunCurrentScriptAction.java
@@ -37,8 +37,8 @@ import org.openide.awt.ActionReference;
 import org.openide.awt.ActionReferences;
 import org.openide.awt.ActionID;
 import org.openide.cookies.SaveCookie;
-import org.openide.util.Exceptions;
 import org.openide.util.NbBundle.Messages;
+import org.opensim.utils.ErrorDialog;
 
 
 @ActionID(category = "Edit",
@@ -76,7 +76,7 @@ public final class ToolsRunCurrentScriptAction implements ActionListener {
                     sc.save();
                 }
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
             }
         }
         ScriptingShellTopComponent.getDefault().getConsole().executeFile(path);

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/gui.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/gui.java
@@ -52,10 +52,9 @@ import org.opensim.modeling.Probe;
 import org.opensim.modeling.State;
 import org.opensim.modeling.Storage;
 import org.opensim.tracking.tools.ToolbarSimulationAction;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.TheApp;
-import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.motions.MotionsDB;
-import org.opensim.view.nodes.OneModelNode;
 import org.opensim.view.pub.OpenSimDB;
 import org.opensim.view.pub.ViewDB;
 
@@ -178,7 +177,7 @@ public final class gui {
             Model aModel = new Model(fileName);
             OpenSimDB.getInstance().addModel(aModel);
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
         }
     }
     /**
@@ -241,7 +240,7 @@ public final class gui {
     /**
      * findObject locates an Object in the model and returns a reference to it.
      * Beware, since this gives unguarded access to the objects in the model, changes made the object
-     * maynot propagate throughout the model and or application. USe at your own risk.
+     * may not propagate throughout the model and or application. USe at your own risk.
      * 
      * @param aModel
      * @param type : one of Body, Joint, Force (or any force producing object e.g. muscle), Controller

--- a/Gui/opensim/tracking/src/org/opensim/tools/serializers/ToolSerializer.java
+++ b/Gui/opensim/tracking/src/org/opensim/tools/serializers/ToolSerializer.java
@@ -43,6 +43,7 @@ import org.opensim.tracking.AnalyzeAndForwardToolPanel;
 import org.opensim.tracking.AnalyzeToolModel;
 import org.opensim.tracking.ForwardToolModel;
 import org.opensim.tracking.IKToolModel;
+import org.opensim.utils.ErrorDialog;
 
 /**
  *
@@ -92,7 +93,7 @@ public class ToolSerializer extends Observable implements Serializable{
                 toolModel.execute();                
             }
         } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
         }
     }
 

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.form
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.form
@@ -1427,7 +1427,7 @@
                           <EmptySpace min="-2" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" max="-2" attributes="0">
                               <Component id="statesRadioButton1" max="32767" attributes="1"/>
-                              <Component id="motionRadioButton1" alignment="0" pref="62" max="32767" attributes="1"/>
+                              <Component id="motionRadioButton1" alignment="0" pref="0" max="32767" attributes="1"/>
                           </Group>
                           <EmptySpace min="-2" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="1" attributes="0">
@@ -1651,7 +1651,7 @@
                       <Group type="102" alignment="0" attributes="0">
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="jPanel1" alignment="1" max="32767" attributes="2"/>
-                              <Component id="jPanel2" alignment="1" min="0" pref="92" max="32767" attributes="2"/>
+                              <Component id="jPanel2" alignment="1" min="0" pref="122" max="32767" attributes="2"/>
                           </Group>
                           <EmptySpace min="-2" max="-2" attributes="0"/>
                       </Group>

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
@@ -55,6 +55,7 @@ import org.opensim.modeling.Storage;
 import org.opensim.view.motions.MotionsDB;
 import org.opensim.swingui.FileTextFieldAndChooser;
 import org.opensim.utils.BrowserLauncher;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.utils.TheApp;
 import org.opensim.view.FileTextFieldAndChooserWithEdit;
@@ -2010,7 +2011,7 @@ public class AnalyzeAndForwardToolPanel extends BaseToolPanel implements Observe
                 try {
                     cs = new ControlSet(new Storage(controlsFile));
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    ErrorDialog.displayExceptionDialog(ex);
                 }
             }
             else {

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
@@ -41,6 +41,7 @@ import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.StaticOptimization;
 import org.opensim.swingui.SwingWorker;
 import org.opensim.tracking.tools.SimulationDB;
+import org.opensim.utils.DialogUtils;
 import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.MuscleColorByActivationStorage;
@@ -436,7 +437,7 @@ public class AnalyzeToolModel extends AbstractToolModelWithExternalLoads {
             Storage coords = new Storage(coordinatesFileName);
             updateToolTimeRange(coords);
          } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
       }
    }
    }

--- a/Gui/opensim/tracking/src/org/opensim/tracking/CMCToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/CMCToolModel.java
@@ -272,7 +272,7 @@ public class CMCToolModel extends TrackingToolModel {
             Storage coords = new Storage(fileName);
             updateToolTimeRange(coords);
          } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
       }
 
    }

--- a/Gui/opensim/tracking/src/org/opensim/tracking/EditExternalLoadsPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/EditExternalLoadsPanel.java
@@ -48,6 +48,7 @@ import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.ExternalForce;
 import org.opensim.modeling.Storage;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.utils.TheApp;
 
@@ -128,7 +129,7 @@ public class EditExternalLoadsPanel extends javax.swing.JPanel
             try {
                 externalLoadsStorage = new Storage(dataFileName, true);
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
             }
         }
         updateButtonAvailability();
@@ -584,7 +585,7 @@ public class EditExternalLoadsPanel extends javax.swing.JPanel
                      externalLoadsDataFileName.setFileName(newFilename);
                 }
              } catch (IOException ex) {
-                 ex.printStackTrace();
+                 ErrorDialog.displayExceptionDialog(ex);
              }
          }
          dLoads.setDataFileName(externalLoadsDataFileName.getFileName());

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
@@ -317,7 +317,7 @@ public class ForwardToolModel extends AbstractToolModelWithExternalLoads {
                 startTime = s.getFirstTime();
                 endTime = s.getLastTime();
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
             }
          }
          updateControlTimeRange(startTime, endTime);
@@ -337,7 +337,7 @@ public class ForwardToolModel extends AbstractToolModelWithExternalLoads {
             Storage s = new Storage(fileName);
             updateStatesTimeRange(s.getFirstTime(), s.getLastTime());
          } catch (IOException ex) {
-             ex.printStackTrace();
+             ErrorDialog.displayExceptionDialog(ex);
          }
       }
    }
@@ -379,6 +379,7 @@ public class ForwardToolModel extends AbstractToolModelWithExternalLoads {
             worker = new ForwardToolWorker();
             SimulationDB.getInstance().startSimulation(this);
          } catch (IOException ex) {
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(ex.getMessage()));
             setExecuting(false);
             return;
          }

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IKCommonModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IKCommonModel.java
@@ -32,6 +32,7 @@ import org.opensim.modeling.MarkerData;
 import org.opensim.modeling.MarkerPlacer;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.Storage;
+import org.opensim.utils.ErrorDialog;
 
 //===========================================================================
 // IKCommonModel
@@ -106,6 +107,7 @@ public class IKCommonModel extends Observable implements Observer {
          } catch (IOException ex) {
             markerData = null;
             success = false;
+            ErrorDialog.displayExceptionDialog(ex);
          }
       }
       ikMarkerTasksModel.markerDataChanged(markerData);
@@ -141,6 +143,7 @@ public class IKCommonModel extends Observable implements Observer {
          } catch (IOException ex) {
             coordinateData = null;
             success = false;
+            ErrorDialog.displayExceptionDialog(ex);
          }
       }
       ikCoordinateTasksModel.coordinateDataChanged(coordinateData);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
@@ -155,7 +155,7 @@ public class InverseDynamicsToolModel extends AbstractToolModelWithExternalLoads
             try {
                 motion = new Storage(InverseDynamicsTool().getCoordinatesFileName());
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
             }
          }
          if (motion!=null){

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
@@ -52,6 +52,7 @@ import org.opensim.view.motions.MotionsDB;
 import org.opensim.swingui.FileTextFieldAndChooser;
 import org.opensim.tracking.InverseDynamicsToolModel.InputSource;
 import org.opensim.utils.BrowserLauncher;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.TheApp;
 import org.opensim.view.ModelEvent;
 import org.opensim.view.excitationEditor.ExcitationEditorJFrame;
@@ -639,7 +640,7 @@ private void reuseSelectedQuantitiesCheckBoxActionPerformed(java.awt.event.Actio
                 try {
                     cs = new ControlSet(new Storage(controlsFile));
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    ErrorDialog.displayExceptionDialog(ex);
                 }
             }
             else {
@@ -702,7 +703,7 @@ private void reuseSelectedQuantitiesCheckBoxActionPerformed(java.awt.event.Actio
                     toolModel.setInitialTime(st.getFirstTime());
                     toolModel.setFinalTime(st.getLastTime());
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    ErrorDialog.displayExceptionDialog(ex);
                 }
              }
       }

--- a/Gui/opensim/tracking/src/org/opensim/tracking/RRAToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/RRAToolModel.java
@@ -179,6 +179,7 @@ public class RRAToolModel extends TrackingToolModel {
                   //newReducedResidualsModel.setup();
                } catch (IOException ex) {
                   newReducedResidualsModel = null;
+                  ErrorDialog.displayExceptionDialog(ex);
                }
                //OpenSim20 added argument
                OpenSimDB.getInstance().replaceModel(reducedResidualsModel, newReducedResidualsModel, null);
@@ -255,7 +256,7 @@ public class RRAToolModel extends TrackingToolModel {
             Storage coords = new Storage(fileName);
             updateToolTimeRange(coords);
          } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
       }
    }
    }

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
@@ -590,6 +590,7 @@ public class ScaleToolModel extends Observable implements Observer {
          } catch (IOException ex) {
             extraMarkerSet = null;
             success = false;
+            ErrorDialog.displayExceptionDialog(ex);
          }
       }
       
@@ -681,6 +682,7 @@ public class ScaleToolModel extends Observable implements Observer {
          } catch (IOException ex) {
             measurementTrial = null;
             success = false;
+            ErrorDialog.displayExceptionDialog(ex);
          }
       }
       if(resetTimeRange && measurementTrial!=null) setMeasurementTrialTimeRange(measurementTrial.getTimeRange());

--- a/Gui/opensim/tracking/src/org/opensim/tracking/tools/ToolbarRunForwardAction.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/tools/ToolbarRunForwardAction.java
@@ -34,6 +34,7 @@ import org.openide.util.actions.CallableSystemAction;
 import org.opensim.modeling.ForwardTool;
 import org.opensim.modeling.Model;
 import org.opensim.tracking.ForwardToolModel;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.experimentaldata.ModelForExperimentalData;
 import org.opensim.view.pub.OpenSimDB;
 
@@ -61,7 +62,7 @@ public final class ToolbarRunForwardAction extends CallableSystemAction implemen
                 
                 // Change 
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
             }   
    }
    

--- a/Gui/opensim/utils/src/org/opensim/utils/ErrorDialog.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/ErrorDialog.java
@@ -54,4 +54,12 @@ public class ErrorDialog {
         DialogDisplayer.getDefault().notify(
                 new NotifyDescriptor.Message(message));
     }
+    
+    /*
+    * Display Exceptionerror message ina friendly dialog
+    */
+    public static void displayExceptionDialog(IOException ex){
+        DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(ex.getMessage()));
+        ex.printStackTrace();
+    }
 }

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -519,7 +519,7 @@ public final class FileUtils {
                     try {
                         badFiles += outFiles[i].getCanonicalFile().getName()+" ";
                     } catch (IOException ex) {
-                        ex.printStackTrace();
+                        ErrorDialog.displayExceptionDialog(ex);
                     }
                    allExist = false;
                }

--- a/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
@@ -250,7 +250,7 @@ public final class TheApp {
                     try {
                         FileUtils.copyFiles(srcPath, destPath);
                     } catch (IOException ex) {
-                        Exceptions.printStackTrace(ex);
+                        ErrorDialog.displayExceptionDialog(ex);
                         System.out.println("Folder "+srcPath.toAbsolutePath()+" couldn't be copied..Skipping");
                     }
                 }

--- a/Gui/opensim/view/src/org/opensim/threejs/ExportSceneToThreeJsAction.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ExportSceneToThreeJsAction.java
@@ -40,6 +40,7 @@ import org.openide.awt.ActionRegistration;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle.Messages;
 import org.opensim.modeling.Model;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.pub.OpenSimDB;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.pub.ViewDB;
@@ -80,7 +81,7 @@ public final class ExportSceneToThreeJsAction implements ActionListener {
             }
             JSONUtilities.writeJsonFile(jsonTop, fileName);
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
         } finally {
         }
         return vizJson;

--- a/Gui/opensim/view/src/org/opensim/view/ExplorerTopComponent.java
+++ b/Gui/opensim/view/src/org/opensim/view/ExplorerTopComponent.java
@@ -58,6 +58,7 @@ import org.opensim.modeling.Muscle;
 import org.opensim.view.experimentaldata.ModelForExperimentalData;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PathPoint;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.nodes.OneModelNode;
 import org.opensim.view.experimentaldata.ExperimentalDataTopNode;
 import org.opensim.view.nodes.MarkersNode;
@@ -264,7 +265,7 @@ final public class ExplorerTopComponent extends TopComponent
                                       if (nodes[k] != null)
                                          nodes[k].destroy();
                                    } catch (IOException ex) {
-                                      ex.printStackTrace();
+                                      ErrorDialog.displayExceptionDialog(ex);
                                    }
                                 }
                              }
@@ -317,7 +318,7 @@ final public class ExplorerTopComponent extends TopComponent
                              if(modelNode != null) modelNode.destroy();
                              updateCurrentModelNode(null);
                           } catch (IOException ex) {
-                             ex.printStackTrace();
+                             ErrorDialog.displayExceptionDialog(ex);
                           }
                           break;
                        }

--- a/Gui/opensim/view/src/org/opensim/view/FileOpenOsimModelAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FileOpenOsimModelAction.java
@@ -97,7 +97,7 @@ public class FileOpenOsimModelAction extends CallableSystemAction {
                     try {
                         OpenSimDB.getInstance().addModel(aModel);
                     } catch (IOException ex) {
-                        DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message(ex.getMessage()));
+                        ErrorDialog.displayExceptionDialog(ex);
                     }
             }});
         retValue = true;

--- a/Gui/opensim/view/src/org/opensim/view/Installer.java
+++ b/Gui/opensim/view/src/org/opensim/view/Installer.java
@@ -40,6 +40,7 @@ import org.openide.util.NbBundle;
 import org.openide.windows.WindowManager;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.utils.ApplicationState;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.TheApp;
 import org.opensim.view.actions.ApplicationExit;
 import org.opensim.view.base.OpenSimBaseCanvas;
@@ -121,7 +122,7 @@ public class Installer extends ModuleInstall {
                 as.addObject("PluginsDB", PluginsDB.getInstance());
                 as.addObject("MotionsDB", new MotionsDBDescriptor(MotionsDB.getInstance()));
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
             }
         }
         

--- a/Gui/opensim/view/src/org/opensim/view/OpenModelFileAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/OpenModelFileAction.java
@@ -27,6 +27,7 @@ import java.awt.event.ActionEvent;
 import java.io.File;
 import java.io.IOException;
 import javax.swing.AbstractAction;
+import org.opensim.utils.ErrorDialog;
 
 /**
  * A Class that displays a passed in url
@@ -47,7 +48,7 @@ class OpenModelFileAction extends AbstractAction
         } catch (ClassNotFoundException ex) {
             ex.printStackTrace();
         } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
         }
             
     }

--- a/Gui/opensim/view/src/org/opensim/view/actions/ApplicationExit.java
+++ b/Gui/opensim/view/src/org/opensim/view/actions/ApplicationExit.java
@@ -47,6 +47,7 @@ import org.opensim.view.motions.MotionsDB;
 import org.opensim.view.motions.MotionsDBDescriptor;
 import org.opensim.view.pub.OpenSimDB;
 import org.opensim.modeling.Model;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.TheApp;
 import org.opensim.view.pub.OpenSimDBDescriptor;
 import org.opensim.view.pub.PluginsDB;
@@ -102,7 +103,7 @@ public class ApplicationExit extends WindowAdapter
       } catch (FileNotFoundException ex) {
           ex.printStackTrace();
       } catch (IOException ex) {
-          ex.printStackTrace();
+          ErrorDialog.displayExceptionDialog(ex);
       }
       //System.out.println("Finish saving application state.");
 

--- a/Gui/opensim/view/src/org/opensim/view/dataObjects/OsimOpenSupport.java
+++ b/Gui/opensim/view/src/org/opensim/view/dataObjects/OsimOpenSupport.java
@@ -33,6 +33,7 @@ import org.openide.filesystems.FileObject;
 import org.openide.loaders.OpenSupport;
 import org.openide.util.Exceptions;
 import org.openide.windows.CloneableTopComponent;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.FileOpenOsimModelAction;
 
@@ -60,7 +61,7 @@ class OsimOpenSupport extends OpenSupport implements OpenCookie, CloseCookie {
         } catch (ClassNotFoundException ex) {
             Exceptions.printStackTrace(ex);
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+           ErrorDialog.displayExceptionDialog(ex);
         }
     }
 

--- a/Gui/opensim/view/src/org/opensim/view/excitationEditor/ExcitationEditorJFrame.java
+++ b/Gui/opensim/view/src/org/opensim/view/excitationEditor/ExcitationEditorJFrame.java
@@ -46,6 +46,7 @@ import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.SetActuators;
 import org.opensim.utils.BrowserLauncher;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.utils.TheApp;
 import org.opensim.view.pub.OpenSimDB;
@@ -325,7 +326,7 @@ public class ExcitationEditorJFrame extends javax.swing.JFrame {
                 writer.flush();
                 writer.close();
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
             }
         }
 

--- a/Gui/opensim/view/src/org/opensim/view/excitationEditor/ExcitationEditorJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/excitationEditor/ExcitationEditorJPanel.java
@@ -76,6 +76,7 @@ import org.opensim.modeling.SetControlNodes;
 import org.opensim.modeling.PiecewiseConstantFunction;
 import org.opensim.modeling.XYFunctionInterface;
 import org.opensim.utils.DialogUtils;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.utils.OpenSimDialog;
 import org.opensim.view.excitationEditor.ExcitationRenderer.ExcitationFillMode;
@@ -1383,7 +1384,7 @@ public class ExcitationEditorJPanel extends javax.swing.JPanel implements TreeSe
              getExcitationGridPanel().getColumn(i).setColumnNameLabelText(columnName);
          }
       } catch (IOException ex) {
-          ex.printStackTrace();
+          ErrorDialog.displayExceptionDialog(ex);
       }
     }
 

--- a/Gui/opensim/view/src/org/opensim/view/excitationEditor/ExcitationPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/excitationEditor/ExcitationPanel.java
@@ -56,6 +56,7 @@ import org.opensim.modeling.SetControlNodes;
 import org.opensim.modeling.Storage;
 import org.opensim.modeling.XYFunctionInterface;
 import org.opensim.utils.DialogUtils;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.utils.OpenSimDialog;
 import org.opensim.view.functionEditor.FunctionPanel;
@@ -305,7 +306,7 @@ public class ExcitationPanel extends FunctionPanel{
                 try {
                     s = new Storage(fileName);
                 } catch (IOException ex) {
-                    ex.printStackTrace();
+                    ErrorDialog.displayExceptionDialog(ex);
                 }
                 if (s == null) return;  // Bad file
                 // Open file and show filter to select columns. Return names

--- a/Gui/opensim/view/src/org/opensim/view/excitationEditor/MoveExcitationHandler.java
+++ b/Gui/opensim/view/src/org/opensim/view/excitationEditor/MoveExcitationHandler.java
@@ -40,6 +40,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 import javax.swing.tree.MutableTreeNode;
 import javax.swing.tree.TreePath;
+import org.opensim.utils.ErrorDialog;
 
 /**
  *
@@ -142,7 +143,7 @@ public class MoveExcitationHandler extends NodeMoveTransferHandler{
             }
             topPanel.validate();
        } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
         } catch (UnsupportedFlavorException ex) {
             ex.printStackTrace();
         }
@@ -172,7 +173,7 @@ public class MoveExcitationHandler extends NodeMoveTransferHandler{
             }
             topPanel.validate();
        } catch (IOException ex) {
-            ex.printStackTrace();
+            ErrorDialog.displayExceptionDialog(ex);
         } catch (UnsupportedFlavorException ex) {
             ex.printStackTrace();
         }

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
@@ -35,6 +35,7 @@ import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.tree.DefaultMutableTreeNode;
 import org.opensim.modeling.ArrayStr;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.motions.MotionControlJPanel;
 import org.opensim.view.motions.MotionDisplayer;
@@ -273,7 +274,7 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
             } catch (FileNotFoundException ex) {
                 ex.printStackTrace();
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
             }
       }  
       return success;

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/EditMotionObjectsPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/EditMotionObjectsPanel.java
@@ -40,6 +40,7 @@ import org.opensim.modeling.ArrayInt;
 import org.opensim.modeling.ExternalForce;
 import org.opensim.modeling.ExternalLoads;
 import org.opensim.modeling.Model;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.motions.MotionsDB;
 
@@ -456,7 +457,7 @@ private void jButtonLoadActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
                     aMotion.getClassified().add(motionForce);
                }
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
             }
     }
 

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ModelForExperimentalData.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ModelForExperimentalData.java
@@ -56,7 +56,7 @@ public class ModelForExperimentalData extends Model{
     /**
      * Creates a new instance of ModelForExperimentalData
      */
-    public ModelForExperimentalData(int i, AnnotatedMotion motionData) throws IOException {
+    public ModelForExperimentalData(int i, AnnotatedMotion motionData) {
         super();
         setName("ExperimentalData_"+i);
         this.motionData=motionData;

--- a/Gui/opensim/view/src/org/opensim/view/markerEditor/MarkersLoadFromFileAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/markerEditor/MarkersLoadFromFileAction.java
@@ -45,6 +45,7 @@ import org.opensim.modeling.MarkerSet;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.OpenSimObject;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.nodes.MarkersNode;
@@ -79,7 +80,7 @@ public class MarkersLoadFromFileAction extends AbstractAction {
         try {
             newMarkerSet = new MarkerSet(model, fileName);
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
             return;
         }
         MarkerSet modelMarkerSet = model.getMarkerSet();
@@ -108,7 +109,7 @@ public class MarkersLoadFromFileAction extends AbstractAction {
         try {
            context.restoreStateFromCachedModel();
         } catch (IOException ex) {
-           Exceptions.printStackTrace(ex);
+           ErrorDialog.displayExceptionDialog(ex);
         }       
         // This hack is so that the adopted Marker isn't gc'ed
          newMarkerSet.setMemoryOwner(false);

--- a/Gui/opensim/view/src/org/opensim/view/markerEditor/NewMarkerAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/markerEditor/NewMarkerAction.java
@@ -49,6 +49,7 @@ import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PhysicalFrame;
 import org.opensim.modeling.Vec3;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.ObjectsAddedEvent;
 import org.opensim.view.nodes.MarkersNode;
@@ -91,7 +92,7 @@ public class NewMarkerAction extends AbstractAction {
         try {
            context.restoreStateFromCachedModel();
        } catch (IOException ex) {
-           Exceptions.printStackTrace(ex);
+           ErrorDialog.displayExceptionDialog(ex);
        }
         Vector<OpenSimObject> markers = new  Vector<OpenSimObject>();
         markers.add(newMarker);

--- a/Gui/opensim/view/src/org/opensim/view/markerEditor/OneMarkerDeleteAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/markerEditor/OneMarkerDeleteAction.java
@@ -41,6 +41,7 @@ import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PhysicalFrame;
 import org.opensim.modeling.Vec3;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.ObjectsDeletedEvent;
 import org.opensim.view.nodes.OneMarkerNode;
@@ -113,7 +114,7 @@ public final class OneMarkerDeleteAction extends CallableSystemAction {
                     try {
                         context.restoreStateFromCachedModel();
                     } catch (IOException ex) {
-                        Exceptions.printStackTrace(ex);
+                        ErrorDialog.displayExceptionDialog(ex);
                     }
                     Vector<OpenSimObject> markers = new  Vector<OpenSimObject>();
                     markers.add(newMarker);
@@ -139,7 +140,7 @@ public final class OneMarkerDeleteAction extends CallableSystemAction {
         try {
             context.restoreStateFromCachedModel();
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
         }
         // Update the marker name list in the ViewDB.
         OpenSimDB.getInstance().getModelGuiElements(model).updateMarkerNames();

--- a/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
@@ -37,6 +37,7 @@ import org.opensim.modeling.MarkerData;
 import org.opensim.view.experimentaldata.ModelForExperimentalData;
 import org.opensim.modeling.Storage;
 import org.opensim.modeling.Units;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.experimentaldata.AnnotatedMotion;
 import org.opensim.view.pub.OpenSimDB;
@@ -90,8 +91,7 @@ public final class FileLoadDataAction extends CallableSystemAction {
                         modelForDataImport = new ModelForExperimentalData(nextNumber++, amot);
                         OpenSimDB.getInstance().addModel(modelForDataImport);
                     } catch (IOException ex) {
-                        ex.printStackTrace();
-                        System.out.println("Missing resource file Models/Internal/_openSimlab.osim. Previewing is aborted.");
+                        ErrorDialog.displayExceptionDialog(ex);
                         return;
                     }
                     MotionsDB.getInstance().addMotion(modelForDataImport, amot, null);

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionsDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionsDB.java
@@ -48,6 +48,7 @@ import org.opensim.modeling.CoordinateSet;
 import org.opensim.view.experimentaldata.ModelForExperimentalData;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.Storage;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.ModelEvent;
@@ -410,7 +411,7 @@ public class MotionsDB extends Observable // Observed by other entities in motio
                         if(parentOrTopMotionsNode!=null && parentOrTopMotionsNode.getChildren().getNodesCount()==0 && parentOrTopMotionsNode.getName().equals("Motions"))
                            parentOrTopMotionsNode.destroy();
                      } catch (IOException ex) {
-                        ex.printStackTrace();
+                        ErrorDialog.displayExceptionDialog(ex);
                      }
                      break;
                   }

--- a/Gui/opensim/view/src/org/opensim/view/nodes/ConnectionEditor.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/ConnectionEditor.java
@@ -30,6 +30,7 @@ import javax.swing.undo.CannotRedoException;
 import javax.swing.undo.CannotUndoException;
 import org.openide.util.Exceptions;
 import org.opensim.modeling.*;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.SingleModelGuiElements;
 import org.opensim.view.pub.OpenSimDB;
@@ -110,7 +111,7 @@ public class ConnectionEditor {
                 connector.setConnecteeName(oldValue);
                 context.restoreStateFromCachedModel();  
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
         }
         }
         handleConnectionChangeCommon();

--- a/Gui/opensim/view/src/org/opensim/view/nodes/PropertyEditorAdaptor.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/PropertyEditorAdaptor.java
@@ -25,12 +25,14 @@ package org.opensim.view.nodes;
 
 import java.awt.Color;
 import java.io.IOException;
+import java.text.ParseException;
 import javax.swing.JOptionPane;
 import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.CannotRedoException;
 import javax.swing.undo.CannotUndoException;
 import org.openide.util.Exceptions;
 import org.opensim.modeling.*;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.SingleModelGuiElements;
 import org.opensim.view.pub.OpenSimDB;
@@ -200,6 +202,7 @@ public class PropertyEditorAdaptor {
         if (d.getSize() == 3) {
             setValueVec3(new Vec3(d.getitem(0), d.getitem(1), d.getitem(2)));
         }
+            
     }
 
     public void setValueVec3(Vec3 v) {
@@ -316,7 +319,7 @@ public class PropertyEditorAdaptor {
             workString = workString.substring(liveStart+1, liveEnd);
         }
         else if (liveStart!=liveEnd){
-          //throw new ParseException("Illegal format: Expect space separated values, optionally between matched parentheses", liveEnd);
+          ErrorDialog.showMessageDialog(aString);
           return;
         }
         String[] splits = workString.split(" ");
@@ -388,7 +391,7 @@ public class PropertyEditorAdaptor {
             PropertyHelper.setValueDouble(oldValue, prop);
                 context.restoreStateFromCachedModel();  
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
         }
         }
         handlePropertyChangeCommon();
@@ -434,7 +437,7 @@ public class PropertyEditorAdaptor {
             PropertyHelper.setValueString(oldValue, prop);
                 context.restoreStateFromCachedModel();  
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
         }
         }
         handlePropertyChangeCommon();
@@ -482,7 +485,7 @@ public class PropertyEditorAdaptor {
                     PropertyHelper.setValueBool(oldValue, prop);
                     context.restoreStateFromCachedModel();
                 } catch (IOException ex) {
-                    Exceptions.printStackTrace(ex);
+                    ErrorDialog.displayExceptionDialog(ex);
                 }
             }
         }
@@ -529,7 +532,7 @@ public class PropertyEditorAdaptor {
             PropertyHelper.setValueInt(oldValue, prop);
                 context.restoreStateFromCachedModel();  
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
         }
         }
         handlePropertyChangeCommon();
@@ -580,7 +583,7 @@ public class PropertyEditorAdaptor {
             }
                 context.restoreStateFromCachedModel();
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
         }
         }
         handlePropertyChangeCommon();
@@ -631,7 +634,7 @@ public class PropertyEditorAdaptor {
             }
                 if (supportUndo) context.restoreStateFromCachedModel();
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
         }
         }
         
@@ -685,7 +688,7 @@ public class PropertyEditorAdaptor {
             }
                 if (supportUndo) context.restoreStateFromCachedModel();
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
         }
         }
         
@@ -741,7 +744,7 @@ public class PropertyEditorAdaptor {
             }
                 context.restoreStateFromCachedModel();
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
             }
         }
         handlePropertyChangeCommon();
@@ -788,7 +791,7 @@ public class PropertyEditorAdaptor {
                  prop.setValueAsObject(oldObject);
                 context.restoreStateFromCachedModel();  
             } catch (IOException ex) {
-                Exceptions.printStackTrace(ex);
+                ErrorDialog.displayExceptionDialog(ex);
             }
         }
         handlePropertyChangeCommon();
@@ -900,7 +903,7 @@ public class PropertyEditorAdaptor {
             ViewDB.getInstance().updateModelDisplay(model);
             ViewDB.renderAll();
         } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
+            ErrorDialog.displayExceptionDialog(ex);
     }
     }
             

--- a/Gui/opensim/view/src/org/opensim/view/pub/OpenSimDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/OpenSimDB.java
@@ -55,6 +55,7 @@ import org.opensim.modeling.Force;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.OpenSimObject;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.TheApp;
 import org.opensim.view.*;
 import vtk.vtkMatrix4x4;
@@ -222,7 +223,7 @@ public class OpenSimDB extends Observable implements Externalizable{
             try {
                 addModel(newModel, newContext);
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
             }
          //mapModelsToContexts.put(newModel, newContext);
          /*
@@ -418,7 +419,7 @@ public class OpenSimDB extends Observable implements Externalizable{
             try {
                 newContext = new OpenSimContext(aModel.initSystem(), aModel);
             } catch (IOException ex) {
-                ex.printStackTrace();
+                ErrorDialog.displayExceptionDialog(ex);
                 return null;
             }
          mapModelsToContexts.put(aModel, newContext);

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -69,6 +69,7 @@ import org.opensim.threejs.JSONMessageHandler;
 import org.opensim.threejs.JSONUtilities;
 import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.threejs.VisualizerWindowAction;
+import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.Prefs;
 import org.opensim.utils.TheApp;
 import org.opensim.view.*;
@@ -478,7 +479,7 @@ public final class ViewDB extends Observable implements Observer, LookupListener
                        if (modelVisToJsonFilesMap.get(dJson)!=null)
                             Files.deleteIfExists(modelVisToJsonFilesMap.get(dJson));
                     } catch (IOException ex) {
-                       Exceptions.printStackTrace(ex);
+                       ErrorDialog.displayExceptionDialog(ex);
                     }
                     modelVisToJsonFilesMap.remove(dJson);
                     if (currentJson == dJson) // Cleanup stale Json, will be set fresh by next current model
@@ -527,7 +528,7 @@ public final class ViewDB extends Observable implements Observer, LookupListener
            JSONUtilities.writeJsonFile(vizJson, fileName);
            modelVisToJsonFilesMap.put(vizJson, Paths.get(fileName));
        } catch (IOException ex) {
-           Exceptions.printStackTrace(ex);
+           ErrorDialog.displayExceptionDialog(ex);
        }
         // send message to visualizer to load model from file
         websocketdb.broadcastMessageJson(vizJson.createOpenModelJson(), socket);
@@ -1092,8 +1093,8 @@ public final class ViewDB extends Observable implements Observer, LookupListener
    }
 
    public void setSelectedObject(OpenSimObject obj) {
-      //FIX40 if (findObjectInSelectedList(obj)!=-1)
-      //    return;
+      if (findObjectInSelectedList(obj)!=-1)
+          return;
       //clearSelectedObjects();
 
       if (obj != null) {


### PR DESCRIPTION
While most of these exceptions are never invoked in normal operation this's a more conservative approach to communicate errors reported by API or filesystem to users. Also addresses issue #553