### PR TITLE
Run vcredist_x64.exe in NSIS installer.

### DIFF
--- a/Gui/opensim/CMakeLists.txt
+++ b/Gui/opensim/CMakeLists.txt
@@ -23,8 +23,19 @@ add_custom_target(CopyOpenSimCore ALL
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                   COMMENT "Copy opensim-core Java Bindings to GUI.")
 if (WIN32)
+    # InstallRequiredSystemLibraries defines MSVC_REDIST_DIR,
+    # which is not really intended for use outside of 
+    # InstallRequiredSystemLibraries, but it's the best mechanism
+    # we have for now.
+    # https://docs.microsoft.com/en-us/cpp/ide/deployment-in-visual-cpp
+    # https://gitlab.kitware.com/cmake/cmake/issues/17725
+    include(InstallRequiredSystemLibraries)
+    # TODO: We only support 64-bit now. If building for 32-bit, must
+    # use vcredist_x86.exe (could use CMAKE_MSVC_ARCH).
+    set(MSVC_REDIST_EXE "${MSVC_REDIST_DIR}/vcredist_x64.exe")
+
     add_custom_target(PrepareInstaller ALL
-                  COMMAND ${Ant_EXECUTABLE} copy-installer-files -Dapi.dir="${OpenSim_ROOT_DIR}"
+                  COMMAND ${Ant_EXECUTABLE} copy-installer-files -Dapi.dir="${OpenSim_ROOT_DIR}" -Dmsvc.redist.exe="${MSVC_REDIST_EXE}"
                   ${ANT_ARGS}
                   DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/build.xml"
                   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -68,6 +79,7 @@ add_custom_target(CopyModels ALL
                   COMMENT "Copy models and examples-to installer folder.")
 add_dependencies(CopyModels opensim-models)
 endif()
+
 
 if (APPLE)
     if (OpenSim_FOUND)

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -109,7 +109,14 @@
                 file="${installer-files.dir}/make_installer.nsi" />
         <replace file="${opensim.dist.dir}/../make_installer.nsi" value="${app.version}">
             <replacefilter token="@VERSION@" />
-        </replace>        
+        </replace>
+        
+        <!-- Copy the Visual C++ redistributable installer, 
+             which the NSIS installer will run during installation.
+             https://docs.microsoft.com/en-us/cpp/ide/deployment-in-visual-cpp -->
+        <copy todir="${opensim.dist.dir}/bin/"
+            file="${msvc.redist.exe}" />
+
     </target>
     <target name="copy-jre" description="Copy JRE to installer">
         <copy todir="${opensim.dist.dir}/jdk/jre">

--- a/Gui/opensim/installer_files/Windows/make_installer.nsi
+++ b/Gui/opensim/installer_files/Windows/make_installer.nsi
@@ -81,6 +81,10 @@ Section "OpenSim Application" SecMain
 
   ;Create uninstaller
   WriteUninstaller "$INSTDIR\Uninstall.exe"
+  
+  ;Run the Visual C++ redistributable installer.
+  ;https://docs.microsoft.com/en-us/cpp/ide/deployment-in-visual-cpp
+  ExecWait '"$INSTDIR\bin\vcredist_x64.exe"'
 
 SectionEnd
 

--- a/Gui/opensim/installer_files/Windows/make_installer.nsi
+++ b/Gui/opensim/installer_files/Windows/make_installer.nsi
@@ -51,10 +51,9 @@
   !insertmacro MUI_PAGE_WELCOME
 
   !insertmacro MUI_PAGE_LICENSE "opensim\LICENSE.txt"
-  !insertmacro MUI_PAGE_COMPONENTS
+  ;We have only 1 component; no need to prompt.
+  ;!insertmacro MUI_PAGE_COMPONENTS
   !insertmacro MUI_PAGE_DIRECTORY
-  !insertmacro MUI_PAGE_INSTFILES
-
   !insertmacro MUI_PAGE_INSTFILES
   !insertmacro MUI_PAGE_FINISH
 
@@ -84,21 +83,22 @@ Section "OpenSim Application" SecMain
   
   ;Run the Visual C++ redistributable installer.
   ;https://docs.microsoft.com/en-us/cpp/ide/deployment-in-visual-cpp
-  ExecWait '"$INSTDIR\bin\vcredist_x64.exe"'
+  ExecWait '"$INSTDIR\bin\vcredist_x64.exe" /quiet /norestart'
 
 SectionEnd
 
 ;--------------------------------
 ;Descriptions
+  ;Commented out this section because MUI_PAGE_COMPONENTS
+  ;above is commented out.
+  
+  ;;Language strings
+  ;LangString DESC_SecMain ${LANG_ENGLISH} "Install OpenSim Application."
 
-  ;Language strings
-  LangString DESC_SecMain ${LANG_ENGLISH} "Install OpenSim Application."
-
-  ;Assign language strings to sections
-  !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
-    !insertmacro MUI_DESCRIPTION_TEXT ${SecMain} $(DESC_SecMain)
-  !insertmacro MUI_FUNCTION_DESCRIPTION_END
-
+  ;;Assign language strings to sections
+  ;!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+  ;  !insertmacro MUI_DESCRIPTION_TEXT ${SecMain} $(DESC_SecMain)
+  ;!insertmacro MUI_FUNCTION_DESCRIPTION_END
 ;--------------------------------
 ;Uninstaller Section
 


### PR DESCRIPTION
Fixes #744, #807 

### Brief summary of changes

- Use CMake to find the location of the Visual C++ redistributable installer.
- Use Ant to place the redistributable installer within OpenSim's installation.
- Use NSIS to run the redistributable installer during the OpenSim installation.

### Testing I've completed

- Built the GUI and the installer locally and ensured that the Visual C++ redistributable installer runs when running the OpenSim installer.

### CHANGELOG.md (choose one)

- no need to update because...this restores previous behavior.


### TODO

- ~The NSIS installer seems to install everything twice. All files are unzipped twice, and the Visual C++ redistributable is invoked twice. I tried googling to see if this is a common issue with NSIS but I didn't find anything. @aymanhab, any ideas?~ EDIT: This is now fixed.
