### PR TITLE
Same number of segments for experimental marker as model markers

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -973,6 +973,8 @@ public class MotionDisplayer {
             getExperimenalMarkerGeometryJson().put("uuid", uuidForMarkerGeometry.toString());
             getExperimenalMarkerGeometryJson().put("type", "SphereGeometry");
             getExperimenalMarkerGeometryJson().put("radius", 5);
+            getExperimenalMarkerGeometryJson().put("widthSegments", 32);
+            getExperimenalMarkerGeometryJson().put("heightSegments", 16);            
             getExperimenalMarkerGeometryJson().put("name", "DefaultExperimentalMarker");
             JSONArray json_geometries = (JSONArray) modelVisJson.get("geometries");
             json_geometries.add(getExperimenalMarkerGeometryJson());


### PR DESCRIPTION
Fixes issue discussed along with #761 

### Brief summary of changes
Change resolution for experimental markers to match model markers

### Testing I've completed
Loaded model with markers, overlaid experimental markers, the markers looked similar

### CHANGELOG.md (choose one)

- no need to update, bugfix
