### PR TITLE
Avoid syncing GUI with visualizer in response to info messages

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -378,6 +378,7 @@ public final class ViewDB extends Observable implements Observer, LookupListener
       //if (!isVtkGraphicsAvailable()) return;
       if (arg instanceof JSONObject){
           handleJson((JSONObject) arg);
+          return;
       }
       if (o instanceof VisWebSocket){
           // Sync. socket with current ViweDB


### PR DESCRIPTION
Fixes issue # 
Choppy playback at beginning of animation due to extra info messages from visualizer.

### Brief summary of changes
Minor optimization to avoid processsing info messages 

### Testing I've completed
Smoother animation playback at beginning

### CHANGELOG.md (choose one)

- no need to update because bugfix
