### PR TITLE
[readme] Refer users to appveyor and travis scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ include source code for the
 cannot be used to build OpenSim 3.x or earlier.**
 
 **NOTE: Due to the small development team working on the GUI, we do not provide
-support for building or altering the OpenSim GUI source code.**
+support for building or altering the OpenSim GUI source code. Advanced users
+can refer to the appveyor.yml or .travis.yml scripts in this folder.**
 
 More information can be found at our websites
  - [OpenSim website](http://opensim.stanford.edu)


### PR DESCRIPTION
This PR adds a note to the readme to refer users who want to build the GUI to look at the appveyor and travis scripts. I made sure to note that this is for "advanced users." The main motivation here is to guide the development team on how to build the GUI.