### PR TITLE
Fix experimental marker preference

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/actions/EditPreferencesJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/actions/EditPreferencesJPanel.java
@@ -74,7 +74,8 @@ public class EditPreferencesJPanel extends javax.swing.JPanel {
        "Muscle Dsiplay Radius",
        "BuildDate",
        "One Material Meshes",
-       "Save Movie Frames"
+       "Save Movie Frames",
+       "Experimental Marker Size"
    };
    /** Creates new form EditPreferencesJPanel */
    public EditPreferencesJPanel() throws BackingStoreException {

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -377,7 +377,7 @@ public class MotionDisplayer {
     /** Creates a new instance of MotionDisplayer */
     public MotionDisplayer(Storage motionData, Model model) {
         String saved = "5";
-        String currentSize =Preferences.userNodeForPackage(TheApp.class).get("Experimental Marker Size(mm)", saved);
+        String currentSize =Preferences.userNodeForPackage(TheApp.class).get("Experimental Marker Size (mm)", saved);
         Preferences.userNodeForPackage(TheApp.class).put("Experimental Marker Size (mm)", currentSize);
         DEFAULT_MARKER_SIZE = Double.parseDouble(currentSize);
         this.experimentalForceScaleFactor = 1.0;

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -41,6 +41,7 @@ import java.util.Hashtable;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Vector;
+import java.util.prefs.Preferences;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.opensim.logger.OpenSimLogger;
@@ -71,6 +72,7 @@ import org.opensim.modeling.UnitVec3;
 import org.opensim.modeling.Vec3;
 import org.opensim.threejs.JSONUtilities;
 import org.opensim.threejs.ModelVisualizationJson;
+import org.opensim.utils.TheApp;
 import org.opensim.view.MuscleColoringFunction;
 import org.opensim.view.OpenSimvtkGlyphCloud;
 import org.opensim.view.SingleModelVisuals;
@@ -374,6 +376,10 @@ public class MotionDisplayer {
     
     /** Creates a new instance of MotionDisplayer */
     public MotionDisplayer(Storage motionData, Model model) {
+        String saved = "5";
+        String currentSize =Preferences.userNodeForPackage(TheApp.class).get("Experimental Marker Size(mm)", saved);
+        Preferences.userNodeForPackage(TheApp.class).put("Experimental Marker Size (mm)", currentSize);
+        DEFAULT_MARKER_SIZE = Double.parseDouble(currentSize);
         this.experimentalForceScaleFactor = 1.0;
         this.experimentalMarkerScaleFactor = 1.0;
         this.model = model;
@@ -1006,7 +1012,7 @@ public class MotionDisplayer {
         }
         
     }
-    public static final double DEFAULT_MARKER_SIZE = 5;
+    public static double DEFAULT_MARKER_SIZE = 5;
 
     public void addExperimentalDataObjectsToJson(AbstractList<ExperimentalDataObject> expObjects) {
         // Make sure this


### PR DESCRIPTION
Fixes issue #643

### Brief summary of changes
Introduce new preference "Experimental Marker Size (mm)" that specifies size in millimeters. 

### Testing I've completed
Previewed Marker data, changed preference, reloaded, restarted, Preference and behavior is as expected.

### CHANGELOG.md (choose one)

- Need to document new preference
