### PR TITLE
Use first frame of data for visualization

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalDataNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalDataNode.java
@@ -97,10 +97,6 @@ public class ExperimentalDataNode extends OpenSimNode{
                            (ExperimentalObjectDisplayHideAction) ExperimentalObjectDisplayHideAction.findObject(
                            (Class<org.opensim.view.experimentaldata.ExperimentalObjectDisplayHideAction>)Class.forName("org.opensim.view.experimentaldata.ExperimentalObjectDisplayHideAction"), 
                                    true),
-                            null,
-                            (ExperimentalObjectDisplayShowTrailAction) ExperimentalObjectDisplayShowTrailAction.findObject(
-                           (Class<org.opensim.view.experimentaldata.ExperimentalObjectDisplayShowTrailAction>)Class.forName("org.opensim.view.experimentaldata.ExperimentalObjectDisplayShowTrailAction"), 
-                                   true),
                 };
                 
                 

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalMarker.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalMarker.java
@@ -37,6 +37,7 @@ import org.opensim.modeling.ArrayDouble;
 import org.opensim.modeling.DecorativeSphere;
 import org.opensim.modeling.ModelDisplayHints;
 import org.opensim.modeling.State;
+import org.opensim.modeling.StateVector;
 import org.opensim.modeling.Transform;
 import org.opensim.modeling.Vec3;
 import org.opensim.view.motions.MotionDisplayer;
@@ -100,9 +101,12 @@ public class ExperimentalMarker extends MotionObjectBodyPoint {
         expMarker_json.put("name", getName());
         expMarker_json.put("geometry", motionDisplayer.getExperimenalMarkerGeometryJson().get("uuid"));
         expMarker_json.put("material", motionDisplayer.getExperimenalMarkerMaterialJson().get("uuid"));
+        StateVector dataAtStartTime = motionDisplayer.getSimmMotionData().getStateVector(0);
+        ArrayDouble interpolatedStates = dataAtStartTime.getData();
+        int idx = getStartIndexInFileNotIncludingTime();
         JSONArray pos = new JSONArray();
         for (int i = 0; i < 3; i++) {
-            pos.add(0.0);
+            pos.add(interpolatedStates.get(idx+i));
         }
         expMarker_json.put("position", pos);
         expMarker_json.put("castShadow", false);

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalObjectDisplayHideAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalObjectDisplayHideAction.java
@@ -22,12 +22,15 @@
  * -------------------------------------------------------------------------- */
 package org.opensim.view.experimentaldata;
 
+import org.json.simple.JSONObject;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.CallableSystemAction;
+import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.motions.MotionControlJPanel;
+import org.opensim.view.pub.ViewDB;
 
 public final class ExperimentalObjectDisplayHideAction extends CallableSystemAction {
     
@@ -39,10 +42,13 @@ public final class ExperimentalObjectDisplayHideAction extends CallableSystemAct
              ExperimentalDataNode node= (ExperimentalDataNode) selected[i];
              ExperimentalDataObject obj=node.getDataObject();
              // Tell MotionDisplayer to hide it
-             obj.getMyGlyph().hide(obj.getGlyphIndex());
+             //obj.getMyGlyph().hide(obj.getGlyphIndex());
+             ModelVisualizationJson modelVis = ViewDB.getInstance().getModelVisualizationJson(node.getModelForNode());
+             JSONObject command = modelVis.createSetVisibilityCommandForUUID(false, obj.getDataObjectUUID());
+             ViewDB.getInstance().sendVisualizerCommand(command);
              //System.out.println("Hiding index "+obj.getGlyphIndex()+" of object "+obj.toString());
              obj.setDisplayed(false);
-             obj.getMyGlyph().setModified();
+             //obj.getMyGlyph().setModified();
          }
       }
       MotionControlJPanel.getInstance().getMasterMotion().applyTime();

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalObjectDisplayShowAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalObjectDisplayShowAction.java
@@ -22,10 +22,12 @@
  * -------------------------------------------------------------------------- */
 package org.opensim.view.experimentaldata;
 
+import org.json.simple.JSONObject;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.CallableSystemAction;
+import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.motions.MotionControlJPanel;
 import org.opensim.view.pub.ViewDB;
@@ -41,16 +43,10 @@ public final class ExperimentalObjectDisplayShowAction extends CallableSystemAct
              ExperimentalDataNode node= (ExperimentalDataNode) selected[i];
              ExperimentalDataObject obj=node.getDataObject();
              // Tell MotionDisplayer to hide it
-             obj.getMyGlyph().show(obj.getGlyphIndex());
-             /*
-             double[] location = new double[3];
-             obj.getMyGlyph().getLocation(obj.getGlyphIndex(), location);
-             vtkCaptionActor2D theCaption = new vtkCaptionActor2D();
-             theCaption.SetAttachmentPoint(location);
-             theCaption.SetCaption(obj.getBaseName());
-             ViewDB.getInstance().getCurrentModelWindow().getCanvas().GetRenderer().AddActor2D(theCaption);*/
+             ModelVisualizationJson modelVis = ViewDB.getInstance().getModelVisualizationJson(node.getModelForNode());
+             JSONObject command = modelVis.createSetVisibilityCommandForUUID(true, obj.getDataObjectUUID());
+             ViewDB.getInstance().sendVisualizerCommand(command);
              obj.setDisplayed(true);
