### PR TITLE
Expose method to scripting shell (getResourcesDir) 

### DIFF
--- a/Gui/opensim/scriptingShell/src/org/opensim/console/gui.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/gui.java
@@ -362,11 +362,18 @@ public final class gui {
     }
     
     /**
-     * GInvoke method to install resources to user directory
+     * Invoke method to install resources to user directory
      */
     static public String installResources()
     {
         return TheApp.installResources();
+    }
+    /**
+     * @return the full path to the directory used to install Resources (Models, CodeExamples)
+     */
+    static public String getResourcesDir()
+    {
+        return TheApp.getResourcesDir();
     }
     /**
      * getClassName() returns the full qualified name of the Class that obj is an instance of

--- a/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
@@ -41,6 +41,7 @@ import org.openide.LifecycleManager;
 import org.openide.util.Exceptions;
 import org.openide.util.ImageUtilities;
 import java.nio.file.StandardCopyOption;
+import java.util.prefs.Preferences;
 import javax.swing.JPanel;
 import org.openide.DialogDescriptor;
 import org.openide.DialogDisplayer;
@@ -187,7 +188,14 @@ public final class TheApp {
     public static String getUserDir() {
         return userDir;
     }
-
+    /**
+     * Get Resources Directory where Models, Code has been installed. It will be updated by the installer 
+     * when new Resources are installed.
+     * @return 
+     */
+    public static String getResourcesDir() {
+        return Preferences.userNodeForPackage(TheApp.class).get("OpenSimResourcesDir", null);
+    }
     public static String installResources() {
         // Popup a directory browser dialog prompting for install location of Models, Scripts
         String userHome = System.getProperty("user.home")+File.separator+"Documents"+File.separator+"OpenSim"+


### PR DESCRIPTION
so that GUI scripts can use it to locate models and data files

Fixes issue #736 partly

### Brief summary of changes
Added method to obtain resources directory selected by user on first lanuch

### Testing I've completed
built application, invoked method from scripting shell, got correct answer, modified a script to use the method and it worked as expected

### CHANGELOG.md (choose one)
Need to update doc. to explain the usage.
