### PR TITLE
Copy Models before building Resources.zip as part of PrepareInstaller

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,10 +69,10 @@ build_script:
   - cd ../build
   - cmake ../opensim-gui -G"Visual Studio 15 2017 Win64" -DCMAKE_PREFIX_PATH=C:\opensim-core-VC141 -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:/Program Files/NetBeans 8.2;-Dnbplatform.default.harness.dir=C:/Program Files/NetBeans 8.2/harness"
   - cmake --build . --target CopyOpenSimCore --config Release
+  - cmake --build . --target CopyModels --config Release
   - cmake --build . --target PrepareInstaller --config Release
   - cmake --build . --target CopyJRE --config Release
   - cmake --build . --target CopyVisualizer --config Release
-  - cmake --build . --target CopyModels --config Release
   #
   # TODO edit the .opensim folder name (in opensim.conf)
   


### PR DESCRIPTION
AppVeyor build scripts copies Models after Resource.zip has been created. This PR switches the order so that Models are copied first and so included in Resources.zip. 