### PR TITLE
Separate command for model Show/Hide similar to ShowOnly 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/ModelDisplayHideAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/ModelDisplayHideAction.java
@@ -23,16 +23,28 @@
 
 package org.opensim.view;
 
+import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
+import org.opensim.view.nodes.OneModelNode;
+import org.opensim.view.pub.ViewDB;
 
-public class ObjectDisplayShowAction extends ObjectDisplayShowHideBaseAction {
+public class ModelDisplayHideAction extends ObjectDisplayShowHideBaseAction {
 
-   public ObjectDisplayShowAction() {
-      super(true);
+   public ModelDisplayHideAction() {
+      super(false);
    }
 
    public String getName() {
-      return NbBundle.getMessage(ObjectDisplayHideAction.class, "CTL_ModelDisplayShowAction");
+      return NbBundle.getMessage(ObjectDisplayShowAction.class, "CTL_ModelDisplayHideAction");
    }
 
+   public void performAction() {
+         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
+         for (Node node:selected){
+             if (node instanceof OneModelNode){
+                 OneModelNode omnode = (OneModelNode) node;
+                 ViewDB.getInstance().toggleModelDisplay(omnode.getModel(), false);
+             }
+         }
+   }
 }

--- a/Gui/opensim/view/src/org/opensim/view/ModelDisplayMenuAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/ModelDisplayMenuAction.java
@@ -32,7 +32,6 @@ import org.openide.util.actions.Presenter;
 import org.opensim.view.nodes.IsolateCurrentModelAction;
 
 public final class ModelDisplayMenuAction extends CallableSystemAction implements Presenter.Popup {
-    static boolean noGFX=false;
     
     public boolean isEnabled() {
         return true;
@@ -58,19 +57,17 @@ public final class ModelDisplayMenuAction extends CallableSystemAction implement
 
    public JMenuItem getPopupPresenter() {
       JMenu displayMenu = new JMenu("Display");
-      if (noGFX)
-         return displayMenu;
       try {
       
          displayMenu.add(new JMenuItem(
-                 (ObjectDisplayShowAction) ObjectDisplayShowAction.findObject(
-                 (Class)Class.forName("org.opensim.view.ObjectDisplayShowAction"), true)));
+                 (ModelDisplayShowAction) ModelDisplayShowAction.findObject(
+                 (Class)Class.forName("org.opensim.view.ModelDisplayShowAction"), true)));
          displayMenu.add(new JMenuItem(
                 (IsolateCurrentModelAction) IsolateCurrentModelAction.findObject(
                         (Class)Class.forName("org.opensim.view.nodes.IsolateCurrentModelAction"), true)));
          displayMenu.add(new JMenuItem(
-                 (ObjectDisplayHideAction) ObjectDisplayHideAction.findObject(
-                 (Class)Class.forName("org.opensim.view.ObjectDisplayHideAction"), true)));
+                 (ModelDisplayHideAction) ModelDisplayHideAction.findObject(
+                 (Class)Class.forName("org.opensim.view.ModelDisplayHideAction"), true)));
          displayMenu.add(new JMenuItem(
                 (ModelDisplayEditAction) ModelDisplayEditAction.findObject(
                         (Class)Class.forName("org.opensim.view.ModelDisplayEditAction"), true)));       

--- a/Gui/opensim/view/src/org/opensim/view/ModelDisplayShowAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/ModelDisplayShowAction.java
@@ -23,16 +23,28 @@
 
 package org.opensim.view;
 
+import org.openide.nodes.Node;
 import org.openide.util.NbBundle;
+import org.opensim.view.nodes.OneModelNode;
+import org.opensim.view.pub.ViewDB;
 
-public class ObjectDisplayShowAction extends ObjectDisplayShowHideBaseAction {
+public class ModelDisplayShowAction extends ObjectDisplayShowHideBaseAction {
 
-   public ObjectDisplayShowAction() {
+   public ModelDisplayShowAction() {
       super(true);
    }
 
    public String getName() {
-      return NbBundle.getMessage(ObjectDisplayHideAction.class, "CTL_ModelDisplayShowAction");
+      return NbBundle.getMessage(ObjectDisplayShowAction.class, "CTL_ModelDisplayShowAction");
    }
 
+   public void performAction() {
+         Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
+         for (Node node:selected){
+             if (node instanceof OneModelNode){
+                 OneModelNode omnode = (OneModelNode) node;
+                 ViewDB.getInstance().toggleModelDisplay(omnode.getModel(), true);
+             }
+         }
+   }
 }

--- a/Gui/opensim/view/src/org/opensim/view/ObjectDisplayHideAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/ObjectDisplayHideAction.java
@@ -25,7 +25,7 @@ package org.opensim.view;
 
 import org.openide.util.NbBundle;
 
-public final class ObjectDisplayHideAction extends ObjectDisplayShowHideBaseAction {
+public class ObjectDisplayHideAction extends ObjectDisplayShowHideBaseAction {
 
    public ObjectDisplayHideAction() {
       super(false);

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -1866,10 +1866,9 @@ public final class ViewDB extends Observable implements Observer, LookupListener
     * Show only the passed in model and hide all others.
     */
    public void isolateModel(Model openSimModel) {
-      Enumeration<Model> models=mapModelsToVisuals.keys();
+      Enumeration<Model> models=mapModelsToJsons.keys();
       while(models.hasMoreElements()){
          Model next = models.nextElement();
-         SingleModelVisuals vis = mapModelsToVisuals.get(next);
          toggleModelDisplay(next, (openSimModel==next));
       }
       repaintAll();


### PR DESCRIPTION
These commands now operate on the Model visualization as a whole rather than descend to leaf nodes so they leave user set visualization preferences intact.