### PR TITLE
Live animation of RRA was broken

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -527,6 +527,15 @@ public class MotionDisplayer {
       int newIndex = simmMotionData.getStateIndex(columnName);
       if (newIndex ==-1)
           return 0;
+       // in live RRA and other situations where we get 4.0 style state-pathnames as columns, use them
+       if (stateNames != null && stateNames.findIndex(columnName) != -1) {
+           int stateIndex = stateNames.findIndex(columnName);  // includes time so 0 is time
+           int stateIndexMinusTime = stateIndex - 1;
+           mapIndicesToObjectTypes.put(columnIndex, ObjectTypesInMotionFiles.State);
+           mapIndicesToObjects.put(columnIndex, new Integer(stateIndexMinusTime));
+           canonicalStateNames.add(columnName);
+           return 1;
+       }
       String canonicalCcolumnName = columnName.replace('.', '/');
       CoordinateSet coords = model.getCoordinateSet();
       for (int i = 0; i<coords.getSize(); i++){


### PR DESCRIPTION
 This was due to mishandling of column names that are full path-names. Fixed. This has no effect on loading motions from files.

Fixes issue #794

### Brief summary of changes
Added check for columns that are fullPathNames while rendering live motion.

### Testing I've completed
Ran RRA on gait2354 and the model animated as in 3.3

### CHANGELOG.md (choose one)

- no need to update because bugfix
