### PR TITLE
Use file protocol as browser on osx doesn't handle file path without it

### DIFF
--- a/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/BrowserPageDisplayerAction.java
+++ b/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/BrowserPageDisplayerAction.java
@@ -64,7 +64,7 @@ class BrowserPageDisplayerAction extends AbstractAction
             Exceptions.printStackTrace(ex);
         }
         // If issues with online tutorials then open local file
-        String path = BrowserLauncher.isConnected() ? url : TheApp.getCrossPlatformInstallDir() +  "/doc/" + file+".html";
+        String path = BrowserLauncher.isConnected() ? url : "file://"+TheApp.getCrossPlatformInstallDir() +  "/doc/" + file+".html";
         
         System.out.println("Path: " + path + "or "+
                 TheApp.getCrossPlatformInstallDir() + File.separator + "/doc/" + file+".html");

--- a/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/OpenDoxygenAction.java
+++ b/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/OpenDoxygenAction.java
@@ -45,7 +45,7 @@ public final class OpenDoxygenAction extends CallableSystemAction {
     public void performAction() {
         String basePath = TheApp.getCrossPlatformInstallDir();
         String doxygenPath = BrowserLauncher.isConnected() ? "https://simtk.org/api_docs/opensim/api_docs40/" :
-                basePath + "/sdk/doc/OpenSimAPI.html";
+                "file://"+basePath + "/sdk/doc/OpenSimAPI.html";
 
         BrowserLauncher.openURL(doxygenPath);
 


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
When using local files, prepend file:// to the url

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because bugfix
