### PR TITLE
Last frame was missing from tools because step() is not called

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
@@ -347,6 +347,7 @@ public class JavaMotionDisplayerCallback extends AnalysisWrapperWithTimer {
     }
    @Override
     public int end(State s) {
+        processStep(s, storage.getSize());
         return  super.end(s);
     }
 }

--- a/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
@@ -347,7 +347,10 @@ public class JavaMotionDisplayerCallback extends AnalysisWrapperWithTimer {
     }
    @Override
     public int end(State s) {
-        processStep(s, storage.getSize());
+        if (kinReporter != null)
+            kinReporter.end(s);
+        if (statesReporter!=null)
+            statesReporter.end(s);
         return  super.end(s);
     }
 }


### PR DESCRIPTION
Change in core caused Step not to be called on last frame, instead end is called. Update the animation (analysis) on GUI side to follow this convention.