### PR TITLE
Animation speedup

### DIFF
--- a/Gui/opensim/coordinateViewer/src/org/opensim/coordinateviewer/CoordinateSliderWithBox.java
+++ b/Gui/opensim/coordinateViewer/src/org/opensim/coordinateviewer/CoordinateSliderWithBox.java
@@ -438,7 +438,7 @@ private double getSpeedFromTextboxInternalUnits() {
           if (updateDisplay) {
              // Use renderAll rather than repaintAll for greater responsiveness in 3d viewer
              //ViewDB.getInstance().updateModelDisplay(OpenSimDB.getInstance().getCurrentModel());
-             ViewDB.getInstance().updateModelDisplayNoRepaint(OpenSimDB.getInstance().getCurrentModel(), false);
+             ViewDB.getInstance().updateModelDisplayNoRepaint(OpenSimDB.getInstance().getCurrentModel(), false, true);
              ViewDB.getInstance().renderAll();
              Vector<OpenSimObject> objs = new Vector<OpenSimObject>(1);
              objs.add(coord);

--- a/Gui/opensim/scriptingShell/src/org/opensim/customGui/CoordinateAdaptor.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/customGui/CoordinateAdaptor.java
@@ -69,7 +69,7 @@ public class CoordinateAdaptor extends DblBoundedRangeModel {
         coord.setDefaultValue(value);
          // Use renderAll rather than repaintAll for greater responsiveness in 3d viewer
          Model mdl=OpenSimDB.getInstance().getCurrentModel();
-         ViewDB.getInstance().updateModelDisplayNoRepaint(mdl, false);
+         ViewDB.getInstance().updateModelDisplayNoRepaint(mdl, false, true);
          ViewDB.getInstance().renderAll();
          Vector<OpenSimObject> objs = new Vector<OpenSimObject>(1);
          objs.add(coord);

--- a/Gui/opensim/scriptingShell/src/org/opensim/customGui/DynamicPropertyAdaptor.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/customGui/DynamicPropertyAdaptor.java
@@ -85,7 +85,7 @@ public class DynamicPropertyAdaptor extends DblBoundedRangeModel {
         context.realizePosition();
          // Use renderAll rather than repaintAll for greater responsiveness in 3d viewer
          Model mdl=OpenSimDB.getInstance().getCurrentModel();
-         ViewDB.getInstance().updateModelDisplayNoRepaint(mdl, false);
+         ViewDB.getInstance().updateModelDisplayNoRepaint(mdl, false, true);
          ViewDB.getInstance().renderAll();
          Vector<OpenSimObject> objs = new Vector<OpenSimObject>(1);
          objs.add(dObject);

--- a/Gui/opensim/scriptingShell/src/org/opensim/customGui/DynamicPropertyComponentAdaptor.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/customGui/DynamicPropertyComponentAdaptor.java
@@ -88,7 +88,7 @@ public class DynamicPropertyComponentAdaptor extends DblBoundedRangeModel {
         context.realizePosition();
          // Use renderAll rather than repaintAll for greater responsiveness in 3d viewer
          Model mdl=OpenSimDB.getInstance().getCurrentModel();
-         ViewDB.getInstance().updateModelDisplayNoRepaint(mdl, false);
+         ViewDB.getInstance().updateModelDisplayNoRepaint(mdl, false, true);
          ViewDB.getInstance().renderAll();
          Vector<OpenSimObject> objs = new Vector<OpenSimObject>(1);
          objs.add(dObject);

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -549,14 +549,16 @@ public class ModelVisualizationJson extends JSONObject {
     //============
     // PER FRAME
     //============
-    public JSONObject createFrameMessageJson(boolean colorByState) {
+    public JSONObject createFrameMessageJson(boolean colorByState, boolean forceRender) {
         JSONObject msg = new JSONObject();
         msg.put("Op", "Frame");
         JSONArray bodyTransforms_json = new JSONArray();
         msg.put("Transforms", bodyTransforms_json);
         JSONArray geompaths_json = new JSONArray();
         msg.put("paths", geompaths_json);
-        
+        msg.put("time", state.getTime());
+        msg.put("model", modelUUID.toString());
+        msg.put("render", forceRender);
         appendToFrame(bodyTransforms_json, colorByState, geompaths_json);
         return msg;
     }

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -551,11 +551,18 @@ public class ModelVisualizationJson extends JSONObject {
     //============
     public JSONObject createFrameMessageJson(boolean colorByState) {
         JSONObject msg = new JSONObject();
-        Iterator<Integer> bodyIdIter = mapBodyIndicesToFrames.keySet().iterator();
         msg.put("Op", "Frame");
         JSONArray bodyTransforms_json = new JSONArray();
         msg.put("Transforms", bodyTransforms_json);
+        JSONArray geompaths_json = new JSONArray();
+        msg.put("paths", geompaths_json);
+        
+        appendToFrame(bodyTransforms_json, colorByState, geompaths_json);
+        return msg;
+    }
 
+    public void appendToFrame(JSONArray bodyTransforms_json, boolean colorByState, JSONArray geompaths_json) {
+        Iterator<Integer> bodyIdIter = mapBodyIndicesToFrames.keySet().iterator();
         if (ready) { // Avoid trying to send a frame before Json is completely populated
             while (bodyIdIter.hasNext()) {
                 int bodyId = bodyIdIter.next();
@@ -591,16 +598,16 @@ public class ModelVisualizationJson extends JSONObject {
             };
             for (AbstractPathPoint app: proxyPathPoints.keySet()){
                 //System.out.println("Process Conditional Path point "+app.getName());
-                  if (!app.isActive(state)){
+                if (!app.isActive(state)){
                     ComputedPathPointInfo proxyPointInfo = proxyPathPoints.get(app);
                     //System.out.println("Use proxy "+proxyPoint.getName());
                     Vec3 loc = computePointLocationFromNeighbors(proxyPointInfo.pt1, app.getBody(), proxyPointInfo.pt2, proxyPointInfo.ratio);
                     Transform localTransform = new Transform();
-                       localTransform.setP(loc);
-                       JSONObject pathpointXform_json = new JSONObject();
-                       pathpointXform_json.put("uuid", mapComponentToUUID.get(app).get(0).toString());
-                       pathpointXform_json.put("matrix", JSONUtilities.createMatrixFromTransform(localTransform, new Vec3(1., 1., 1.), visScaleFactor));
-                       bodyTransforms_json.add(pathpointXform_json);
+                    localTransform.setP(loc);
+                    JSONObject pathpointXform_json = new JSONObject();
+                    pathpointXform_json.put("uuid", mapComponentToUUID.get(app).get(0).toString());
+                    pathpointXform_json.put("matrix", JSONUtilities.createMatrixFromTransform(localTransform, new Vec3(1., 1., 1.), visScaleFactor));
+                    bodyTransforms_json.add(pathpointXform_json);
                 }
                 else {
                     //System.out.println("Pathpoint " + app.getName() + " active");
@@ -611,7 +618,7 @@ public class ModelVisualizationJson extends JSONObject {
                     pathpointXform_json.put("uuid", mapComponentToUUID.get(app).get(0).toString());
                     pathpointXform_json.put("matrix", JSONUtilities.createMatrixFromTransform(localTransform, new Vec3(1., 1., 1.), visScaleFactor));
                     bodyTransforms_json.add(pathpointXform_json);
-                 } 
+                } 
             }
             PhysicalFrame ground = mapBodyIndicesToFrames.get(0);
             for (UUID computedPointUUID: computedPathPoints.keySet()){
@@ -631,9 +638,6 @@ public class ModelVisualizationJson extends JSONObject {
                     updatePathWithWrapping(path, bodyTransforms_json);
                 }
             }            // Computed points need recomputation
-            
-            JSONArray geompaths_json = new JSONArray();
-            msg.put("paths", geompaths_json);
 
             Set<GeometryPath> paths = pathList.keySet();
             Iterator<GeometryPath> pathIter = paths.iterator();
@@ -662,7 +666,6 @@ public class ModelVisualizationJson extends JSONObject {
                 nextMotionDisplayer.addMotionObjectsToFrame(bodyTransforms_json, geompaths_json);
             }
         }
-        return msg;
     }
         
      private void updatePathWithWrapping(GeometryPath path, JSONArray bodyTransforms) {

--- a/Gui/opensim/view/src/org/opensim/view/editors/DofFunctionEventListener.java
+++ b/Gui/opensim/view/src/org/opensim/view/editors/DofFunctionEventListener.java
@@ -73,7 +73,7 @@ public class DofFunctionEventListener implements FunctionEventListener {
             Function newFunction = fre.getReplacementFunction();
             if (Function.getCPtr(oldFunction) != Function.getCPtr(newFunction)) {
                openSimContext.replaceTransformAxisFunction(dof, newFunction);
-               ViewDB.getInstance().updateModelDisplayNoRepaint(model, false);
+               ViewDB.getInstance().updateModelDisplayNoRepaint(model, false, true);
                ViewDB.getInstance().renderAll();
                guiElem.setUnsavedChangesFlag(true);
             }
@@ -85,7 +85,7 @@ public class DofFunctionEventListener implements FunctionEventListener {
                String coordName = dof.getCoordinateNamesInArray().getitem(0);
                Coordinate coord = dof.getJoint().get_coordinates(0);
                openSimContext.setValue(coord, openSimContext.getValue(coord));
-               ViewDB.getInstance().updateModelDisplayNoRepaint(model, false);
+               ViewDB.getInstance().updateModelDisplayNoRepaint(model, false, true);
                ViewDB.getInstance().renderAll();
                guiElem.setUnsavedChangesFlag(true);
             }

--- a/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/JavaMotionDisplayerCallback.java
@@ -180,7 +180,7 @@ public class JavaMotionDisplayerCallback extends AnalysisWrapperWithTimer {
                       motionDisplayer.applyFrameToModel(getStorage().getSize()-1); 
                   
                   //ViewDB.getInstance().updateModelDisplay(getModelForDisplay());  // Faster? than the next few indented lines
-                    ViewDB.getInstance().updateModelDisplayNoRepaint(getModelForDisplay(), true);
+                    ViewDB.getInstance().updateModelDisplayNoRepaint(getModelForDisplay(), true, true);
                     ////ViewDB.getInstance().renderAll(); // Render now (if want to do it later, use repaintAll()) -- may slow things down too much
                     //ViewDB.getInstance().repaintAll();
                   lastRenderTime = currentRealTime; 

--- a/Gui/opensim/view/src/org/opensim/view/motions/MasterMotionModel.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MasterMotionModel.java
@@ -80,8 +80,6 @@ public class MasterMotionModel {
          Model dModel = disp.getModel();
          ViewDB.getInstance().updateModelDisplayNoRepaint(dModel, true);
       }
-      //ViewDB.getInstance().repaintAll();
-      ViewDB.getInstance().renderAll();
       MotionsDB motionsDB = MotionsDB.getInstance();
       motionsDB.reportTimeChange(getCurrentTime());
    }

--- a/Gui/opensim/view/src/org/opensim/view/motions/MasterMotionModel.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MasterMotionModel.java
@@ -78,7 +78,8 @@ public class MasterMotionModel {
       for(int i=0; i<displayers.size(); i++) {
          MotionDisplayer disp = displayers.get(i);
          Model dModel = disp.getModel();
-         ViewDB.getInstance().updateModelDisplayNoRepaint(dModel, true);
+         // Force rendering only for the last displayer to avoid multiple render calls per frame
+         ViewDB.getInstance().updateModelDisplayNoRepaint(dModel, true, i==(displayers.size()-1));
       }
       MotionsDB motionsDB = MotionsDB.getInstance();
       motionsDB.reportTimeChange(getCurrentTime());

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Observable;
 import java.util.Observer;
+import java.util.prefs.Preferences;
 import javax.swing.*;
 import javax.swing.border.TitledBorder;
 import javax.swing.event.ChangeEvent;
@@ -46,6 +47,7 @@ import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.Storage;
+import org.opensim.utils.TheApp;
 import org.opensim.view.ExplorerTopComponent;
 import org.opensim.view.motions.MotionEvent.Operation;
 import org.opensim.view.ObjectsRenamedEvent;
@@ -535,6 +537,7 @@ public class MotionControlJPanel extends javax.swing.JToolBar
               // reset motion if at end already
               getMasterMotion().setTime(getMasterMotion().getEndTime());
           }
+          int timerRate = ViewDB.getInstance().getFrameTime();
           animationTimer = new Timer(timerRate, new RealTimePlayActionListener(-1));
           animationTimer.start();
           // correct selected modes
@@ -577,6 +580,8 @@ public class MotionControlJPanel extends javax.swing.JToolBar
               getMasterMotion().setTime(getMasterMotion().getStartTime());
           }
           ViewDB.getInstance().startAnimation();
+          int timerRate = ViewDB.getInstance().getFrameTime();
+
           animationTimer = new Timer(timerRate, new RealTimePlayActionListener(1));
           animationTimer.start();
           // correct selected modes

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -114,7 +114,7 @@ public final class ViewDB extends Observable implements Observer, LookupListener
    private static WebSocketDB websocketdb;
    private static JSONObject jsondb;
    private SelectedObject selectInVisualizer = null;
-   
+   private static int frameRate = 30;
    /* Following block handles buffering Appearance changes so they're sent once
     * as a message to visualizer.
    */
@@ -162,6 +162,14 @@ public final class ViewDB extends Observable implements Observer, LookupListener
              websocketdb.broadcastMessageJson(msg, null);
         }
 
+    }
+
+    public int getFrameTime() {
+        String saved = Preferences.userNodeForPackage(TheApp.class).get("FrameRate", String.valueOf(frameRate));
+        if (saved!= null)
+            frameRate = Integer.parseInt(saved);
+        Preferences.userNodeForPackage(TheApp.class).put("FrameRate", String.valueOf(frameRate));
+        return frameRate; // 30 FPS default
     }
    
    class AppearanceChange {

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -2299,8 +2299,10 @@ public final class ViewDB extends Observable implements Observer, LookupListener
             if (msgType.equalsIgnoreCase("info")) {
                 if (jsonObject.get("renderTime")!=null){
                     double frameRenderTimeInMillis = JSONMessageHandler.convertObjectFromJsonToDouble(jsonObject.get("renderTime"));
-                    int frameRate = ((int) (frameRenderTimeInMillis/30.0))+30;
-                    Preferences.userNodeForPackage(TheApp.class).put("FrameRate", String.valueOf(frameRate));
+                    //System.out.println("renderTime"+frameRenderTimeInMillis);
+                    int frameRate = (int) (frameRenderTimeInMillis*1.5);
+                    if (frameRate > 30)
+                        Preferences.userNodeForPackage(TheApp.class).put("FrameRate", String.valueOf(frameRate));
                     return;
                 }
                 if (debugLevel > 1) {

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -1443,11 +1443,6 @@ public final class ViewDB extends Observable implements Observer, LookupListener
    }
    
    public void updateModelDisplayNoRepaint(Model aModel, boolean colorByState) {
-      if (isVtkGraphicsAvailable()){
-        lockDrawingSurfaces(true);
-        mapModelsToVisuals.get(aModel).updateModelDisplay(aModel);
-        lockDrawingSurfaces(false);
-      }
       if (websocketdb != null){
         ModelVisualizationJson cJson = mapModelsToJsons.get(aModel);
         websocketdb.broadcastMessageJson(cJson.createFrameMessageJson(colorByState), null);

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -140,7 +140,7 @@ public final class ViewDB extends Observable implements Observer, LookupListener
                 websocketdb.broadcastMessageJson(modelJson.updateComponentVisuals(mc, frame), null);
             }
             else // just send frame in case xforms change
-                websocketdb.broadcastMessageJson(currentJson.createFrameMessageJson(false), null);
+                websocketdb.broadcastMessageJson(currentJson.createFrameMessageJson(false, true), null);
         }
     }
     /*
@@ -1438,14 +1438,14 @@ public final class ViewDB extends Observable implements Observer, LookupListener
       }
       if (websocketdb != null && currentJson != null && applyAppearanceChange){
         // Make xforms JSON
-        websocketdb.broadcastMessageJson(currentJson.createFrameMessageJson(false), null);
+        websocketdb.broadcastMessageJson(currentJson.createFrameMessageJson(false, true), null);
       }
    }
    
-   public void updateModelDisplayNoRepaint(Model aModel, boolean colorByState) {
+   public void updateModelDisplayNoRepaint(Model aModel, boolean colorByState, boolean refresh) {
       if (websocketdb != null){
         ModelVisualizationJson cJson = mapModelsToJsons.get(aModel);
-        websocketdb.broadcastMessageJson(cJson.createFrameMessageJson(colorByState), null);
+        websocketdb.broadcastMessageJson(cJson.createFrameMessageJson(colorByState, refresh), null);
       }
    }
 
@@ -2297,6 +2297,12 @@ public final class ViewDB extends Observable implements Observer, LookupListener
         String msgType = (String)jsonObject.get("type");
         if (msgType != null) {
             if (msgType.equalsIgnoreCase("info")) {
+                if (jsonObject.get("renderTime")!=null){
+                    double frameRenderTimeInMillis = JSONMessageHandler.convertObjectFromJsonToDouble(jsonObject.get("renderTime"));
+                    int frameRate = ((int) (frameRenderTimeInMillis/30.0))+30;
+                    Preferences.userNodeForPackage(TheApp.class).put("FrameRate", String.valueOf(frameRate));
+                    return;
+                }
                 if (debugLevel > 1) {
                     String msg = "Rendered " + jsonObject.get("numFrames") + " frames in " + jsonObject.get("totalTime") + " ms.";
                     double rendertimeAverage = ((Double) jsonObject.get("totalTime")) / ((Long) jsonObject.get("numFrames"));

--- a/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
+++ b/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
@@ -78,6 +78,7 @@ public class WebSocketDB {
     
     public void broadcastMessageJson(JSONObject msg, VisWebSocket specificSocket)
     {
+         System.out.println("Broadcast:"+msg.get("Op"));
         if (specificSocket != null){
             specificSocket.sendVisualizerMessage(msg);
             return;

--- a/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
+++ b/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
@@ -78,7 +78,7 @@ public class WebSocketDB {
     
     public void broadcastMessageJson(JSONObject msg, VisWebSocket specificSocket)
     {
-         System.out.println("Broadcast:"+msg.get("Op"));
+        //System.out.println("Broadcast:"+msg.get("Op"));
         if (specificSocket != null){
             specificSocket.sendVisualizerMessage(msg);
             return;


### PR DESCRIPTION
Fixes issue #333 

### Brief summary of changes
Multiple optimizations to speed up synchronized motions in particular, regulate frameRate based on frame render time reported by visualizer, avoid extra refresh calls on visualizer side. Workaround messages being sent multiple times across the websocket. There's a complementary part to this fix on visualizer repo.

### Testing I've completed
Ran tutorials and models/motions in standard workflows

### CHANGELOG.md (choose one)

- no need to update because all these are internal optimizations
