### PR TITLE
Avoid safeDownCast before calling assign to keep RTTI info intact

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
@@ -97,7 +97,7 @@ public class OpenSimGeometryPathEditorPanel extends javax.swing.JPanel {
    private final OpenSimContext openSimContext;
    private final Model currentModel;
    private OpenSimObject objectWithPath = null; // the actuator that is currently shown in the Muscle Editor window
-   private final GeometryPath savePath;
+   private final OpenSimObject savePath;
    private final GeometryPath currentPath;
    private JButton RestoreButton;
    public enum EditOperation { 
@@ -106,7 +106,7 @@ public class OpenSimGeometryPathEditorPanel extends javax.swing.JPanel {
    /** Creates new form OpenSimGeometryPathEditorPanel */
     public OpenSimGeometryPathEditorPanel(GeometryPath pathToEdit) {
         currentModel = pathToEdit.getModel();
-        savePath = GeometryPath.safeDownCast(pathToEdit.clone());
+        savePath = pathToEdit.clone();
         currentPath = pathToEdit;
         openSimContext = OpenSimDB.getInstance().getContext(currentModel);
         initComponents();


### PR DESCRIPTION
Fixes issue #817 Partially
### Brief summary of changes
Avoid safedowncast before calling assign to keep RTTI info intact

### Testing I've completed
Made edits, then hit restore. Didn't get exception but the visuals don't update yet.

### CHANGELOG.md (choose one)

- no need to update because bugfix
