### PR TITLE
Avoid trivial edits due to property editor rendering

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/editors/FrameNameEditor.java
+++ b/Gui/opensim/view/src/org/opensim/view/editors/FrameNameEditor.java
@@ -109,6 +109,8 @@ public class FrameNameEditor extends PropertyEditorSupport
     }
 
     public void propertyChange(PropertyChangeEvent evt) {
+        // ignoe trivial events
+        if (evt.getNewValue()==null && evt.getOldValue()==null) return;
         Model mdl = ViewDB.getCurrentModel();
         PropertyEditorAdaptor pea = new PropertyEditorAdaptor(mdl); // Need Model, Object, Property, Node
         pea.handleModelChange();


### PR DESCRIPTION
Fixes issue #

### Brief summary of changes
Rendering frame selection editor fires trivial events that slows GUI down and messes undo stack.

### Testing I've completed
Checked that editing workflow isn't invoked unnecessarily

### CHANGELOG.md (choose one)

- no need to update because bugfix
