### PR TITLE
Fix vis crash too many polygons

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
@@ -89,7 +89,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("type", "CylinderGeometry");
         dg_json.put("radiusTop", 0.);
         dg_json.put("radiusBottom", arg0.getBaseRadius()*visualizerScaleFactor);
-        dg_json.put("widthSegments", 64);
+        dg_json.put("widthSegments", 32);
         dg_json.put("heightSegments", 1);
         return dg_json;
     }
@@ -113,7 +113,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("type", "TorusGeometry");
 	dg_json.put("radius", arg0.getTorusRadius()*visualizerScaleFactor);
 	dg_json.put("tube", arg0.getTubeRadius()*visualizerScaleFactor);
-	dg_json.put("radialSegments", 64);
+	dg_json.put("radialSegments", 32);
 	dg_json.put("tubularSegments", 24);
         jsonArr.add(dg_json);  
         createMaterialJson(arg0, true);
@@ -270,8 +270,8 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("uuid", geomID.toString());
         dg_json.put("type", "SphereGeometry");
 	dg_json.put("radius", visualizerScaleFactor);
-	dg_json.put("widthSegments", 64);
-	dg_json.put("heightSegments", 64);
+	dg_json.put("widthSegments", 32);
+	dg_json.put("heightSegments", 16);
         if (quadrants.equals("")){
            dg_json.put("phiStart", 0);
            dg_json.put("phiLength", 6.28);
@@ -318,8 +318,8 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("uuid", geomID.toString());
         dg_json.put("type", "SphereGeometry");
         dg_json.put("radius", arg0.getRadius()*visualizerScaleFactor);
-        dg_json.put("widthSegments", 64);
-        dg_json.put("heightSegments", 64);
+        dg_json.put("widthSegments", 32);
+        dg_json.put("heightSegments", 16);
         if (quadrants.equals("")){
             dg_json.put("phiStart", 0);
             dg_json.put("phiLength", 6.28);
@@ -359,7 +359,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("uuid", geomID.toString());
         dg_json.put("type", "CircleGeometry");
 	dg_json.put("radius", arg0.getRadius()*visualizerScaleFactor);
-	dg_json.put("segments", 64);
+	dg_json.put("segments", 32);
         jsonArr.add(dg_json); 
         createMaterialJson(arg0, false);
     }
@@ -378,7 +378,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("radiusTop", arg0.getRadius()*visualizerScaleFactor);
         dg_json.put("radiusBottom", arg0.getRadius()*visualizerScaleFactor);
         dg_json.put("height", arg0.getHalfHeight()*2*visualizerScaleFactor);
-        dg_json.put("radialSegments", 64);
+        dg_json.put("radialSegments", 32);
         dg_json.put("heightSegments", 1);
         if (!quadrants.equals("")){
             dg_json.put("thetaLength", 3.14159);

--- a/Gui/opensim/visualizationServer/src/org/eclipse/jetty/VisWebSocket.java
+++ b/Gui/opensim/visualizationServer/src/org/eclipse/jetty/VisWebSocket.java
@@ -73,13 +73,13 @@ public class VisWebSocket extends Observable { // Socket to handle incoming traf
     @OnWebSocketClose
     public void onClose (Session peer, int in, String cause) {
         peers.remove(peer);
-        System.out.println("onClose");
+        System.out.println("onClose: cause="+cause);
         WebSocketDB.getInstance().unRegisterSocket(this);
     }
     
     @OnWebSocketError
      public void onError (Session peer, Throwable er) {
-        //System.out.println("onError");
+        System.out.println("onError:"+er.getMessage());
     }        
     // Receive message from Visualizer
     @OnWebSocketMessage


### PR DESCRIPTION
Earlier commit changed number of tessellations for analytical shapes to reduce rendering artifacts, on larger models or multiple models this was very problematic. Undoing