### PR TITLE
Mark model dirty with unsaved changes on Marker delete

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/markerEditor/OneMarkerDeleteAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/markerEditor/OneMarkerDeleteAction.java
@@ -44,6 +44,7 @@ import org.opensim.modeling.Vec3;
 import org.opensim.utils.ErrorDialog;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.ObjectsDeletedEvent;
+import org.opensim.view.SingleModelGuiElements;
 import org.opensim.view.nodes.OneMarkerNode;
 import org.opensim.view.pub.OpenSimDB;
 import org.opensim.view.pub.ViewDB;
@@ -144,6 +145,8 @@ public final class OneMarkerDeleteAction extends CallableSystemAction {
         }
         // Update the marker name list in the ViewDB.
         OpenSimDB.getInstance().getModelGuiElements(model).updateMarkerNames();
+        SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);
+        guiElem.setUnsavedChangesFlag(true);
     }
   
 }


### PR DESCRIPTION
Fixes issue #768

### Brief summary of changes
Turn on "dirty" flag when Markers are deleted.

### Testing I've completed
Loaded a model, deleted  a marker, tried to close without explicit save, was prompted if want to save changes.

### CHANGELOG.md (choose one)

- no need to update bugfix
