### PR TITLE
Special handling of mass_center property to update visualization on edit

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -2257,6 +2257,12 @@ public final class ViewDB extends Observable implements Observer, LookupListener
             websocketdb.broadcastMessageJson(vis.createTranslateObjectCommand(marker, marker.get_location()), null);
         }
     }
+    public void setObjectTranslationInParentByUuid(UUID objectUuid, Vec3 newlocation) {
+        if (websocketdb!=null){
+            websocketdb.broadcastMessageJson(
+                    ModelVisualizationJson.createTranslateObjectByUuidCommand(objectUuid, newlocation), null);
+        }
+    }
     
     public void applyColorToObjectByUUID(Model model, UUID objectUUID, Vec3 newColor) {
         if (websocketdb!=null){


### PR DESCRIPTION
Fixes issue #296

### Brief summary of changes
BodyNode introduced special functions to call on edits to mass_center that also update display

### Testing I've completed
Loaded model, show COM, edit (gfx update as expected), undo/redo all work.

### CHANGELOG.md 

- no need to update because bugfix
