### PR TITLE
Don't apply hide/show to aggregate Nodes directly, only leaf nodes

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/ObjectAppearanceChangeAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/ObjectAppearanceChangeAction.java
@@ -52,7 +52,7 @@ public abstract class ObjectAppearanceChangeAction extends CallableSystemAction 
                     collectDescendentNodes((OpenSimNode) ch.getNodeAt(chNum), objectNodes, opensimObjects);
                 }
             }
-            if (selected[i] instanceof OneComponentNode) {
+            if (selected[i] instanceof OneComponentNode && selected[i].isLeaf()) {
                 if (!(opensimObjects.contains(((OneComponentNode)selected[i]).getOpenSimObject()))){
                     objectNodes.add((OneComponentNode)selected[i]);
                     opensimObjects.add(((OneComponentNode)selected[i]).getOpenSimObject());


### PR DESCRIPTION
Fixes issue #686 

### Brief summary of changes
When applying hide/show to nodes, apply only to leaf nodes in navigator view

### Testing I've completed
Sequence of hide/show/sjowOnly

### CHANGELOG.md (choose one)

- no need to update because behavior is unchanged from 3.3