-             obj.getMyGlyph().setModified();
          }
       }
       MotionControlJPanel.getInstance().getMasterMotion().applyTime();

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalObjectDisplayShowOnlyAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalObjectDisplayShowOnlyAction.java
@@ -22,10 +22,12 @@
  * -------------------------------------------------------------------------- */
 package org.opensim.view.experimentaldata;
 
+import org.json.simple.JSONObject;
 import org.openide.nodes.Node;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.CallableSystemAction;
+import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.motions.MotionControlJPanel;
 import org.opensim.view.nodes.OneModelNode;
@@ -46,9 +48,12 @@ public final class ExperimentalObjectDisplayShowOnlyAction extends CallableSyste
              ExperimentalDataNode node= (ExperimentalDataNode) siblings[i];
              ExperimentalDataObject obj=node.getDataObject();
              // Tell MotionDisplayer to hide it
-             obj.getMyGlyph().hide(obj.getGlyphIndex());
+             ModelVisualizationJson modelVis = ViewDB.getInstance().getModelVisualizationJson(node.getModelForNode());
+             JSONObject command = modelVis.createSetVisibilityCommandForUUID(false, obj.getDataObjectUUID());
+             ViewDB.getInstance().sendVisualizerCommand(command);
+             //System.out.println("Hiding index "+obj.getGlyphIndex()+" of object "+obj.toString());
              obj.setDisplayed(false);
-             obj.getMyGlyph().setModified();
+
          }
       }
       // No show selected ones
@@ -57,9 +62,10 @@ public final class ExperimentalObjectDisplayShowOnlyAction extends CallableSyste
              ExperimentalDataNode node= (ExperimentalDataNode) selected[i];
              ExperimentalDataObject obj=node.getDataObject();
              // Tell MotionDisplayer to hide it
-             obj.getMyGlyph().show(obj.getGlyphIndex());
+             ModelVisualizationJson modelVis = ViewDB.getInstance().getModelVisualizationJson(node.getModelForNode());
+             JSONObject command = modelVis.createSetVisibilityCommandForUUID(true, obj.getDataObjectUUID());
+             ViewDB.getInstance().sendVisualizerCommand(command);
              obj.setDisplayed(true);
-             obj.getMyGlyph().setModified();
          }
       }
       MotionControlJPanel.getInstance().getMasterMotion().applyTime();

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.java
@@ -715,7 +715,9 @@ public class MotionControlJPanel extends javax.swing.JToolBar
              MotionDisplayer newMotionDisplayer = new MotionDisplayer(evt.getMotion(), evt.getModel());
              MotionsDB.getInstance().addMotionDisplayer(evt.getMotion(), newMotionDisplayer);
              getMasterMotion().getDisplayer(0).getAssociatedMotions().add(newMotionDisplayer);
+             newMotionDisplayer.setupMotionDisplay();
              getMasterMotion().setTime(getMasterMotion().getCurrentTime());
+
          }
          motionLoaded = (getMasterMotion().getNumMotions() > 0);
          updatePanelDisplay();

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -1011,6 +1011,7 @@ public class MotionDisplayer {
             ArrayList<UUID> comp_uuids = new ArrayList<UUID>();
             motObjectsChildren.add(nextExpObject.createDecorationJson(comp_uuids, this));
             mapComponentToUUID.put(nextExpObject, comp_uuids);
+            mapUUIDToComponent.put(comp_uuids.get(0), nextExpObject);
         }
     }
     

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -381,9 +381,10 @@ public class MotionDisplayer {
         simmMotionData = motionData;
         currentForceShape = DEFAULT_FORCE_SHAPE;
         modelVisJson = ViewDB.getInstance().getModelVisualizationJson(model);
-        setupMotionDisplay();
-        // create a buffer to be used for comuptation of constrained states
-        //statesBuffer = new double[model.getNumStateVariables()];
+        // We create a temporary array to hold interpolated values, in case Slider doesn't coincide with data
+        colNames = simmMotionData.getColumnLabels();
+        int numColumnsIncludingTime = colNames.getSize();
+        interpolatedStates = new ArrayDouble(0.0, numColumnsIncludingTime-1);
         
         modelVisJson.addMotionDisplayer(this);
         if (model instanceof ModelForExperimentalData) return;
@@ -393,8 +394,6 @@ public class MotionDisplayer {
         if (simmMotionData == null)
            return;
 
-        // We create a temporary array to hold interpolated values, in case Slider doesn't coincide with data
-        colNames = simmMotionData.getColumnLabels();
         int numColumnsIncludingTime = colNames.getSize();
         interpolatedStates = new ArrayDouble(0.0, numColumnsIncludingTime-1);
         // If provided simmMotionData is empty or have one frame, then we're building it live and can't


### PR DESCRIPTION
Rearrange initialization of MotionDisplayer, use data from first frame to create visuals. Also implement the Display menu under ExperimentalData objects for Hide/Show/ShowOnly remove trails