### PR TITLE
Use MeshStandardMaterial for ModelMarker with 2 sidedness 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1260,8 +1260,11 @@ public class ModelVisualizationJson extends JSONObject {
         UUID mat_uuid = UUID.randomUUID();
         mat_json.put("uuid", mat_uuid.toString());
         mat_json.put("name", "MarkerMat");
-        mat_json.put("type", "MeshPhongMaterial");
-        mat_json.put("shininess", 30);
+        mat_json.put("type", "MeshStandardMaterial");
+        mat_json.put("transparent", true);
+        mat_json.put("metalness", 0);
+        mat_json.put("roughness", 1.0);
+        mat_json.put("side", 2);
         //mat_json.put("transparent", true);
         String colorString = JSONUtilities.mapColorToRGBA(hints.get_marker_color());
         mat_json.put("color", colorString);


### PR DESCRIPTION
This makes model markers in line with other meshes. Emissive color is set to pink as well so the markers are not dark if in shadow and indistinguishable from  Experimental markers

Fixes issue #761 

### Brief summary of changes
Changed values and type of Material pre-created for Model markers

### Testing I've completed
Loaded models with markers 

### CHANGELOG.md (choose one)

- no need to update, bugfix
