### PR TITLE
Better material for model markers

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1124,10 +1124,12 @@ public class ModelVisualizationJson extends JSONObject {
         UUID mat_uuid = UUID.randomUUID();
         mat_json.put("uuid", mat_uuid.toString());
         mat_json.put("name", "MarkerMat");
-        mat_json.put("type", "MeshBasicMaterial");
+        mat_json.put("type", "MeshPhongMaterial");
+        mat_json.put("shininess", 30);
         //mat_json.put("transparent", true);
         String colorString = JSONUtilities.mapColorToRGBA(hints.get_marker_color());
         mat_json.put("color", colorString);
+        mat_json.put("emissive", colorString);
         json_materials.add(mat_json);
         marker_mat_json = mat_json;
         return mat_uuid;

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -973,7 +973,7 @@ public class MotionDisplayer {
             UUID uuidForMarkerGeometry = UUID.randomUUID();
             getExperimenalMarkerGeometryJson().put("uuid", uuidForMarkerGeometry.toString());
             getExperimenalMarkerGeometryJson().put("type", "SphereGeometry");
-            getExperimenalMarkerGeometryJson().put("radius", 15);
+            getExperimenalMarkerGeometryJson().put("radius", 5);
             getExperimenalMarkerGeometryJson().put("name", "DefaultExperimentalMarker");
             JSONArray json_geometries = (JSONArray) modelVisJson.get("geometries");
             json_geometries.add(getExperimenalMarkerGeometryJson());


### PR DESCRIPTION
Use same material and radius for Experimental markers and model markers, users can change the size of Experimental markers after issue #474 fix is submitted.