### PR TITLE
Restore persist models functionality

### DIFF
--- a/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
@@ -59,7 +59,7 @@ public final class TheApp {
     private static Image appImage;
     private static String installDir=null;
     private static String OS = System.getProperty("os.name").toLowerCase();
-    private static String userDir = System.getProperty("user.dir")+File.separatorChar;
+    private static String userDir = System.getProperty("netbeans.user")+File.separatorChar;
     /** Creates a new instance of TheApp 
     protected TheApp() {
     }

--- a/Gui/opensim/view/src/org/opensim/view/Installer.java
+++ b/Gui/opensim/view/src/org/opensim/view/Installer.java
@@ -104,7 +104,7 @@ public class Installer extends ModuleInstall {
         restorePrefs();
         
         String saved = Preferences.userNodeForPackage(TheApp.class).get("Persist Models", "On");
-        if (false){ // FIX40 Disable for ISB for startup issue 305
+        if (saved.equalsIgnoreCase("on")){ 
             /** Restore from file */            
             try {
                 XMLDecoder decoder = new XMLDecoder(new BufferedInputStream(

--- a/Gui/opensim/view/src/org/opensim/view/actions/ApplicationExit.java
+++ b/Gui/opensim/view/src/org/opensim/view/actions/ApplicationExit.java
@@ -84,7 +84,7 @@ public class ApplicationExit extends WindowAdapter
       if (answer == JOptionPane.NO_OPTION || answer == JOptionPane.CLOSED_OPTION)
          return false;
 
-      System.out.println("Start saving application state.");
+      System.out.println("Start saving application state to file:"+TheApp.getUserDir()+"AppState.xml");
       try {
           ApplicationState state = ApplicationState.getInstance();
           OpenSimDBDescriptor dbDesc = new OpenSimDBDescriptor(OpenSimDB.getInstance());
@@ -95,7 +95,7 @@ public class ApplicationExit extends WindowAdapter
           state.addObject("PluginsDB", PluginsDB.getInstance());
           state.addObject("MotionsDB", new MotionsDBDescriptor(MotionsDB.getInstance()));
           XMLEncoder e = new XMLEncoder(new BufferedOutputStream(
-					new FileOutputStream(TheApp.getUserDir()+"AppState.xml")));
+                new FileOutputStream(TheApp.getUserDir()+"AppState.xml")));
           
           e.writeObject(state); // This method serializes an object graph 
           e.close();


### PR DESCRIPTION
Fixes issue #657
### Brief summary of changes
Restore functionality to remember open models on restart.

### Testing I've completed
Switched user preference to Persist Models to "ON" and the application indeed remembered last open models
### CHANGELOG.md (choose one)

- no need to update because functionality was default in 3.3, may need to document where the file is located cross platform
-