### PR TITLE
Fix wrapCylinder quadrant visualization

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
@@ -384,8 +384,12 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
             dg_json.put("thetaLength", Math.PI);
             if (quadrants.equalsIgnoreCase("-y"))
                 dg_json.put("thetaStart", -0.5*Math.PI);
-            else
+            else if (quadrants.equalsIgnoreCase("y"))
                 dg_json.put("thetaStart", 0.5*Math.PI);
+            else if (quadrants.equalsIgnoreCase("x"))
+                dg_json.put("thetaStart", 0);
+            else
+                dg_json.put("thetaStart", Math.PI);
         }
         return dg_json;
     }

--- a/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
@@ -388,7 +388,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
                 dg_json.put("thetaStart", 0.5*Math.PI);
             else if (quadrants.equalsIgnoreCase("x"))
                 dg_json.put("thetaStart", 0);
-            else
+            else if (quadrants.equalsIgnoreCase("-x"))
                 dg_json.put("thetaStart", Math.PI);
         }
         return dg_json;


### PR DESCRIPTION
Fixes issue #691

### Brief summary of changes
Layer that communicates wrapObjects to visualizer was not handling all quadrants specifications properly

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because bugfix