### PR TITLE
Expose Frame offsets for editing of Joints and Geometry

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/Installer.java
+++ b/Gui/opensim/view/src/org/opensim/view/Installer.java
@@ -139,6 +139,7 @@ public class Installer extends ModuleInstall {
         //PropertyEditorManager.registerEditor(OpenSimObject.class, OpenSimObjectEditor.class);
         EditorRegistry.addEditor("Body", new BodyNameEditor());
         EditorRegistry.addEditor("PhysicalFrame", new FrameNameEditor());
+        EditorRegistry.addEditor("Frame", new FrameNameEditor());
     }
     /**
      * restorePrefs is primarily used for the first time around where there are no pref values

--- a/Gui/opensim/view/src/org/opensim/view/nodes/ConnectionEditor.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/ConnectionEditor.java
@@ -73,7 +73,8 @@ public class ConnectionEditor {
     public void handleConnectionChangeCommon() {
         if (Component.safeDownCast(obj)!= null){
             Component mc = Component.safeDownCast(obj);
-            Boolean isFrame = connector.getConnecteeTypeName().equalsIgnoreCase("PhysicalFrame");
+            Boolean isFrame = connector.getConnecteeTypeName().equalsIgnoreCase("PhysicalFrame")||
+                    connector.getConnecteeTypeName().equalsIgnoreCase("Frame");
             ViewDB.getInstance().updateComponentVisuals(model, mc, isFrame);  
             ViewDB.repaintAll();
         }

--- a/Gui/opensim/view/src/org/opensim/view/nodes/GroundNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/GroundNode.java
@@ -58,7 +58,7 @@ public class GroundNode extends OneFrameNode{
          children.add(arrNodes);
          
       }
-
+      createFrameNodes(children);
       if(children.getNodesCount()==0) setChildren(Children.LEAF);      
       addDisplayOption(displayOption.Colorable);
       addDisplayOption(displayOption.Isolatable);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneBodyNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneBodyNode.java
@@ -59,7 +59,7 @@ public class OneBodyNode extends OneFrameNode{
          children.add(arrNodes);
          
       }
-
+      createFrameNodes(children);
       if(children.getNodesCount()==0) setChildren(Children.LEAF);      
       addDisplayOption(displayOption.Colorable);
       addDisplayOption(displayOption.Isolatable);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneComponentWithGeometryNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneComponentWithGeometryNode.java
@@ -76,7 +76,7 @@ public abstract class OneComponentWithGeometryNode extends OneComponentNode impl
     protected void addAppearanceProperties(Sheet sheet) {
         try {
             sheet.get(Sheet.PROPERTIES).remove("Appearance");
-            Sheet.Set appearanceSheet = createExpertSet();
+            Sheet.Set appearanceSheet = new Sheet.Set();
             appearanceSheet.setDisplayName("Appearance");
             sheet.put(appearanceSheet);
             // Visible boolean property

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -29,6 +29,8 @@
 package org.opensim.view.nodes;
 
 import java.awt.Image;
+import java.beans.PropertyEditorSupport;
+import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -36,6 +38,9 @@ import javax.swing.ImageIcon;
 import javax.swing.Action;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
+import org.openide.nodes.PropertySupport;
+import org.openide.nodes.Sheet;
+import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.opensim.modeling.Component;
 import org.opensim.modeling.ComponentIterator;
@@ -43,36 +48,47 @@ import org.opensim.modeling.ComponentsList;
 import org.opensim.modeling.Frame;
 import org.opensim.modeling.FrameGeometry;
 import org.opensim.modeling.Geometry;
+import org.opensim.modeling.Model;
+import org.opensim.modeling.OpenSimContext;
+import org.opensim.modeling.PhysicalOffsetFrame;
+import org.opensim.modeling.State;
+import org.opensim.modeling.Transform;
 import org.opensim.view.FrameToggleVisibilityAction;
+import org.opensim.view.pub.OpenSimDB;
+import org.opensim.view.pub.ViewDB;
 
 /**
  *
  * @author Ayman
  */
 public class OneFrameNode extends OneModelComponentNode {
-   private static ResourceBundle bundle = NbBundle.getBundle(OneFrameNode.class);
-   Frame frame;
+    private static ResourceBundle bundle = NbBundle.getBundle(OneFrameNode.class);
+    Frame frame;
+    State state;
+    OpenSimContext context;
+    
     public OneFrameNode(Frame comp) {
         super(comp);
         frame = comp;
         setShortDescription(bundle.getString("HINT_FrameNode"));
-        createGeometryNodes();
+        createGeometryNodes();        
+        
     }
    
     protected final void createGeometryNodes() {
         // attached_geometry doesn't reach geometry mounted on 
-		// offset frames, use iterator instead
-		// Caveat if nested bodies or components have geometry 
-		// it may appear multiple times
+        // offset frames, use iterator instead
+        // Caveat if nested bodies or components have geometry 
+        // it may appear multiple times
         ComponentsList compList = frame.getComponentsList();
         ComponentIterator compIter = compList.begin();
         Children children = getChildren();
         while (!compIter.equals(compList.end())) {
             Component comp = compIter.__deref__();
             Geometry oneG = Geometry.safeDownCast(comp);
-            if (oneG!=null && FrameGeometry.safeDownCast(oneG)==null){
-                Frame base = oneG.getFrame().findBaseFrame();
-                if (base.getAbsolutePathString().equals(frame.getAbsolutePathString())){
+            if (oneG != null && FrameGeometry.safeDownCast(oneG) == null) {
+                Frame gFrame = oneG.getFrame();
+                if (gFrame.equals(frame)){
                     OneGeometryNode node = new OneGeometryNode(oneG);
                     Node[] arrNodes = new Node[1];
                     arrNodes[0] = node;
@@ -81,17 +97,6 @@ public class OneFrameNode extends OneModelComponentNode {
             }
             compIter.next();
         }
-        /*
-        int geomSize = frame.getPropertyByName("attached_geometry").size();
-        // Create node for geometry
-        Children children = getChildren();
-        for (int g = 0; g < geomSize; g++) {
-            Geometry oneG = frame.get_attached_geometry(g);
-            OneGeometryNode node = new OneGeometryNode(oneG);
-            Node[] arrNodes = new Node[1];
-            arrNodes[0] = node;
-            children.add(arrNodes);
-        }*/
     }
     
    @Override
@@ -132,5 +137,112 @@ public class OneFrameNode extends OneModelComponentNode {
             ex.printStackTrace();
         }
         return retActions;
-    }  
+    }
+    /* Utility function to create child nodes for descendent frames
+    */
+    protected void createFrameNodes(Children children) {
+        // Find Frames and make nodes for them (PhysicalOffsetFrames)
+        ComponentsList descendents = comp.getComponentsList();
+        ComponentIterator compIter = descendents.begin();
+        while (!compIter.equals(descendents.end())) {
+            Frame frame = Frame.safeDownCast(compIter.__deref__());
+            if (frame != null) {
+                OneFrameNode node = new OneFrameNode(frame);
+                Node[] arrNodes = new Node[1];
+                arrNodes[0] = node;
+                children.add(arrNodes);
+            }
+            compIter.next();
+        }
+    }
+    public String getTranslationString() {
+        Frame frame = Frame.safeDownCast(comp);
+        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);
+        Transform transform = offsetFrame.getOffsetTransform();
+        String translationVec3AsString = transform.p().toString();
+        return translationVec3AsString.substring(2, translationVec3AsString.length()-1).replace(',', ' ');
+    }
+    public void setTranslationString(String string) {
+        Frame frame = Frame.safeDownCast(comp);
+        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);
+        String vals[] = string.split(" ");
+        context = OpenSimDB.getInstance().getContext(getModelForNode());
+        context.cacheModelAndState();
+        //offsetFrame.upd_orientation(0);
+        for (int i=0; i<3; i++)
+            offsetFrame.upd_translation().set(i, Double.valueOf(vals[i]));
+        refreshDisplay();
+        return;
+    }
+    
+    public String getRotationString() {
+        Frame frame = Frame.safeDownCast(comp);
+        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);
+        Transform transform = offsetFrame.getOffsetTransform();
+        String rotationVec3AsString = transform.R().convertRotationToBodyFixedXYZ().toString();
+        return rotationVec3AsString.substring(2, rotationVec3AsString.length()-1).replace(',', ' ');
+    }
+    public void setRotationString(String string) {
+        Frame frame = Frame.safeDownCast(comp);
+        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);
+        String vals[] = string.split(" ");
+        context = OpenSimDB.getInstance().getContext(getModelForNode());
+        context.cacheModelAndState();
+        //offsetFrame.upd_orientation(0);
+        for (int i=0; i<3; i++)
+            offsetFrame.upd_orientation().set(i, Double.valueOf(vals[i]));
+        refreshDisplay();
+        return;
+    }
+
+    private void refreshDisplay() {
+        try {
+            context.restoreStateFromCachedModel();
+        } catch (IOException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        Model model = getModelForNode();
+        Frame frame = Frame.safeDownCast(comp);
+        ViewDB.getInstance().updateDecorations(model, frame);
+        //ViewDB.getInstance().updateModelDisplay(model);
+        ViewDB.repaintAll();
+    }
+    
+   @Override
+    public Sheet createSheet() {
+        Sheet sheet;
+        sheet = super.createSheet();
+        addFrameProperties(sheet);
+        return sheet;
+    }
+    /*
+     Custom handlers of Edits to translation and orientation to force updates to scenegraph
+    */
+    private void addFrameProperties(Sheet sheet) {
+        Frame frame = Frame.safeDownCast(comp);
+        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);
+        Sheet.Set sheetSet = sheet.get(Sheet.PROPERTIES);
+        if (offsetFrame!=null){ 
+            sheetSet.remove("translation");
+            sheetSet.remove("orientation");
+            try {
+                // Expose traslations and rotatiosn
+                PropertySupport.Reflection translationProp = new PropertySupport.Reflection(this,
+                        String.class, "getTranslationString", "setTranslationString");
+                translationProp.setValue("canEditAsText", Boolean.TRUE);
+                translationProp.setDisplayName("Translation");
+                translationProp.setValue("suppressCustomEditor", Boolean.TRUE);
+                sheetSet.put(translationProp);
+               
+                PropertySupport.Reflection rotationProp = new PropertySupport.Reflection(this,
+                        String.class, "getRotationString", "setRotationString");
+                rotationProp.setValue("canEditAsText", Boolean.TRUE);
+                rotationProp.setDisplayName("Rotation");
+                rotationProp.setValue("suppressCustomEditor", Boolean.TRUE);
+                sheetSet.put(rotationProp);
+            } catch (NoSuchMethodException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+        }
+    }
 }

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -71,10 +71,13 @@ public class OneFrameNode extends OneModelComponentNode {
             Component comp = compIter.__deref__();
             Geometry oneG = Geometry.safeDownCast(comp);
             if (oneG!=null && FrameGeometry.safeDownCast(oneG)==null){
-                OneGeometryNode node = new OneGeometryNode(oneG);
-                Node[] arrNodes = new Node[1];
-                arrNodes[0] = node;
-                children.add(arrNodes);
+                Frame base = oneG.getFrame().findBaseFrame();
+                if (base.getAbsolutePathString().equals(frame.getAbsolutePathString())){
+                    OneGeometryNode node = new OneGeometryNode(oneG);
+                    Node[] arrNodes = new Node[1];
+                    arrNodes[0] = node;
+                    children.add(arrNodes);
+                }
             }
             compIter.next();
         }

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -42,6 +42,7 @@ import org.openide.nodes.PropertySupport;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
+import org.opensim.modeling.Body;
 import org.opensim.modeling.Component;
 import org.opensim.modeling.ComponentIterator;
 import org.opensim.modeling.ComponentsList;
