### PR TITLE
animate during tool run

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
@@ -94,6 +94,7 @@ public class JavaMotionDisplayerCallback extends AnalysisWrapperWithTimer {
          createResultStorage();
       
       motionDisplayer = new MotionDisplayer(getStorage(), getModelForDisplay());
+      motionDisplayer.setupMotionDisplay();
       this.progressHandle = progressHandle;
       setRefreshRateInMillis(getRefreshRatePreference());
    }
@@ -132,6 +133,7 @@ public class JavaMotionDisplayerCallback extends AnalysisWrapperWithTimer {
       else
           createResultStorage();
       motionDisplayer = new MotionDisplayer(getStorage(), getModelForDisplay());
+      motionDisplayer.setupMotionDisplay();
       this.progressHandle = progressHandle;
       setRefreshRateInMillis(getRefreshRatePreference());
    }


### PR DESCRIPTION
Fixes issue #794 

### Brief summary of changes
When running tools, we don't have prebuilt storage file to convert into states. Use workflow from 3.3 to animate instead, then switch to states when done.

### Testing I've completed
Ran tools, visualization did animate as expected.

### CHANGELOG.md (choose one)

- no need to update because bugfix
