### PR TITLE
Use more robust toURI, toURL methods to convert file path to String

### DIFF
--- a/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/BrowserPageDisplayerAction.java
+++ b/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/BrowserPageDisplayerAction.java
@@ -54,21 +54,26 @@ class BrowserPageDisplayerAction extends AbstractAction
         
     @Override
     public void actionPerformed(ActionEvent e) {
-        String file="";
         try {
-            URL onlineURL = new URL(url);
-            file = onlineURL.getFile();
-            int lastSeparatorIndex = file.lastIndexOf('/');
-            file = file.substring(lastSeparatorIndex);
+            String file="";
+            URL onlineURL = null;
+            try {
+                onlineURL = new URL(url);
+                file = onlineURL.getFile();
+                int lastSeparatorIndex = file.lastIndexOf('/');
+                file = file.substring(lastSeparatorIndex);
+            } catch (MalformedURLException ex) {
+                Exceptions.printStackTrace(ex);
+            }
+            // If issues with online tutorials then open local file
+            URL path = BrowserLauncher.isConnected() ? onlineURL : new File(TheApp.getCrossPlatformInstallDir() +  "/doc/" + file+".html").toURI().toURL();
+            
+            System.out.println("Path: " + path + "or "+
+                    TheApp.getCrossPlatformInstallDir() + File.separator + "/doc/" + file+".html");
+            BrowserLauncher.openURL(path.toString());
         } catch (MalformedURLException ex) {
             Exceptions.printStackTrace(ex);
         }
-        // If issues with online tutorials then open local file
-        String path = BrowserLauncher.isConnected() ? url : "file://"+TheApp.getCrossPlatformInstallDir() +  "/doc/" + file+".html";
-        
-        System.out.println("Path: " + path + "or "+
-                TheApp.getCrossPlatformInstallDir() + File.separator + "/doc/" + file+".html");
-        BrowserLauncher.openURL(path);            
     }
     
 }

--- a/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/OpenDoxygenAction.java
+++ b/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/OpenDoxygenAction.java
@@ -32,7 +32,9 @@ package org.opensim.helputils.helpmenu;
  */
 import java.io.File;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URL;
+import org.openide.util.Exceptions;
 
 import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
@@ -43,11 +45,15 @@ import org.opensim.utils.TheApp;
 public final class OpenDoxygenAction extends CallableSystemAction {
 
     public void performAction() {
-        String basePath = TheApp.getCrossPlatformInstallDir();
-        String doxygenPath = BrowserLauncher.isConnected() ? "https://simtk.org/api_docs/opensim/api_docs40/" :
-                "file://"+basePath + "/sdk/doc/OpenSimAPI.html";
-
-        BrowserLauncher.openURL(doxygenPath);
+        try {
+            String basePath = TheApp.getCrossPlatformInstallDir();
+            String doxygenPath = BrowserLauncher.isConnected() ? "https://simtk.org/api_docs/opensim/api_docs40/" :
+                    new File(basePath + "/sdk/doc/OpenSimAPI.html").toURI().toURL().toString();
+            
+            BrowserLauncher.openURL(doxygenPath);
+        } catch (MalformedURLException ex) {
+            Exceptions.printStackTrace(ex);
+        }
 
     }
 


### PR DESCRIPTION
Fixes issue #0
### Brief summary of changes
Use builtin methods to convert file path (for offline usage) to URL to use in browser 

### Testing I've completed
Tested tutorials and doxygen open properly on windows while online and offline

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
