### PR TITLE
fix Analysis Edit Crash

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/AbstractToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AbstractToolModel.java
@@ -95,9 +95,9 @@ public abstract class AbstractToolModel extends Observable {
    //------------------------------------------------------------------------
    public AnalysisSet getAnalysisSet() { return tool.getAnalysisSet(); }
    public void addCopyOfAnalysis(Analysis analysis) {
-      Analysis analysisCopy = Analysis.safeDownCast(analysis.clone()); // C++-side copy
-      analysisCopy.setName(analysis.getConcreteClassName()); // Change name...  otherwise name will be "default" since currently the analyses we're making copies of come from the registered object table
-      getAnalysisSet().cloneAndAppend(analysisCopy);
+      getAnalysisSet().cloneAndAppend(analysis); // All cloning memory management on Cpp side
+      Analysis an = getAnalysisSet().get(getAnalysisSet().getSize()-1);
+      an.setName(analysis.getConcreteClassName());
       setModified(Operation.AnalysisAddedOrRemoved);
    }
    public void replaceAnalysis(int i, Analysis analysis) {

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalysisSetPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalysisSetPanel.java
@@ -43,6 +43,7 @@ import javax.swing.event.ListSelectionListener;
 import javax.swing.table.AbstractTableModel;
 import org.opensim.modeling.Analysis;
 import org.opensim.modeling.AnalysisSet;
+import org.opensim.modeling.OpenSimObject;
 import org.opensim.view.editors.ObjectEditDialogMaker;
 
 //===========================================================================
@@ -254,9 +255,11 @@ public class AnalysisSetPanel extends javax.swing.JPanel implements Observer {
    private void editButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_editButtonActionPerformed
       if(currentSelectedRow>=0) {
          Analysis analysis = toolModel.getAnalysisSet().get(currentSelectedRow);
-         Analysis analysisCopy = Analysis.safeDownCast(analysis.clone());
+         OpenSimObject analysisCopy = analysis.clone();
          ObjectEditDialogMaker editorDialog = new ObjectEditDialogMaker(analysis, true, "OK");
          if(!editorDialog.process()) {
+            //System.out.println("analysis concrete type"+analysis.getConcreteClassName());
+            //System.out.println("analysisCopy concrete type"+analysisCopy.getConcreteClassName());
             analysis.assign(analysisCopy);
          } else {
             // If edit was successful, notify observers to enable "Run"


### PR DESCRIPTION
Fix crash canceling out of Analysis edit that was due to Object slicing (due to safeDownCast). Analysis Edits on Mac and windows can be done and cancelled safely