### PR TITLE
[travis] travis_wait for make PrepareInstaller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,8 @@ install:
   - mkdir ../build && cd ../build
   - cmake ../opensim-gui -DCMAKE_PREFIX_PATH=~/opensim-core -DAnt_EXECUTABLE="/Applications/NetBeans/NetBeans 8.2.app/Contents/Resources/NetBeans/extide/ant/bin/ant" -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=/Applications/NetBeans/NetBeans 8.2.app/Contents/Resources/NetBeans;-Dnbplatform.default.harness.dir=/Applications/NetBeans/NetBeans 8.2.app/Contents/Resources/NetBeans/harness"
   - make CopyOpenSimCore
-  - make PrepareInstaller
+  # Sometimes, pkgbuild takes longer than 10 minutes.
+  - travis_wait make PrepareInstaller
   
 script: 
   - echo "No tests."


### PR DESCRIPTION
This PR adds `travis_wait` to a line that may take longer than 10 minutes (running pkgbuild). This is just a workaround; ideally, we would find out what's causing `pkgbuild` to take so long.