### PR TITLE
Make intermediate pathpoints created by wrapping invisible 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1444,7 +1444,7 @@ public class ModelVisualizationJson extends JSONObject {
         for (int i = 0; i < count; i++) {
             double ratio = (1.0 + i) / (count + 1.0);
             Vec3 location = computePointLocationFromNeighbors(lastPathPoint, mapBodyIndicesToFrames.get(0), currentPathPoint, ratio);
-            JSONObject bpptInBodyJson =createPathPointObjectJson(null, "", false, location, matuuid.toString(), true);
+            JSONObject bpptInBodyJson =createPathPointObjectJson(null, "", false, location, matuuid.toString(), false);
             UUID ppt_uuid = UUID.fromString((String) bpptInBodyJson.get("uuid"));
             computedPathPoints.put(ppt_uuid, new ComputedPathPointInfo(lastPathPoint, currentPathPoint, ratio));
             children.add(bpptInBodyJson);


### PR DESCRIPTION
These points are not user editable and cause artifacts

Fixes issue #691

### Brief summary of changes
Turn off Visible flag for intermediate/made-up path points

### Testing I've completed
Loaded models with wrapping, saw no intermediate pathpoints in wireframe mode.

### CHANGELOG.md (choose one)

- no need to update because bugfix
