### PR TITLE
Undo partial fix that was inadvertently pushed along with PR 568 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -1093,8 +1093,8 @@ public final class ViewDB extends Observable implements Observer, LookupListener
    }
 
    public void setSelectedObject(OpenSimObject obj) {
-      if (findObjectInSelectedList(obj)!=-1)
-          return;
+      //FIX40 if (findObjectInSelectedList(obj)!=-1)
+      //    return;
       //clearSelectedObjects();
 
       if (obj != null) {


### PR DESCRIPTION
Back fix to selection notification handling as it doesn't belong to error handling PR