### PR TITLE
Add flag to indicate if property edit affects state 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/AppearanceHelper.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/AppearanceHelper.java
@@ -60,6 +60,7 @@ public class AppearanceHelper {
         final DecorativeGeometry.Representation oldRep = appearance.get_representation();
         final int newRep = pref;
         final PropertyEditorAdaptor pea = new PropertyEditorAdaptor(model, appearance.upd_SurfaceProperties(), ap, compNode);
+        pea.setAffectsState(false);
         ap.setValueIsDefault(false);
         pea.setValueInt(newRep, false);
         // Delay update display till end
@@ -98,6 +99,7 @@ public class AppearanceHelper {
         final boolean newVis = newValue;
         final Model model = this.model;
         final PropertyEditorAdaptor pea = new PropertyEditorAdaptor(model, appearance, ap, compNode);
+        pea.setAffectsState(false);
         ap.setValueIsDefault(false);
         pea.setValueBool(newVis, false, false);
         // Delay update display till end
@@ -137,6 +139,7 @@ public class AppearanceHelper {
         final Model model = this.model;
         final Vec3 oldValue = new Vec3(appearance.get_color());
         final PropertyEditorAdaptor pea = new PropertyEditorAdaptor(model, appearance, ap, compNode);
+        pea.setAffectsState(false);
         ap.setValueIsDefault(false);
         final Vec3 newColorVec3 = new Vec3(colorComp[0], colorComp[1], colorComp[2]);
         pea.setValueVec3(newColorVec3, false);
@@ -177,6 +180,7 @@ public class AppearanceHelper {
         final double newOpacity = opacity;
         final Model model = this.model;
         final PropertyEditorAdaptor pea = new PropertyEditorAdaptor(model, appearance, ap, compNode);
+        pea.setAffectsState(false);
         ap.setValueIsDefault(false);
         pea.setValueDouble(newOpacity, false);
         // Delay update display till end

--- a/Gui/opensim/view/src/org/opensim/view/nodes/PropertyEditorAdaptor.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/PropertyEditorAdaptor.java
@@ -55,14 +55,19 @@ import org.opensim.view.pub.ViewDB;
  */
 public class PropertyEditorAdaptor {
 
+    /**
+     * @param affectsState the affectsState to set
+     */
+    public void setAffectsState(boolean affectsState) {
+        this.affectsState = affectsState;
+    }
+
     OpenSimObject obj; // Object being edited or selected in navigator window
     AbstractProperty prop; // Property being edited
     OpenSimContext context = null; // Context object needed to recreate the system as needed, cached for speed
     Model model; // model to which obj belongs
     OpenSimObjectNode node;
-
-    Model clonedModel;
-    State clonedState;
+    private boolean affectsState = true;
     
     public PropertyEditorAdaptor(String propertyName, OpenSimObjectNode ownerNode) {
         this.model = ownerNode.getModelForNode();
@@ -378,21 +383,24 @@ public class PropertyEditorAdaptor {
     }
         
     private void handlePropertyChange(final double oldValue, final double v, boolean supportUndo) {
-        
-        context.cacheModelAndState();
-        PropertyHelper.setValueDouble(v, prop);        
-        try {
-            context.restoreStateFromCachedModel();
-        } catch (IOException iae) {
+        if (!affectsState)
+            PropertyHelper.setValueDouble(v, prop);
+        else {
+            context.cacheModelAndState();
+            PropertyHelper.setValueDouble(v, prop);
+
             try {
-                 new JOptionPane(iae.getMessage(), 
-				JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
-                
-            PropertyHelper.setValueDouble(oldValue, prop);
-                context.restoreStateFromCachedModel();  
-            } catch (IOException ex) {
-                ErrorDialog.displayExceptionDialog(ex);
-        }
+                context.restoreStateFromCachedModel();
+            } catch (IOException iae) {
+                try {
+                    new JOptionPane(iae.getMessage(),
+                            JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
+                    PropertyHelper.setValueDouble(oldValue, prop);
+                    context.restoreStateFromCachedModel();
+                } catch (IOException ex) {
+                    ErrorDialog.displayExceptionDialog(ex);
+                }
+            }
         }
         handlePropertyChangeCommon();
         
@@ -617,27 +625,37 @@ public class PropertyEditorAdaptor {
     }
 
     private void handlePropertyChange(final Vec3 oldValue, final Vec3 v, boolean supportUndo) {
-        if (supportUndo) context.cacheModelAndState();
-        for (int i = 0; i < 3; i++) {
-            PropertyHelper.setValueVec3(v.get(i), prop , i);
-        }
-
-        try {
-            if (supportUndo) context.restoreStateFromCachedModel();
-        } catch (IOException iae) {
-            try {
-                new JOptionPane(iae.getMessage(),
-                        JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
-
+        if (!affectsState) {
             for (int i = 0; i < 3; i++) {
-                    PropertyHelper.setValueVec3(oldValue.get(i), prop, i);
+                PropertyHelper.setValueVec3(v.get(i), prop, i);
             }
-                if (supportUndo) context.restoreStateFromCachedModel();
-            } catch (IOException ex) {
-                ErrorDialog.displayExceptionDialog(ex);
+        } else {
+            if (supportUndo) {
+                context.cacheModelAndState();
+            }
+            for (int i = 0; i < 3; i++) {
+                PropertyHelper.setValueVec3(v.get(i), prop, i);
+            }
+
+            try {
+                if (supportUndo) {
+                    context.restoreStateFromCachedModel();
+                }
+            } catch (IOException iae) {
+                try {
+                    new JOptionPane(iae.getMessage(),
+                            JOptionPane.ERROR_MESSAGE).createDialog(null, "Error").setVisible(true);
+                    for (int i = 0; i < 3; i++) {
+                        PropertyHelper.setValueVec3(oldValue.get(i), prop, i);
+                    }
+                    if (supportUndo) {
+                        context.restoreStateFromCachedModel();
+                    }
+                } catch (IOException ex) {
+                    ErrorDialog.displayExceptionDialog(ex);
+                }
+            }
         }
-        }
-        
         handlePropertyChangeCommon();
   
         if (supportUndo) {


### PR DESCRIPTION
Use flag to speed up Appearance change without save/restore state overhead.

Fixes issue #446

### Brief summary of changes
Add a flag affectsState to PropertyEditor(s) that's true by default but is turned off for Appearance edits

### Testing I've completed
Changes in opacity and color are significantly faster and are undoable

### CHANGELOG.md 

- no need to update because all changes are internal