### PR TITLE
Bubble message associated with Exception thrown on tool failures

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
@@ -138,7 +138,7 @@ public class AnalyzeToolModel extends AbstractToolModelWithExternalLoads {
             SimulationDB.getInstance().fireToolStart();
             result = tool.run();
          } catch (IOException ex) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details."));
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details.\n"+ex.getMessage()));
             ex.printStackTrace();
             SimulationDB.getInstance().fireToolFinish();
          }

--- a/Gui/opensim/tracking/src/org/opensim/tracking/CMCToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/CMCToolModel.java
@@ -178,7 +178,7 @@ public class CMCToolModel extends TrackingToolModel {
          try {
             result = tool.run();
          } catch (IOException ex) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details."));
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details\n"+ex.getMessage()));
             ex.printStackTrace();
          }
 

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
@@ -132,7 +132,7 @@ public class ForwardToolModel extends AbstractToolModelWithExternalLoads {
          try {
             result = tool.run();
          } catch (IOException ex) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details."));
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details.\n"+ex.getMessage()));
             ex.printStackTrace();
          }
 

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
@@ -129,7 +129,7 @@ public class InverseDynamicsToolModel extends AbstractToolModelWithExternalLoads
          try {
             result = idTool.run();
          } catch (IOException ex) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details."));
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details\n"+ex.getMessage()));
             ex.printStackTrace();
          }
 

--- a/Gui/opensim/tracking/src/org/opensim/tracking/RRAToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/RRAToolModel.java
@@ -136,7 +136,7 @@ public class RRAToolModel extends TrackingToolModel {
             SimulationDB.getInstance().fireToolStart();
             result = tool.run();
          } catch (IOException ex) {
-            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details."));
+            DialogDisplayer.getDefault().notify(new NotifyDescriptor.Message("Tool execution failed. Check Messages window for details.\n"+ex.getMessage()));
             ex.printStackTrace();
             SimulationDB.getInstance().fireToolFinish();
          }


### PR DESCRIPTION

Fixes issue #585 partially

### Brief summary of changes
GUI was catching exceptions thrown by tools on failures but was reporting only that tool failed (assuming message already displayed in message window).

### Testing I've completed
Tried files used to reproduce 585 and now I get the message from Execption displayed in the failure reporting dialog.

### CHANGELOG.md 

- no need to update 
