### PR TITLE
Avoid sending uninitialized bounding box to visualizer 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -263,7 +263,10 @@ public class AnnotatedMotion extends Storage { // MotionDisplayer needs to know 
     }
 
     public final double[] getBoundingBox() {
-        return boundingBox;
+        if (isBoundingBoxComputed())
+            return boundingBox;
+        else
+            return new double[]{0., 0., 0., 1., 1., 1.};
     }
 
     public double getUnitConversion() {


### PR DESCRIPTION
when loading experimental forces, don't send uninitialized bounding box to visualizer