### PR TITLE
Fix typo in "Muscle Display Radius" preference 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -272,8 +272,8 @@ public class ModelVisualizationJson extends JSONObject {
         
         // Decide on bone shape/width
         saved = ".005";
-        String currentSize= Preferences.userNodeForPackage(TheApp.class).get("Muscle Dsiplay Radius", saved);
-        Preferences.userNodeForPackage(TheApp.class).put("Muscle Dsiplay Radius", currentSize);
+        String currentSize= Preferences.userNodeForPackage(TheApp.class).get("Muscle Display Radius", saved);
+        Preferences.userNodeForPackage(TheApp.class).put("Muscle Display Radius", currentSize);
         prefMuscleDisplayRadius = Double.parseDouble(currentSize);
         
         createJsonForModel(model);

--- a/Gui/opensim/view/src/org/opensim/view/actions/EditPreferencesJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/actions/EditPreferencesJPanel.java
@@ -70,8 +70,11 @@ public class EditPreferencesJPanel extends javax.swing.JPanel {
        "AntiAliasingFrames",
        "Marker Display Radius",
        "NonCurrentModelOpacity",
-       "Refresh Rate (ms.)"
-       
+       "Refresh Rate (ms.)",
+       "Muscle Dsiplay Radius",
+       "BuildDate",
+       "One Material Meshes",
+       "Save Movie Frames"
    };
    /** Creates new form EditPreferencesJPanel */
    public EditPreferencesJPanel() throws BackingStoreException {


### PR DESCRIPTION
This caused Preference to appear twice, also this PR retires some prefs that were used during development

Fixes issue #539 by removing duplicate preference reported earlier

### Brief summary of changes
Fix typo and retire some Preferences that were introduced during development

### Testing I've completed
Launched application, opened preference dialog, no repeated Preferences

### CHANGELOG.md (choose one)

- We should update current list of Preferences and when they do take effect in user guide.
