### PR TITLE
Json for Brick sent to visualizer is in full lengths rather than half-lengths

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
@@ -401,9 +401,9 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         JSONObject dg_json = new JSONObject();
         dg_json.put("uuid", geomID.toString());
         dg_json.put("type", "BoxGeometry");
-        dg_json.put("width", arg0.getHalfLengths().get(0)*visualizerScaleFactor);
-        dg_json.put("height", arg0.getHalfLengths().get(1)*visualizerScaleFactor);
-        dg_json.put("depth", arg0.getHalfLengths().get(2)*visualizerScaleFactor);
+        dg_json.put("width", arg0.getHalfLengths().get(0)*2*visualizerScaleFactor);
+        dg_json.put("height", arg0.getHalfLengths().get(1)*2*visualizerScaleFactor);
+        dg_json.put("depth", arg0.getHalfLengths().get(2)*2*visualizerScaleFactor);
         dg_json.put("radialSegments", 1);
         dg_json.put("heightSegments", 1);
         return dg_json;


### PR DESCRIPTION
Fixes issue #760
### Brief summary of changes
When communicating Brick geometry to visualizer, pass full length rather than half lengths

### Testing I've completed
Loaded model in issue 760 and had correct dimensions as verified in expert mode

### CHANGELOG.md (choose one)

- no need to update because Brick is a new functionality/geometry
