### PR TITLE
Fix sync motions issue 339

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/CommandComposerThreejs.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/CommandComposerThreejs.java
@@ -123,11 +123,16 @@ public class CommandComposerThreejs {
         commandJson.put("objectUuid", objectUuid.toString());
         return commandJson;
     }
-
+    // newObject may have no uuid!!!
     static JSONObject createAddObjectCommandJson(JSONObject newObject) {
         JSONObject commandJson = new JSONObject();
         commandJson.put("type", "AddObjectCommand");
-        commandJson.put("objectUuid", newObject.get("uuid"));
+        if (newObject.get("uuid")!=null)
+            commandJson.put("objectUuid", newObject.get("uuid"));
+        else {
+            JSONObject jObj = (JSONObject) newObject.get("object");
+            commandJson.put("objectUuid", jObj.get("uuid"));
+        }
         commandJson.put("object", newObject);
         return commandJson;
     }

--- a/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
+++ b/Gui/opensim/visualizationServer/src/org/eclipse/jetty/WebSocketDB.java
@@ -81,7 +81,8 @@ public class WebSocketDB {
     {
         // Every time we broadcast a message will give it uuid so clients can check for duplicates
         msg.put("message_uuid", UUID.randomUUID().toString());
-        //System.out.println("Broadcast:"+msg.get("Op"));
+        if (!msg.get("Op").equals("Frame") && debug)
+            System.out.println("Broadcast:"+msg.toJSONString());
         if (specificSocket != null){
             specificSocket.sendVisualizerMessage(msg);
             return;


### PR DESCRIPTION
Fixes issue #339

### Brief summary of changes
Synchronizing or reusing previewed data broke due to caching visualizer uuids that was introduces to speed up animation. The cache was not kept fully up to date when objects were removed/hidden.

### Testing I've completed
Loaded, played, animated multiple sets of experimental data (Markers, Forces both separately or using associate data to motion) and all worked without issue.

### CHANGELOG.md 

- no need to update because this is a bug fix and behavior is identical to 3.3
