### PR TITLE
Remove warnings when "internally" converting motions into states

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/IKToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IKToolModel.java
@@ -159,8 +159,8 @@ public class IKToolModel extends Observable implements Observer {
                     addMotion = false;
                 }
             }
-            // Create a new States storage and load it in GUI 
             // We don't create full state to avoid polluting results
+            // This will be done internally in MotionDisplayer
             Storage ikmotion = new Storage(animationCallback.getStorage()); // Java-side copy
             ikmotion.setName("IKResults");
             updateMotion(ikmotion);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
@@ -161,14 +161,12 @@ public class InverseDynamicsToolModel extends AbstractToolModelWithExternalLoads
          if (motion!=null){
             // Create a new States storage and load it in GUI 
             // this should make playback faster since no need to assemble
-            Storage idmotion = new Storage(512, "IDResults"); // Java-side copy
             if (motion.isInDegrees()){
                 getOriginalModel().getSimbodyEngine().convertDegreesToRadians(motion);
             }
-            getOriginalModel().formStateStorage(
-                    motion,
-                    idmotion, false);
-            updateMotion(idmotion); // replaces current motion
+            Storage idmotion = new Storage(motion, true); // Java-side copy
+            idmotion.setName("IDResults");
+            updateMotion(idmotion); // replaces current motion, internally will be made into states
 
          }
          getModel().removeAnalysis(animationCallback, false);

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -441,7 +441,7 @@ public class MotionDisplayer {
         else if (!liveMotion){ // This is the most common handling of old Result files
             // create a local Storage and use that to drive animation
             motionAsStates = new Storage();
-            model.formStateStorage(simmMotionData, motionAsStates);
+            model.formStateStorage(simmMotionData, motionAsStates, false);
             statesFile = true;
             // Fix size of temporary array to hold interpolated values
             numColumnsIncludingTime = motionAsStates.getColumnLabels().getSize();


### PR DESCRIPTION
Turn off warnings on converting motion files (e.g. IK, ID output) into stateStorage used for faster display in MotionDisplayer. Also found out that ID was converting motion to states unnecessarily before passing on to MotionDisplayer, reverted to behave similar to IK. 