### PR TITLE
Close model with unsaved changes saves upon user confirmation

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/actions/FileCloseAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/actions/FileCloseAction.java
@@ -102,7 +102,10 @@ public static boolean closeModel(Model model) {
                     else if (cmd.equalsIgnoreCase("Discard")){
                         OpenSimDB.setCurrentCloseModelDefaultAction(CloseModelDefaultAction.DISCARD);                       
                     }
-                 }               
+                 } // Even if user doesn't want to remember decision, save Model
+                else if (cmd.equalsIgnoreCase("Save")){
+                    FileSaveModelAction.saveOrSaveAsModel(model, false);
+                }
             }
         });
        confirmDialog.setClosingOptions(null);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/MarkerAdapter.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/MarkerAdapter.java
@@ -40,6 +40,7 @@ import org.opensim.modeling.Vec3;
 import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.ObjectsRenamedEvent;
+import org.opensim.view.SingleModelGuiElements;
 import org.opensim.view.SingleModelVisuals;
 import org.opensim.view.pub.OpenSimDB;
 import org.opensim.view.pub.ViewDB;
@@ -94,6 +95,9 @@ public class MarkerAdapter  {
             };
             ExplorerTopComponent.addUndoableEdit(auEdit);
         }
+        SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);
+        guiElem.setUnsavedChangesFlag(true);
+
     }
 
     private void updateDisplay() {
@@ -141,6 +145,8 @@ public class MarkerAdapter  {
             };
             ExplorerTopComponent.addUndoableEdit(auEdit);            
         }
+        SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);
+        guiElem.setUnsavedChangesFlag(true);
     }
     
     public void setName(String newName){
@@ -176,6 +182,8 @@ public class MarkerAdapter  {
         ObjectsRenamedEvent evnt = new ObjectsRenamedEvent(this, model, objs);
         OpenSimDB.getInstance().setChanged();
         OpenSimDB.getInstance().notifyObservers(evnt);
+        SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);
+        guiElem.setUnsavedChangesFlag(true);
     }
 
 }


### PR DESCRIPTION
Also make sure all Marker edits are recorded as unsaved Changes

Fixes issue #748

### Brief summary of changes
Explicit save was working properly after edit, close after edit was prompting to save but not actually saving (bug was in 3.3 as well). Fixed to actually save.

### Testing I've completed
Marker edit, close, prompted to save, saved, file has changes and new timestamp.

### CHANGELOG.md (choose one)

- not sure since this is a possibly important bugfix from 3.3
