### PR TITLE
Fix unit conversion of offsets obtained from visualizer 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/ModelDisplayEditAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/ModelDisplayEditAction.java
@@ -49,7 +49,7 @@ public final class ModelDisplayEditAction extends CallableSystemAction {
     */
    public void adjustModelDisplayOffset(Model abstractModel) {
       // Show dialog for model display ajdustment
-      ViewDB.getInstance().updateModelOffsets();
+      // offset is always updated offline after each model loading ito visualizer
       final ModelDisplayOffsetJPanel p = new ModelDisplayOffsetJPanel(abstractModel);
       DialogDescriptor desc = new DialogDescriptor(p, "Model Offset", false, new ActionListener() {
 

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -1284,9 +1284,10 @@ public final class ViewDB extends Observable implements Observer, LookupListener
       if (isVtkGraphicsAvailable())
         sceneAssembly.GetBounds(sceneBounds);
       else {
+          int numModels = mapModelsToJsons.size();
           for (int i=0; i<3; i++){
-            sceneBounds[i*2] = -2;
-            sceneBounds[i*2+1] = 2;
+            sceneBounds[i*2] = -2*numModels;
+            sceneBounds[i*2+1] = 2*numModels;
           }
       }
       return sceneBounds;
@@ -2301,11 +2302,15 @@ public final class ViewDB extends Observable implements Observer, LookupListener
                         ModelVisualizationJson nextModelJson = modelJsons.nextElement();
                         String uuidDtring = nextModelJson.getModelUUID().toString();
                         int index = uuids.indexOf(uuidDtring);
-                        JSONObject offsetObj = (JSONObject) positions.get(index);
-                        Vec3 offsetAsVec3 = JSONMessageHandler.convertJsonXYZToVec3(offsetObj);
-                        for (index = 0; index < 3; index++) {
-                            nextModelJson.getTransformWRTScene().p().set(index,
-                                    offsetAsVec3.get(index) / nextModelJson.getVisScaleFactor());
+                        // Be defensive in case model hasn't been found
+                        if (index >=0){
+                            JSONObject offsetObj = (JSONObject) positions.get(index);
+                            // The following call returns Vec3 in model units, no need to convert
+                            Vec3 offsetAsVec3 = JSONMessageHandler.convertJsonXYZToVec3(offsetObj);
+                            for (int vindex = 0; vindex < 3; vindex++) {
+                                nextModelJson.getTransformWRTScene().p().set(vindex,
+                                        offsetAsVec3.get(vindex));
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fixes issue #88, #737

### Brief summary of changes
This is the GUI part of the fix (unit conversion done twice from offsets in visualizer to model space)

### Testing I've completed
Loaded multiple models, changed offsets, values were always correct and stayed correct on revisit.

### CHANGELOG.md (choose one)

- no need to update because it is a bugfix