### PR TITLE
If MarkerPlacer is invoked without scaling, use unscaled model.

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
@@ -343,6 +343,8 @@ public class ScaleToolModel extends Observable implements Observer {
          }
          
          if(getMarkerPlacerEnabled()) {
+             if (processedModelContext==null)
+                 processedModelContext = OpenSimDB.getInstance().createContext(unscaledModel, false);
             // Pass empty path as path to subject, since we already have the static trial as an absolute path
             if(!processedModelContext.processModelMarkerPlacer(scaleTool.getMarkerPlacer(), processedModel, "")) {
                result = false;


### PR DESCRIPTION
Fixes issue #537 

### Brief summary of changes
Code dating back to 3.3 didn't handle MarkerPlacement without Scaling first. The change here uses the unscaled model if Scaling was not requested.

### Testing I've completed
I was able to follow the steps in issue 537 without encountering an exception.

### CHANGELOG.md

- no need to update because it's a bugfix.
