### PR TITLE
GUI used to rename the temporary copy used to run FD for debugging 

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
@@ -101,7 +101,7 @@ public class ForwardToolModel extends AbstractToolModelWithExternalLoads {
                                  }
                               });
          //getOriginalModel().setName("Originial");
-         model.setName("daCopy");
+         //model.setName("daCopy");
          // Animation callback will update the display *of the original model* during forward
          animationCallback = new JavaMotionDisplayerCallback(model, getOriginalModel(), null, progressHandle, false);
          getModel().addAnalysis(animationCallback);


### PR DESCRIPTION
Undo the rename to avoid confusing users