### PR TITLE
Fix path maintained by internal models used to run tools

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
@@ -85,7 +85,7 @@ public class AnalyzeToolModel extends AbstractToolModelWithExternalLoads {
          tool.setToolOwnsModel(false);
          context = new OpenSimContext(workersModel.initSystem(), workersModel); // Has side effect of calling setup
         
-         workersModel.setInputFileName("");
+         //workersModel.setInputFileName("");
          
          if(getInputSource()==InputSource.Motion && getInputMotion()!=null)
             context.setStatesFromMotion(analyzeTool(), getInputMotion(),false); // false == motion is in radians

--- a/Gui/opensim/tracking/src/org/opensim/tracking/CMCToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/CMCToolModel.java
@@ -87,7 +87,7 @@ public class CMCToolModel extends TrackingToolModel {
          // setModel() will call addAnalysisSetToModel
          tool.updateModelForces(workersModel, "");
          workersModel.initSystem();
-         workersModel.setInputFileName("");    // Will do this after initSystem so that contact geometry can be loaded properly
+         //workersModel.setInputFileName("");    // Will do this after initSystem so that contact geometry can be loaded properly
          tool.setModel(workersModel);
 
          setModel(workersModel);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
@@ -70,15 +70,13 @@ public class ForwardToolModel extends AbstractToolModelWithExternalLoads {
          model.setPropertiesFromState(context.getCurrentStateRef());
          String tempFileName=getOriginalModel().getInputFileName();
          //int loc = tempFileName.lastIndexOf(".");
+         // This line fakes the model copy to use same filename as orginal model
+         // for the purposes of loading Contact Meshes.
          model.setInputFileName(tempFileName);
 
          // Update actuator set and contact force set based on settings in the tool, then call setup() and setModel()
          // setModel() will call addAnalysisSetToModel
          tool.updateModelForces(model, "");
-         //ModelPose currentPose = new ModelPose("current", getOriginalModel());
-         //currentPose.useAsDefaultForModel(model);
-         
-         model.setInputFileName("");    // Will do this after initSystem so that contact geometry can be loaded properly
          
          tool.setModel(model);
          model.initSystem(); // call initSystem after tool.setModel since the call invalidates the system to add Analyses in 4.0

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
@@ -85,13 +85,12 @@ public class InverseDynamicsToolModel extends AbstractToolModelWithExternalLoads
          idTool.setModel(workersModel);
          context = new OpenSimContext(workersModel.initSystem(), workersModel); // Has side effect of calling setup
         
-         workersModel.setInputFileName("");
+         //workersModel.setInputFileName("");
          
          if(getInputSource()==InputSource.Motion && getInputMotion()!=null)
             idTool.setCoordinateValues(getInputMotion());
          // We don't need to add model to the 3D view... just using it to dump analyses result files
          setModel(workersModel);
-          //OpenSim23 workersModel.initSystem();
        
          // Initialize progress bar, given we know the number of frames to process
          double ti = getInitialTime();

--- a/Gui/opensim/tracking/src/org/opensim/tracking/RRAToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/RRAToolModel.java
@@ -80,7 +80,7 @@ public class RRAToolModel extends TrackingToolModel {
          // setModel() will call addAnalysisSetToModel
          tool.updateModelForces(workersModel, "");
          workersModel.initSystem();
-         workersModel.setInputFileName("");    // Will do this after initSystem so that contact geometry can be loaded properly
+         //workersModel.setInputFileName("");    // Will do this after initSystem so that contact geometry can be loaded properly
          tool.setModel(workersModel);
 
          setModel(workersModel);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
@@ -414,7 +414,7 @@ public class ScaleToolModel extends Observable implements Observer {
       // Store original model; create copy of the original model as our unscaled model (i.e. the model we'll scale)
       this.originalModel = originalModel;
       unscaledModel = new Model(originalModel);
-      unscaledModel.setInputFileName("");
+      //unscaledModel.setInputFileName("");
       unscaledModel.setOriginalModelPathFromModel(originalModel); // important to keep track of the original path so bone loading works
       //unscaledModel.setup();
       originalMarkerSet = new MarkerSet(unscaledModel.getMarkerSet());


### PR DESCRIPTION
Fixes issue #553

### Brief summary of changes
Removed calls to setInputFilename("") on throwaway models used to run tools in GUI

### Testing I've completed
Successful run of FD on model with contact meshes, launched other tools on the same model.

### CHANGELOG.md (choose one)

- no need to update because it is a bugfix
