### PR TITLE
Restore opensim33 geomertypath behavior

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -237,7 +237,7 @@ public class ModelVisualizationJson extends JSONObject {
         
         UUID pathpointmat_uuid =mapGeometryPathToPathPointMaterialUUID.get(path);
         UUID pathmat_uuid = pathMaterials.get(path);
-        boolean pointsVisible = pathDisplayStatus.get(path);
+        boolean pointsVisible = true;//pathDisplayStatus.get(path);
         // Create plain Geometry with vertices at PathPoints it will have 0 vertices
         // but will be populated live in the visualizer from the Pathppoints
         JSONObject pathGeomJson = new JSONObject();
@@ -1561,7 +1561,7 @@ public class ModelVisualizationJson extends JSONObject {
         // Create viz for currentPoint
         int i=0;
         AbstractPathPoint firstPoint = pathPointSetNoWrap.get(i);
-        UUID pathpoint_uuid = addPathPointObjectToParent(firstPoint, pathpt_mat_uuid.toString(), false);
+        UUID pathpoint_uuid = addPathPointObjectToParent(firstPoint, pathpt_mat_uuid.toString(), visible);
         pathpointActive_jsonArr.add(true);
         addComponentToUUIDMap(firstPoint, pathpoint_uuid);
         pathpoint_jsonArr.add(pathpoint_uuid.toString());
@@ -1588,7 +1588,7 @@ public class ModelVisualizationJson extends JSONObject {
                 ConditionalPathPoint cpp = ConditionalPathPoint.safeDownCast(secondPoint);
                 //System.out.println("Not found in path, ppt:"+secondPoint.getName());
                 pathpoint_uuid = addComputedPathPointObjectToParent(ppointSetIndex, pathPointSetNoWrap, pathpt_mat_uuid.toString(), 
-                        false);
+                        visible);
                 pointAdded = true;
                 ArrayList<UUID> comp_uuids = new ArrayList<UUID>();
                 comp_uuids.add(pathpoint_uuid);
@@ -1637,7 +1637,7 @@ public class ModelVisualizationJson extends JSONObject {
             }
             // Create viz for secondPoint
             if (!pointAdded){
-                pathpoint_uuid = addPathPointObjectToParent(secondPoint, pathpt_mat_uuid.toString(), false);
+                pathpoint_uuid = addPathPointObjectToParent(secondPoint, pathpt_mat_uuid.toString(), visible);
                 pathpoint_jsonArr.add(pathpoint_uuid.toString());
                 pathpointActive_jsonArr.add(true);
                 addComponentToUUIDMap(secondPoint, pathpoint_uuid);
@@ -1673,7 +1673,7 @@ public class ModelVisualizationJson extends JSONObject {
         if (!visible){ // path-belly = cylinder
             obj_json.put("visible", false);
         }
-        pathDisplayStatus.put(path, false);
+        pathDisplayStatus.put(path, true);
         return mesh_uuid;
     }
 

--- a/Gui/opensim/view/src/org/opensim/view/ExplorerTopComponent.java
+++ b/Gui/opensim/view/src/org/opensim/view/ExplorerTopComponent.java
@@ -52,6 +52,7 @@ import org.openide.nodes.Children;
 import org.openide.nodes.Node;
 import org.openide.util.Mutex;
 import org.openide.util.MutexException;
+import org.opensim.modeling.AbstractPathPoint;
 import org.opensim.modeling.GeometryPath;
 import org.opensim.modeling.Marker;
 import org.opensim.modeling.Model;
@@ -366,8 +367,8 @@ final public class ExplorerTopComponent extends TopComponent
                 OneModelNode modelNode = ((OneModelNode) (nodes[i]));
                 Node objectNode = findObjectNode(modelNode, oObject);
                 // Hack to select Muscle based on selected PathPoint
-                if (oObject instanceof PathPoint){
-                    PathPoint ppt = (PathPoint)oObject;
+                if (oObject instanceof AbstractPathPoint){
+                    AbstractPathPoint ppt = (AbstractPathPoint)oObject;
                     GeometryPath ppath = GeometryPath.safeDownCast(ppt.getOwner());
                     OpenSimObject pathOwner = ppath.getOwner();
                     objectNode = findObjectNode(modelNode,pathOwner);

--- a/Gui/opensim/view/src/org/opensim/view/nodes/AppearanceHelper.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/AppearanceHelper.java
@@ -70,7 +70,9 @@ public class AppearanceHelper {
             public void undo() throws CannotUndoException {
                 super.undo();
                 pea.setValueInt(oldRep.swigValue(), false);
+                ViewDB.getInstance().setApplyAppearanceChange(false);
                 ViewDB.getInstance().updateComponentDisplay(model, compNode.comp, ap);
+                ViewDB.getInstance().setApplyAppearanceChange(true);
             }
 
             @Override
@@ -82,7 +84,9 @@ public class AppearanceHelper {
             public void redo() throws CannotRedoException {
                 super.redo();
                 pea.setValueInt(newRep, false);
+                ViewDB.getInstance().setApplyAppearanceChange(false);
                 ViewDB.getInstance().updateComponentDisplay(model, compNode.comp, ap);
+                ViewDB.getInstance().setApplyAppearanceChange(true);
             }
 
             @Override
@@ -109,7 +113,9 @@ public class AppearanceHelper {
             public void undo() throws CannotUndoException {
                 super.undo();
                 pea.setValueBool(oldVis, false, false);
+                ViewDB.getInstance().setApplyAppearanceChange(false);
                 ViewDB.getInstance().updateComponentDisplay(model, compNode.comp, ap);
+                ViewDB.getInstance().setApplyAppearanceChange(true);
             }
 
             @Override
@@ -121,7 +127,9 @@ public class AppearanceHelper {
             public void redo() throws CannotRedoException {
                 super.redo();
                 pea.setValueBool(newVis, false, false);
+                ViewDB.getInstance().setApplyAppearanceChange(false);
                 ViewDB.getInstance().updateComponentDisplay(model, compNode.comp, ap);
+                ViewDB.getInstance().setApplyAppearanceChange(true);
             }
 
             @Override
@@ -190,7 +198,9 @@ public class AppearanceHelper {
             public void undo() throws CannotUndoException {
                 super.undo();
                 pea.setValueDouble(oldOpacity, false);
+                ViewDB.getInstance().setApplyAppearanceChange(false);
                 ViewDB.getInstance().updateComponentDisplay(model, compNode.comp, ap);
+                ViewDB.getInstance().setApplyAppearanceChange(true);
             }
 
             @Override
@@ -202,7 +212,9 @@ public class AppearanceHelper {
             public void redo() throws CannotRedoException {
                 super.redo();
                 pea.setValueDouble(newOpacity, false);
+                ViewDB.getInstance().setApplyAppearanceChange(false);
                 ViewDB.getInstance().updateComponentDisplay(model, compNode.comp, ap);
+                ViewDB.getInstance().setApplyAppearanceChange(true);
             }
 
             @Override

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneMuscleNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneMuscleNode.java
@@ -42,6 +42,7 @@ import org.openide.util.NbBundle;
 import org.opensim.modeling.Marker;
 import org.opensim.modeling.Muscle;
 import org.opensim.modeling.OpenSimObject;
+import org.opensim.view.ObjectDisplayShowOnlyAction;
 import org.opensim.view.editors.BodyNameEditor;
 import org.opensim.view.nodes.OpenSimObjectNode.displayOption;
 
@@ -85,27 +86,16 @@ public class OneMuscleNode extends OneActuatorNode {
         set.remove("optimal_force");
         return sheet;
     }
-    public Action[] getActions(boolean b) {
-        Action[] superActions = (Action[]) super.getActions(b);        
-        // Arrays are fixed size, onvert to a List
-        
-        List<Action> actions = java.util.Arrays.asList(superActions);
-        // Create new Array of proper size
-        Action[] retActions = new Action[actions.size()+1];
-        actions.toArray(retActions);
-        try {
-            // append new command to the end of the list of actions
-            retActions[actions.size()] = (GeometryPathTogglePointsAction) GeometryPathTogglePointsAction.findObject(
-                     (Class)Class.forName("org.opensim.view.nodes.GeometryPathTogglePointsAction"), true);
-        } catch (ClassNotFoundException ex) {
-            ex.printStackTrace();
-        }
-        return retActions;
-    }
+
     // Default action by double click now toggles pathpoints
     @Override
     public Action getPreferredAction() {
-         Action[] actions = getActions(false);
-        return actions[actions.length-1];
+        try {
+            return (ObjectDisplayShowOnlyAction) ObjectDisplayShowOnlyAction.findObject(
+                    (Class)Class.forName("org.opensim.view.ObjectDisplayShowOnlyAction"), true);
+        } catch (ClassNotFoundException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Fixes issue #796 
### Brief summary of changes
Pathpoints are always visible now, selecting one highlights selected muscle in navigator, no explicit command to show/hide points and  pathpoints have same color as Path object itself. All these are behaviors that were adopted in version 3.3 and earlier and are restored.

### Testing I've completed
Variety of display/edit/hide/show/transparency/color changes of muscles and all work as expected with undo support.

### CHANGELOG.md (choose one)

- no need to update because restoring lost functionality. Only difference is that selection is indicated by box rather than color change and selection is single rather than multi.