### PR TITLE
Marker edit frame

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1224,10 +1224,10 @@ public class ModelVisualizationJson extends JSONObject {
        return topJson;
     }
 
-    static public JSONObject createSetPositionCommand(UUID pathpointUuid, Vec3 location) {
+    static public JSONObject createSetPositionCommand(UUID objectUuid, Vec3 location) {
         JSONObject nextpptPositionCommand = new JSONObject();
         nextpptPositionCommand.put("type", "SetPositionCommand");
-        nextpptPositionCommand.put("objectUuid", pathpointUuid.toString());
+        nextpptPositionCommand.put("objectUuid", objectUuid.toString());
         JSONArray locationArray = new JSONArray();
         JSONArray oldLocationArray = new JSONArray();
         for (int p =0; p <3; p++){
@@ -1503,7 +1503,7 @@ public class ModelVisualizationJson extends JSONObject {
                 JSONObject moveOneObject = CommandComposerThreejs.createMoveObjectByUUIDCommandJson(uuids.get(i), parentUUID);
                 commands.add(moveOneObject);
                 // May need to update location as well
-                JSONObject translateOneObject = CommandComposerThreejs.createTranslateObjectCommandJson(dg.getTransform().T(), uuids.get(i));
+                JSONObject translateOneObject = createSetPositionCommand(uuids.get(i), dg.getTransform().T());
                 commands.add(translateOneObject);
             }
             msgMulti.put("cmds", commands);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneMarkerNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneMarkerNode.java
@@ -23,6 +23,7 @@
 package org.opensim.view.nodes;
 
 import java.awt.Image;
+import java.beans.PropertyEditorSupport;
 import java.net.URL;
 import java.util.List;
 import java.util.ResourceBundle;
@@ -35,12 +36,20 @@ import org.openide.nodes.PropertySupport.Reflection;
 import org.openide.nodes.Sheet;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
+import org.opensim.modeling.AbstractSocket;
+import org.opensim.modeling.Component;
+import org.opensim.modeling.Frame;
 import org.opensim.modeling.Marker;
 import org.opensim.modeling.Model;
+import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.OpenSimObject;
+import org.opensim.modeling.PhysicalFrame;
+import org.opensim.threejs.ModelVisualizationJson;
 import org.opensim.view.editors.BodyNameEditor;
 import org.opensim.view.markerEditor.OneMarkerDeleteAction;
 import org.opensim.view.nodes.OpenSimObjectNode.displayOption;
+import org.opensim.view.pub.OpenSimDB;
+import org.opensim.view.pub.ViewDB;
 
 /** Node class to wrap AbstractMarker objects */
 public class OneMarkerNode extends OneComponentNode{
@@ -120,11 +129,42 @@ public class OneMarkerNode extends OneComponentNode{
             locationNodeProp.setName("location");
             locationNodeProp.setShortDescription(getPropertyComment("location"));
             set.put(locationNodeProp);
-   
+            // Also replace seocket so we can fix frame/location
+            Sheet.Set setSockets = sheet.get(Sheet.EXPERT);
+            setSockets.remove("PhysicalFrame:parent_frame");
+            AbstractSocket sock = obj.getSocket("parent_frame");
+            String connecteeType = sock.getConnecteeTypeName();
+            String connectionName = sock.getName();
+            
+            PropertySupport.Reflection nextNodePropFrame = 
+                    new PropertySupport.Reflection(this,
+                    String.class,
+                    "getConnectedToFrame",
+                    "setConnectedToFrame");
+            nextNodePropFrame.setValue("canEditAsText", Boolean.TRUE);
+            nextNodePropFrame.setValue("suppressCustomEditor", Boolean.TRUE);
+            nextNodePropFrame.setName(connecteeType + ":" + connectionName);
+            PropertyEditorSupport editor = EditorRegistry.getEditor(connecteeType);
+            if (editor != null)
+                nextNodePropFrame.setPropertyEditorClass(editor.getClass());
+            setSockets.put(nextNodePropFrame);
+           
         } catch (NoSuchMethodException ex) {
             Exceptions.printStackTrace(ex);
         }
 
         return sheet;
+    }
+    public String getConnectedToFrame() {
+        Marker obj = Marker.safeDownCast(getOpenSimObject());
+        return obj.getParentFrame().getName();
+    }
+    public void setConnectedToFrame(String newParentFrame) {
+        Marker obj = Marker.safeDownCast(getOpenSimObject());
+        Model model = getModelForNode();
+        OpenSimContext context = OpenSimDB.getInstance().getContext(model);
+        Component comp=model.getComponent(newParentFrame);
+        obj.changeFramePreserveLocation(context.getCurrentStateRef(), PhysicalFrame.safeDownCast(comp));
+        ViewDB.getInstance().updateComponentVisuals(model, obj, true);
     }
 }

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneMarkerNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneMarkerNode.java
@@ -165,8 +165,9 @@ public class OneMarkerNode extends OneComponentNode{
         Model model = getModelForNode();
         OpenSimContext context = OpenSimDB.getInstance().getContext(model);
         Component comp=model.getComponent(newParentFrame);
-        // 
+        //System.out.println(obj.dump());
         obj.changeFramePreserveLocation(context.getCurrentStateRef(), PhysicalFrame.safeDownCast(comp));
+        //System.out.println(obj.dump());
         ViewDB.getInstance().updateComponentVisuals(model, obj, true);
         // Mark model dirty
         SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneMarkerNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneMarkerNode.java
@@ -45,6 +45,7 @@ import org.opensim.modeling.OpenSimContext;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PhysicalFrame;
 import org.opensim.threejs.ModelVisualizationJson;
+import org.opensim.view.SingleModelGuiElements;
 import org.opensim.view.editors.BodyNameEditor;
 import org.opensim.view.markerEditor.OneMarkerDeleteAction;
 import org.opensim.view.nodes.OpenSimObjectNode.displayOption;
@@ -164,7 +165,12 @@ public class OneMarkerNode extends OneComponentNode{
         Model model = getModelForNode();
         OpenSimContext context = OpenSimDB.getInstance().getContext(model);
         Component comp=model.getComponent(newParentFrame);
+        // 
         obj.changeFramePreserveLocation(context.getCurrentStateRef(), PhysicalFrame.safeDownCast(comp));
         ViewDB.getInstance().updateComponentVisuals(model, obj, true);
+        // Mark model dirty
+        SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);
+        guiElem.setUnsavedChangesFlag(true);
+
     }
 }


### PR DESCRIPTION
Fixes issue #506 

### Brief summary of changes
Take over Frame editing to use the method that changes frame while preserving location in space
### Testing I've completed
Loaded leg69, did marker edits markers stayed in place or moved very slightly

### CHANGELOG.md (choose one)

- no need to update because same behavior as 3.3
