### PR TITLE
Warn users if saving over a Pre 4.0 model file

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/FileSaveModelAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FileSaveModelAction.java
@@ -37,7 +37,7 @@ public final class FileSaveModelAction extends CallableSystemAction {
    
     public static boolean saveOrSaveAsModel(Model model, boolean forceSaveAs) {
       if(model==null) return false;
-      if (model.getDocumentFileVersion()!= -1 &&  model.getDocumentFileVersion() <=30500){
+      if (model.getDocumentFileVersion()!= -1 &&  model.getDocumentFileVersion() <30500){
           // Show dialog warn new format and give optopn to saveAs
         javax.swing.JTextArea jTextArea1 = new javax.swing.JTextArea();
         //jTextArea1.setColumns(20);

--- a/Gui/opensim/view/src/org/opensim/view/FileSaveModelAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FileSaveModelAction.java
@@ -53,7 +53,7 @@ public final class FileSaveModelAction extends CallableSystemAction {
         JPanel containerPanel = new JPanel();
         containerPanel.setLayout(new javax.swing.BoxLayout(containerPanel, javax.swing.BoxLayout.Y_AXIS));
         containerPanel.add(jTextArea1);
-        DialogDescriptor dd = new DialogDescriptor(containerPanel, "Overwrite old model file");
+        DialogDescriptor dd = new DialogDescriptor(containerPanel, "Overwrite old model file?");
         DialogDisplayer.getDefault().createDialog(dd).setVisible(true);
         Object userInput = dd.getValue();
         if (((Integer)userInput).compareTo((Integer)DialogDescriptor.CANCEL_OPTION)==0){

--- a/Gui/opensim/view/src/org/opensim/view/FileSaveModelAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/FileSaveModelAction.java
@@ -23,6 +23,9 @@
 
 package org.opensim.view;
 
+import javax.swing.JPanel;
+import org.openide.DialogDescriptor;
+import org.openide.DialogDisplayer;
 import org.openide.awt.StatusDisplayer;
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
@@ -34,6 +37,29 @@ public final class FileSaveModelAction extends CallableSystemAction {
    
     public static boolean saveOrSaveAsModel(Model model, boolean forceSaveAs) {
       if(model==null) return false;
+      if (model.getDocumentFileVersion()!= -1 &&  model.getDocumentFileVersion() <=30500){
+          // Show dialog warn new format and give optopn to saveAs
+        javax.swing.JTextArea jTextArea1 = new javax.swing.JTextArea();
+        //jTextArea1.setColumns(20);
+        jTextArea1.setFont(jTextArea1.getFont());
+        String message = "Model originated from an earlier version of OpenSim. If you save, \n" +
+                         "OpenSim will overwrite the model file, and you will not be able to use\n" +
+                         "the model with earlier versions of OpenSim.\n\n" +
+                         "Choose 'OK' to overwrite or 'Cancel' to abort ( use Save-As instead).";
+        jTextArea1.setText(message);
+        //jTextArea1.setRows(4);
+        jTextArea1.setWrapStyleWord(true);
+        jTextArea1.setEnabled(true);
+        JPanel containerPanel = new JPanel();
+        containerPanel.setLayout(new javax.swing.BoxLayout(containerPanel, javax.swing.BoxLayout.Y_AXIS));
+        containerPanel.add(jTextArea1);
+        DialogDescriptor dd = new DialogDescriptor(containerPanel, "Overwrite old model file");
+        DialogDisplayer.getDefault().createDialog(dd).setVisible(true);
+        Object userInput = dd.getValue();
+        if (((Integer)userInput).compareTo((Integer)DialogDescriptor.CANCEL_OPTION)==0){
+                return false;
+        }
+      }
       if(!model.getInputFileName().equals("") && !forceSaveAs) {
          FileSaveAsModelAction.saveModel(model, model.getInputFileName());
          return true;


### PR DESCRIPTION
Fixes issue #766 
### Brief summary of changes
If model is detected to have come from a Pre 4.0 format, a dialog is shown to warn and ask for confirmation to overwrite or to cancel and use SaveAs instead

### Testing I've completed
tested saving over old model files
### CHANGELOG.md (choose one)

-Need to update to indicate the reason.
