### PR TITLE
Rearrange navigator nodes

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/GroundNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/GroundNode.java
@@ -58,7 +58,7 @@ public class GroundNode extends OneFrameNode{
          children.add(arrNodes);
          
       }
-      createFrameNodes(children);
+      OpenSimNodeHelper.createFrameNodes(children, comp);
       if(children.getNodesCount()==0) setChildren(Children.LEAF);      
       addDisplayOption(displayOption.Colorable);
       addDisplayOption(displayOption.Isolatable);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneBodyNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneBodyNode.java
@@ -74,7 +74,7 @@ public class OneBodyNode extends OneFrameNode{
          children.add(arrNodes);
          
       }
-      createFrameNodes(children);
+      OpenSimNodeHelper.createFrameNodes(children, comp);
       if(children.getNodesCount()==0) setChildren(Children.LEAF);      
       addDisplayOption(displayOption.Colorable);
       addDisplayOption(displayOption.Isolatable);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -143,13 +143,11 @@ public class OneFrameNode extends OneModelComponentNode {
     */
     protected void createFrameNodes(Children children) {
         // Find Frames and make nodes for them (PhysicalOffsetFrames)
-        ComponentsList descendents = frame.getModel().getComponentsList();
+        ComponentsList descendents = frame.getComponentsList();
         ComponentIterator compIter = descendents.begin();
         while (!compIter.equals(descendents.end())) {
             Frame frame = Frame.safeDownCast(compIter.__deref__());
-            if (Body.safeDownCast(frame)==null &&
-                    frame != null && !frame.equals(comp)
-                    && frame.findBaseFrame().equals(comp)) {
+            if (Body.safeDownCast(frame)==null && frame !=null) {
                 OneFrameNode node = new OneFrameNode(frame);
                 Node[] arrNodes = new Node[1];
                 arrNodes[0] = node;
@@ -179,7 +177,6 @@ public class OneFrameNode extends OneModelComponentNode {
     }
     
     public String getRotationString() {
-        Frame frame = Frame.safeDownCast(comp);
         PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);
         Transform transform = offsetFrame.getOffsetTransform();
         String rotationVec3AsString = transform.R().convertRotationToBodyFixedXYZ().toString();

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -139,23 +139,7 @@ public class OneFrameNode extends OneModelComponentNode {
         }
         return retActions;
     }
-    /* Utility function to create child nodes for descendent frames
-    */
-    protected void createFrameNodes(Children children) {
-        // Find Frames and make nodes for them (PhysicalOffsetFrames)
-        ComponentsList descendents = frame.getComponentsList();
-        ComponentIterator compIter = descendents.begin();
-        while (!compIter.equals(descendents.end())) {
-            Frame frame = Frame.safeDownCast(compIter.__deref__());
-            if (Body.safeDownCast(frame)==null && frame !=null) {
-                OneFrameNode node = new OneFrameNode(frame);
-                Node[] arrNodes = new Node[1];
-                arrNodes[0] = node;
-                children.add(arrNodes);
-            }
-            compIter.next();
-        }
-    }
+
     public String getTranslationString() {
         Frame frame = Frame.safeDownCast(comp);
         PhysicalOffsetFrame offsetFrame = PhysicalOffsetFrame.safeDownCast(frame);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneJointNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneJointNode.java
@@ -67,10 +67,11 @@ public class OneJointNode extends OneModelComponentNode {
                 TransformAxis ta = spt.getTransformAxis(i);
                 getChildren().add(new Node[]{new OneDofNode(ta)});
             }
-        } else {
+        } 
+        OpenSimNodeHelper.createFrameNodes(getChildren(), comp);
+        if (getChildren().getNodesCount()==0) {
             setChildren(Children.LEAF);
         }
-        OpenSimNodeHelper.createFrameNodes(getChildren(), comp);
     }
 
     public Image getIcon(int i) {

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneJointNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneJointNode.java
@@ -35,8 +35,12 @@ import javax.swing.Action;
 import javax.swing.ImageIcon;
 import org.openide.nodes.Children;
 import org.openide.nodes.Node;
+import org.opensim.modeling.Body;
 import org.opensim.modeling.Component;
+import org.opensim.modeling.ComponentIterator;
+import org.opensim.modeling.ComponentsList;
 import org.opensim.modeling.CustomJoint;
+import org.opensim.modeling.Frame;
 import org.opensim.modeling.Joint;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.SpatialTransform;
@@ -55,6 +59,7 @@ public class OneJointNode extends OneModelComponentNode {
         super(jnt);
         comp = Component.safeDownCast(jnt);
         Joint joint = Joint.safeDownCast(jnt);
+        
         CustomJoint cj = CustomJoint.safeDownCast(joint);
         if (cj != null) {
             SpatialTransform spt = cj.getSpatialTransform();
@@ -64,6 +69,24 @@ public class OneJointNode extends OneModelComponentNode {
             }
         } else {
             setChildren(Children.LEAF);
+        }
+        createFrameNodes(getChildren());
+    }
+    /* Utility function to create child nodes for descendent frames
+    */
+    protected void createFrameNodes(Children children) {
+        // Find Frames and make nodes for them (PhysicalOffsetFrames)
+        ComponentsList descendents = comp.getComponentsList();
+        ComponentIterator compIter = descendents.begin();
+        while (!compIter.equals(descendents.end())) {
+            Frame frame = Frame.safeDownCast(compIter.__deref__());
+            if (frame != null && Body.safeDownCast(frame)==null) {
+                OneFrameNode node = new OneFrameNode(frame);
+                Node[] arrNodes = new Node[1];
+                arrNodes[0] = node;
+                children.add(arrNodes);
+            }
+            compIter.next();
         }
     }
 

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneJointNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneJointNode.java
@@ -70,24 +70,7 @@ public class OneJointNode extends OneModelComponentNode {
         } else {
             setChildren(Children.LEAF);
         }
-        createFrameNodes(getChildren());
-    }
-    /* Utility function to create child nodes for descendent frames
-    */
-    protected void createFrameNodes(Children children) {
-        // Find Frames and make nodes for them (PhysicalOffsetFrames)
-        ComponentsList descendents = comp.getComponentsList();
-        ComponentIterator compIter = descendents.begin();
-        while (!compIter.equals(descendents.end())) {
-            Frame frame = Frame.safeDownCast(compIter.__deref__());
-            if (frame != null && Body.safeDownCast(frame)==null) {
-                OneFrameNode node = new OneFrameNode(frame);
-                Node[] arrNodes = new Node[1];
-                arrNodes[0] = node;
-                children.add(arrNodes);
-            }
-            compIter.next();
-        }
+        OpenSimNodeHelper.createFrameNodes(getChildren(), comp);
     }
 
     public Image getIcon(int i) {

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimNodeHelper.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimNodeHelper.java
@@ -1,0 +1,40 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.opensim.view.nodes;
+
+import org.openide.nodes.Children;
+import org.openide.nodes.Node;
+import org.opensim.modeling.Body;
+import org.opensim.modeling.ComponentIterator;
+import org.opensim.modeling.ComponentsList;
+import org.opensim.modeling.Component;
+import org.opensim.modeling.Frame;
+
+/**
+ * Utility class to help share node creating functions between OpenSimNode subclasses
+ * that do not have common ancestor. All methods are public static
+ * 
+ * @author Ayman
+ */
+public class OpenSimNodeHelper {
+   /* Utility function to create child nodes for descendent frames
+    */
+    static public void createFrameNodes(Children children, Component comp) {
+        // Find Frames and make nodes for them (PhysicalOffsetFrames)
+        ComponentsList descendents = comp.getComponentsList();
+        ComponentIterator compIter = descendents.begin();
+        while (!compIter.equals(descendents.end())) {
+            Frame frame = Frame.safeDownCast(compIter.__deref__());
+            if (Body.safeDownCast(frame)==null && frame !=null) {
+                OneFrameNode node = new OneFrameNode(frame);
+                Node[] arrNodes = new Node[1];
+                arrNodes[0] = node;
+                children.add(arrNodes);
+            }
+            compIter.next();
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #853

### Brief summary of changes
Frame nodes are now created under Ground, Body or Joint nodes based on ownership

### Testing I've completed
Rajagopal model now has no nodes with same name under femur_r, joints have their frame nodes underneath them.
### CHANGELOG.md (choose one)

- Need to document navigator layout once finalized
