### PR TITLE
Cancel progress bar on exceptions not handled by OpenSim API 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/FileOpenOsimModelAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FileOpenOsimModelAction.java
@@ -65,6 +65,9 @@ public class FileOpenOsimModelAction extends CallableSystemAction {
                                 "Could not construct a model from " + fileName + ". Possible reasons: syntax error or unsupported format.", ex);
 
                     }
+                    finally{
+                        progressHandle.finish();
+                    }
 
                 }
             }


### PR DESCRIPTION
Fix issue #618 where opening  a model file throws an exception that's not caught by opensim-core resulting in leftover progress bar.