@@ -142,11 +143,13 @@ public class OneFrameNode extends OneModelComponentNode {
     */
     protected void createFrameNodes(Children children) {
         // Find Frames and make nodes for them (PhysicalOffsetFrames)
-        ComponentsList descendents = comp.getComponentsList();
+        ComponentsList descendents = frame.getModel().getComponentsList();
         ComponentIterator compIter = descendents.begin();
         while (!compIter.equals(descendents.end())) {
             Frame frame = Frame.safeDownCast(compIter.__deref__());
-            if (frame != null) {
+            if (Body.safeDownCast(frame)==null &&
+                    frame != null && !frame.equals(comp)
+                    && frame.findBaseFrame().equals(comp)) {
                 OneFrameNode node = new OneFrameNode(frame);
                 Node[] arrNodes = new Node[1];
                 arrNodes[0] = node;
@@ -204,7 +207,7 @@ public class OneFrameNode extends OneModelComponentNode {
         Model model = getModelForNode();
         Frame frame = Frame.safeDownCast(comp);
         ViewDB.getInstance().updateDecorations(model, frame);
-        //ViewDB.getInstance().updateModelDisplay(model);
+        ViewDB.getInstance().updateModelDisplay(model);
         ViewDB.repaintAll();
     }
     

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -37,6 +37,9 @@ import javax.swing.Action;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
+import org.opensim.modeling.Component;
+import org.opensim.modeling.ComponentIterator;
+import org.opensim.modeling.ComponentsList;
 import org.opensim.modeling.Frame;
 import org.opensim.modeling.Geometry;
 import org.opensim.view.FrameToggleVisibilityAction;
@@ -56,7 +59,25 @@ public class OneFrameNode extends OneModelComponentNode {
     }
    
     protected final void createGeometryNodes() {
-        
+        // attached_geometry doesn't reach geometry mounted on 
+		// offset frames, use iterator instead
+		// Caveat if nested bodies or components have geometry 
+		// it may appear multiple times
+        ComponentsList compList = frame.getComponentsList();
+        ComponentIterator compIter = compList.begin();
+        Children children = getChildren();
+        while (!compIter.equals(compList.end())) {
+            Component comp = compIter.__deref__();
+            Geometry oneG = Geometry.safeDownCast(comp);
+            if (oneG!=null){
+                OneGeometryNode node = new OneGeometryNode(oneG);
+                Node[] arrNodes = new Node[1];
+                arrNodes[0] = node;
+                children.add(arrNodes);
+            }
+            compIter.next();
+        }
+        /*
         int geomSize = frame.getPropertyByName("attached_geometry").size();
         // Create node for geometry
         Children children = getChildren();
@@ -66,7 +87,7 @@ public class OneFrameNode extends OneModelComponentNode {
             Node[] arrNodes = new Node[1];
             arrNodes[0] = node;
             children.add(arrNodes);
-        }
+        }*/
     }
     
    @Override

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -41,6 +41,7 @@ import org.opensim.modeling.Component;
 import org.opensim.modeling.ComponentIterator;
 import org.opensim.modeling.ComponentsList;
 import org.opensim.modeling.Frame;
+import org.opensim.modeling.FrameGeometry;
 import org.opensim.modeling.Geometry;
 import org.opensim.view.FrameToggleVisibilityAction;
 
@@ -69,7 +70,7 @@ public class OneFrameNode extends OneModelComponentNode {
         while (!compIter.equals(compList.end())) {
             Component comp = compIter.__deref__();
             Geometry oneG = Geometry.safeDownCast(comp);
-            if (oneG!=null){
+            if (oneG!=null && FrameGeometry.safeDownCast(oneG)==null){
                 OneGeometryNode node = new OneGeometryNode(oneG);
                 Node[] arrNodes = new Node[1];
                 arrNodes[0] = node;

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
@@ -40,6 +40,7 @@ import org.openide.nodes.Sheet;
 import static org.openide.nodes.Sheet.createExpertSet;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
+import org.opensim.modeling.Component;
 import org.opensim.modeling.Frame;
 import org.opensim.modeling.Geometry;
 import org.opensim.modeling.Model;
@@ -58,8 +59,6 @@ import org.opensim.view.pub.ViewDB;
 public class OneGeometryNode extends OneComponentWithGeometryNode {
     
     private static ResourceBundle bundle = NbBundle.getBundle(OneGeometryNode.class);
-    State state;
-    OpenSimContext context;
     /**
     * Creates a new instance of OneContactForceNode
     */
@@ -106,56 +105,7 @@ public class OneGeometryNode extends OneComponentWithGeometryNode {
     public Sheet createSheet() {
         Sheet sheet;
         sheet = super.createSheet();
-        addFrameProperties(sheet);
         return sheet;
-    }
-
-    private void addFrameProperties(Sheet sheet) {
-        Sheet.Set frameSheet = createExpertSet();
-        frameSheet.setDisplayName("Attachment Frame");
-        sheet.put(frameSheet);
-        Geometry g = Geometry.safeDownCast(comp);
-        Frame frame = g.getFrame();
-        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);
-        // Add dropdown of existing Frames
-
-        PropertySupport.Reflection nextNodeProp;
-        try {
-            nextNodeProp = new PropertySupport.Reflection(this,
-                    String.class,
-                    "getFrameName",
-                    "setFrameName");
-            nextNodeProp.setValue("canEditAsText", Boolean.TRUE);
-            nextNodeProp.setValue("suppressCustomEditor", Boolean.TRUE);
-            nextNodeProp.setName("Frame");
-            PropertyEditorSupport editor = EditorRegistry.getEditor("Frame");
-            if (editor != null)
-                nextNodeProp.setPropertyEditorClass(editor.getClass());
-            frameSheet.put(nextNodeProp);
-        } catch (NoSuchMethodException ex) {
-            Exceptions.printStackTrace(ex);
-        }
-        if (offsetFrame!=null){ 
-            try {
-                // Expose traslations and rotatiosn
-                PropertySupport.Reflection translationProp = new PropertySupport.Reflection(this,
-                        String.class, "getTranslationString", "setTranslationString");
-                translationProp.setValue("canEditAsText", Boolean.TRUE);
-                translationProp.setDisplayName("Translation");
-                translationProp.setValue("suppressCustomEditor", Boolean.TRUE);
-                frameSheet.put(translationProp);
-               
-                PropertySupport.Reflection rotationProp = new PropertySupport.Reflection(this,
-                        String.class, "getRotationString", "setRotationString");
-                rotationProp.setValue("canEditAsText", Boolean.TRUE);
-                rotationProp.setDisplayName("Rotation");
-                rotationProp.setValue("suppressCustomEditor", Boolean.TRUE);
-                frameSheet.put(rotationProp);
-            } catch (NoSuchMethodException ex) {
-                Exceptions.printStackTrace(ex);
-            }
-        }
-        sheet.put(frameSheet);
     }
     
     public String getFrameName() {
@@ -164,60 +114,7 @@ public class OneGeometryNode extends OneComponentWithGeometryNode {
     }
     public void setFrameName(String frame) {
         Geometry g = Geometry.safeDownCast(comp);
-        //g.setFrameName(frame);
-    }
-    
-    public String getTranslationString() {
-        Geometry g = Geometry.safeDownCast(comp);
-        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(g.getFrame());
-        Transform transform = offsetFrame.getOffsetTransform();
-        String translationVec3AsString = transform.p().toString();
-        return translationVec3AsString.substring(2, translationVec3AsString.length()-1).replace(',', ' ');
-    }
-    public void setTranslationString(String string) {
-        Geometry g = Geometry.safeDownCast(comp);
-        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(g.getFrame());
-        String vals[] = string.split(" ");
-        context = OpenSimDB.getInstance().getContext(getModelForNode());
-        context.cacheModelAndState();
-        //offsetFrame.upd_orientation(0);
-        for (int i=0; i<3; i++)
-            offsetFrame.upd_translation().set(i, Double.valueOf(vals[i]));
-        refreshDisplay();
-        return;
-    }
-    
-    public String getRotationString() {
-        Geometry g = Geometry.safeDownCast(comp);
-        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(g.getFrame());
-        Transform transform = offsetFrame.getOffsetTransform();
-        String rotationVec3AsString = transform.R().convertRotationToBodyFixedXYZ().toString();
-        return rotationVec3AsString.substring(2, rotationVec3AsString.length()-1).replace(',', ' ');
-    }
-    public void setRotationString(String string) {
-        Geometry g = Geometry.safeDownCast(comp);
-        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(g.getFrame());
-        String vals[] = string.split(" ");
-        context = OpenSimDB.getInstance().getContext(getModelForNode());
-        context.cacheModelAndState();
-        //offsetFrame.upd_orientation(0);
-        for (int i=0; i<3; i++)
-            offsetFrame.upd_orientation().set(i, Double.valueOf(vals[i]));
-        refreshDisplay();
-        return;
-    }
-
-    private void refreshDisplay() {
-        try {
-            context.restoreStateFromCachedModel();
-        } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
-        }
-        Model model = getModelForNode();
-        Geometry g = Geometry.safeDownCast(comp);
-        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(g.getFrame());
-        ViewDB.getInstance().updateDecorations(model, offsetFrame);
-        //ViewDB.getInstance().updateModelDisplay(model);
-        ViewDB.repaintAll();
+        //Component frameComponent = m.getComponent(frame);
+        //g.connectSocket_frame(frameComponent);
     }
 }

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
@@ -42,6 +42,7 @@ import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
 import org.opensim.modeling.Frame;
 import org.opensim.modeling.Geometry;
+import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.PhysicalOffsetFrame;
 import org.opensim.modeling.State;
@@ -212,7 +213,11 @@ public class OneGeometryNode extends OneComponentWithGeometryNode {
         } catch (IOException ex) {
             Exceptions.printStackTrace(ex);
         }
-        ViewDB.getInstance().updateModelDisplay(getModelForNode());
+        Model model = getModelForNode();
+        Geometry g = Geometry.safeDownCast(comp);
+        PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(g.getFrame());
+        ViewDB.getInstance().updateDecorations(model, offsetFrame);
+        //ViewDB.getInstance().updateModelDisplay(model);
         ViewDB.repaintAll();
     }
 }

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -142,6 +142,15 @@ public final class ViewDB extends Observable implements Observer, LookupListener
                 websocketdb.broadcastMessageJson(currentJson.createFrameMessageJson(false), null);
         }
     }
+    /*
+     * Update Decorations downstream from passed in Component.
+    */
+    public void updateDecorations(Model model, Component comp) {
+        if (websocketdb!=null){
+            ModelVisualizationJson modelJson = getModelVisualizationJson(model);
+             websocketdb.broadcastMessageJson(currentJson.createUpdateDecorationsMessageJson(comp), null);
+        }
+    }
    
    class AppearanceChange {
        Model model;


### PR DESCRIPTION
This PR ended up exposing all Frames in the Navigator tree which allows for editing Joints and Geometry the same way by editing the definition of the Frame itself.