### PR TITLE
Default to 1.0 scale for Pathpoints (looks cleaner) 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -151,7 +151,7 @@ public class ModelVisualizationJson extends JSONObject {
     // Preferences
     private double prefMuscleDisplayRadius=0.005;
     private int NUM_PATHPOINTS_PER_WRAP_OBJECT=8;
-    private double PATHPOINT_SCALEUP=1.5;
+    private double PATHPOINT_SCALEUP=1.0;
     
     public Boolean getFrameVisibility(Frame b) {
         return visualizerFrames.get(b).visible;
@@ -406,7 +406,7 @@ public class ModelVisualizationJson extends JSONObject {
         movable = (model instanceof ModelForExperimentalData);
         createModelJsonNode(); // Model node
         // Decide color Scheme for muscles
-        String saved = "Classic";
+        String saved = "Modern";
         String currentTemplate =Preferences.userNodeForPackage(TheApp.class).get("Muscle Color Scheme", saved);
         Preferences.userNodeForPackage(TheApp.class).put("Muscle Color Scheme", currentTemplate);
         currentPathColorMap = PathColorMapFactory.getColorMap(currentTemplate);
@@ -417,7 +417,7 @@ public class ModelVisualizationJson extends JSONObject {
         Preferences.userNodeForPackage(TheApp.class).put("Muscle Display Radius", currentSize);
         prefMuscleDisplayRadius = Double.parseDouble(currentSize);
         actualMuscleDisplayRadius = 8*200*prefMuscleDisplayRadius;
-        saved = "1.5";
+        saved = "1.0";
         currentSize= Preferences.userNodeForPackage(TheApp.class).get("PathPoint Scaleup", saved);
         Preferences.userNodeForPackage(TheApp.class).put("PathPoint Scaleup", currentSize);
         PATHPOINT_SCALEUP = Double.parseDouble(currentSize);


### PR DESCRIPTION
also use Modern  scheme for colorByActivation by default

Fixes issue #0
### Brief summary of changes
On new machines, no enlarged PathPoints and use Modern color scheme as defaults

### Testing I've completed

### CHANGELOG.md (choose one)

- need to update because these are new Preferences
