### PR TITLE
Allow uninstaller to remove non-empty install directory

### DIFF
--- a/Gui/opensim/installer_files/Windows/make_installer.nsi
+++ b/Gui/opensim/installer_files/Windows/make_installer.nsi
@@ -104,7 +104,7 @@ Section "Uninstall"
 
   Delete "$INSTDIR\Uninstall.exe"
 
-  RMDir "$INSTDIR"
+  RMDir /r "$INSTDIR"
 
   DeleteRegKey /ifempty HKCU "Software\OpenSim@VERSION@"
 


### PR DESCRIPTION
Fixes issue #712

### Brief summary of changes
Uninstaller on Windows now removes the installation folder even if non-empty, added switch

### Testing I've completed
Built installer and tried install/uninstall on my local machine. All worked as expected

### CHANGELOG.md (choose one)

- no need to update because bugfix