### PR TITLE
Transform experimental data

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -976,6 +976,21 @@ public class ModelVisualizationJson extends JSONObject {
         nextpptPositionCommand.put("oldPosition", oldLocationArray);
         return nextpptPositionCommand;
     }
+    
+    static public JSONObject createSetRotationCommand(UUID objectUuid, Vec3 euler) {
+        JSONObject rotationCommandJson = new JSONObject();
+        rotationCommandJson.put("type", "SetRotationCommand");
+        rotationCommandJson.put("objectUuid", objectUuid.toString());
+        JSONArray rotationArray = new JSONArray();
+        JSONArray oldRotationArray = new JSONArray();
+        for (int p =0; p <3; p++){
+            rotationArray.add(euler.get(p));
+            oldRotationArray.add(0);
+        }
+        rotationCommandJson.put("newRotation", rotationArray);
+        rotationCommandJson.put("oldRotation", oldRotationArray);
+        return rotationCommandJson;
+    }
 
     private UUID createMarkerMaterial(ModelDisplayHints hints) {
         JSONObject mat_json = new JSONObject();

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -44,6 +44,7 @@ import org.opensim.modeling.ArrayStr;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.StateVector;
 import org.opensim.modeling.Storage;
+import org.opensim.modeling.Transform;
 import org.opensim.view.motions.MotionControlJPanel;
 import org.opensim.view.motions.MotionDisplayer;
 import org.opensim.view.motions.MotionsDB;
@@ -371,11 +372,11 @@ public class AnnotatedMotion extends Storage {
       }
   }
 
-  public void saveAs(String newFile, vtkTransform transform) throws FileNotFoundException, IOException {
+  public void saveAs(String newFile, Transform transform) throws FileNotFoundException, IOException {
           if (newFile.toLowerCase().endsWith(".trc"))
-             saveAsTRC(newFile, transform);
+             ;//saveAsTRC(newFile, transform);
           else if (newFile.toLowerCase().endsWith(".mot"))
-              saveAsMot(newFile, transform);
+              ;//saveAsMot(newFile, transform);
           else 
               DialogDisplayer.getDefault().notify(
                       new NotifyDescriptor.Message("Please specify either .trc or .mot file extension"));

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -300,7 +300,7 @@ public class AnnotatedMotion extends Storage {
         Transform simtkTransform = new Transform();
         simtkTransform.R().setRotationToBodyFixedXYZ(rotationAnglesInRadians);
         Mat33 mat33 = simtkTransform.R().asMat33();
-        System.out.println("Rotation:"+mat33.toString());
+        //System.out.println("Rotation:"+mat33.toString());
 
         if (classified !=null && classified.size()!=0){
             for(ExperimentalDataObject dataObject:classified){

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -45,10 +45,10 @@ import org.opensim.modeling.Model;
 import org.opensim.modeling.StateVector;
 import org.opensim.modeling.Storage;
 import org.opensim.modeling.Transform;
+import org.opensim.modeling.Vec3;
 import org.opensim.view.motions.MotionControlJPanel;
 import org.opensim.view.motions.MotionDisplayer;
 import org.opensim.view.motions.MotionsDB;
-import vtk.vtkTransform;
 
 /**
  *
@@ -291,7 +291,7 @@ public class AnnotatedMotion extends Storage {
         this.boundingBoxComputed = boundingBoxComputed;
     }
  
-    public Storage applyTransform(vtkTransform vtktransform) {
+    public Storage applyTransform(Transform simtktransform) {
         // Should know what data to apply xform to and how
         // for example mrkers are xformed as is but force vectors would not apply translations etc.
         // utilize the "clasified" table
@@ -301,13 +301,13 @@ public class AnnotatedMotion extends Storage {
                 if (dataObject.getObjectType()==ExperimentalDataItemType.PointData ||
                         dataObject.getObjectType()==ExperimentalDataItemType.MarkerData){
                     int startIndex = dataObject.getStartIndexInFileNotIncludingTime();
-                    transformPointData(motionCopy, vtktransform, startIndex);
+                    transformPointData(motionCopy, simtktransform, startIndex);
                 } else if (dataObject.getObjectType()==ExperimentalDataItemType.PointForceData){
                     int startIndex = dataObject.getStartIndexInFileNotIncludingTime();
                     // First vector, then position
                     // If we allow for translations the first line may need to change
-                    transformPointData(motionCopy, vtktransform, startIndex);
-                    transformPointData(motionCopy, vtktransform, startIndex+3);
+                    transformPointData(motionCopy, simtktransform, startIndex);
+                    transformPointData(motionCopy, simtktransform, startIndex+3);
                 }
                 else {
                     System.out.println("bad type="+dataObject.getObjectType());
@@ -318,17 +318,17 @@ public class AnnotatedMotion extends Storage {
         return motionCopy;
     }
 
-    private void transformPointData(final Storage motionCopy, final vtkTransform vtktransform, final int startIndex) {
-        double[] point3 = new double[]{0., 0., 0. };
+    private void transformPointData(final Storage motionCopy, final Transform simtktransform, final int startIndex) {
+        Vec3 point3 = new Vec3(0., 0., 0. );
         for (int rowNumber=0; rowNumber<getSize(); rowNumber++){
             StateVector row = motionCopy.getStateVector(rowNumber);
             //if (rowNumber==0) System.out.println("Start index="+startIndex+" row size="+row.getSize());
             for(int coord=0; coord <3; coord++) {
-                point3[coord] = row.getData().getitem(startIndex+coord);
+                point3.set(coord, row.getData().getitem(startIndex+coord));
             }
-            double[] xformed = vtktransform.TransformDoublePoint(point3); //inplace
+            Vec3 xformed = simtktransform.xformFrameVecToBase(point3) 
             for(int coord=0; coord <3; coord++) {
-                row.getData().setitem(startIndex+coord, xformed[coord]);
+                row.getData().setitem(startIndex+coord, xformed.get(coord));
             }
             
         }
@@ -374,21 +374,21 @@ public class AnnotatedMotion extends Storage {
 
   public void saveAs(String newFile, Transform transform) throws FileNotFoundException, IOException {
           if (newFile.toLowerCase().endsWith(".trc"))
-             ;//saveAsTRC(newFile, transform);
+             saveAsTRC(newFile, transform);
           else if (newFile.toLowerCase().endsWith(".mot"))
-              ;//saveAsMot(newFile, transform);
+              saveAsMot(newFile, transform);
           else 
               DialogDisplayer.getDefault().notify(
                       new NotifyDescriptor.Message("Please specify either .trc or .mot file extension"));
   }
 
-    private void saveAsMot(String newFile, vtkTransform transform) {
+    private void saveAsMot(String newFile, Transform transform) {
         // Make a full copy of the motion then xform in place.
         Storage xformed = applyTransform(transform);
         xformed.print(newFile);
     }
     
-   private void saveAsTRC(String newFile, vtkTransform transform) throws FileNotFoundException, IOException {
+   private void saveAsTRC(String newFile, Transform transform) throws FileNotFoundException, IOException {
         OutputStream ostream = new FileOutputStream(newFile);
         BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(ostream));
         writer.write("PathFileType        4      (X/Y/Z)      " + newFile + "         ");

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.form
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.3" maxVersion="1.3" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <NonVisualComponents>
@@ -67,7 +67,7 @@
                           <EmptySpace max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="jTransformDataPanel" min="-2" max="-2" attributes="0"/>
-                              <Component id="saveTransformedAsButton" pref="109" max="32767" attributes="1"/>
+                              <Component id="saveTransformedAsButton" max="32767" attributes="1"/>
                           </Group>
                       </Group>
                       <Group type="102" alignment="0" attributes="0">

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
@@ -323,7 +323,8 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
         rotations[0]=xRot-rotations[0];
         rotations[1]=yRot-rotations[1];
         rotations[2]=zRot-rotations[2];
-        Vec3 rotationAsVec3 = new Vec3(rotations[0], rotations[1],rotations[2]);
+        double degToRadians = Math.toRadians(1.0);
+        Vec3 rotationAsVec3 = new Vec3(degToRadians*xRot, degToRadians*yRot, degToRadians*zRot);
         ViewDB.getInstance().setOrientation(displayer.getModel(), rotationAsVec3);
  
     }

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
@@ -35,6 +35,8 @@ import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
 import javax.swing.tree.DefaultMutableTreeNode;
 import org.opensim.modeling.ArrayStr;
+import org.opensim.modeling.Transform;
+import org.opensim.modeling.Vec3;
 import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
 import org.opensim.view.motions.MotionControlJPanel;
@@ -54,7 +56,6 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
     RotationSpinnerListModel ySpinnerModel=new RotationSpinnerListModel(0., -270., 360., 90.);
     RotationSpinnerListModel zSpinnerModel=new RotationSpinnerListModel(0., -270., 360., 90.);
     MotionDisplayer displayer;
-    private vtkTransform lastTranform = new vtkTransform();
     private double[] rotations = new double[]{0., 0., 0.};
    /** Creates new form ClassifyDataJPanel */
     public ClassifyDataJPanel() {
@@ -265,10 +266,11 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
              fileName.concat(currentExtension);
             try {
                 // getCurrentRotations into lastTransform
-                vtkTransform dTransform = new vtkTransform();
-                dTransform.RotateX(dMotion.getCurrentRotations()[0]);
-                dTransform.RotateY(dMotion.getCurrentRotations()[1]);
-                dTransform.RotateZ(dMotion.getCurrentRotations()[2]);
+                Transform dTransform = new Transform();
+                Vec3 rots = new Vec3();
+                for (int i=0; i<3; i++)
+                    rots.set(i, dMotion.getCurrentRotations()[i]);
+                dTransform.R().setRotationToBodyFixedXYZ(rots);
                 dMotion.saveAs(fileName, dTransform);
                 success = true;
             } catch (FileNotFoundException ex) {
@@ -316,23 +318,14 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
     }//GEN-LAST:event_XSpinnerStateChanged
 
     private void updateTransform(double xRot, double yRot, double zRot) {
-        /*Vector<vtkActor> dActors = displayer.getActors();
-        for(vtkActor actor:dActors){
-            actor.SetOrientation(xRot, yRot, zRot);
-        }*/
-        lastTranform = new vtkTransform();
-        getLastTranform().RotateX(xRot);
-        getLastTranform().RotateY(yRot);
-        getLastTranform().RotateZ(zRot);
-        // Remember reptations in case we need to xform again
-        getRotations()[0]=xRot;
-        getRotations()[1]=yRot;
-        getRotations()[2]=zRot;
-        
-        ViewDB.getInstance().setOrientation(displayer.getModel(), getRotations());
-        ViewDB.getInstance().updateAnnotationAnchors();
-        ViewDB.getInstance().repaintAll();
-        amotion.setCurrentRotations(getRotations());
+        amotion.setCurrentRotations(new double[]{xRot, yRot, zRot});
+        // record the deltas since rotations are relative to last transform
+        rotations[0]=xRot-rotations[0];
+        rotations[1]=yRot-rotations[1];
+        rotations[2]=zRot-rotations[2];
+        Vec3 rotationAsVec3 = new Vec3(rotations[0], rotations[1],rotations[2]);
+        ViewDB.getInstance().setOrientation(displayer.getModel(), rotationAsVec3);
+ 
     }
 
     void resetTransforms() {
@@ -374,10 +367,6 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
         }
 
     } //RotationSpinnerListModel
-
-    public vtkTransform getLastTranform() {
-        return lastTranform;
-    }
 
     public double[] getRotations() {
         return rotations;

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
@@ -319,9 +319,9 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
     private void updateTransform(double xRot, double yRot, double zRot) {
         amotion.setCurrentRotations(new double[]{xRot, yRot, zRot});
         // record the deltas since rotations are relative to last transform
-        rotations[0]=xRot-rotations[0];
-        rotations[1]=yRot-rotations[1];
-        rotations[2]=zRot-rotations[2];
+        rotations[0]=xRot;
+        rotations[1]=yRot;
+        rotations[2]=zRot;
         double degToRadians = Math.toRadians(1.0);
         Vec3 rotationAsVec3 = new Vec3(degToRadians*xRot, degToRadians*yRot, degToRadians*zRot);
         ViewDB.getInstance().setOrientation(displayer.getModel(), rotationAsVec3);
@@ -370,9 +370,5 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
 
     public double[] getRotations() {
         return rotations;
-    }
-
-    public void setRotations(double[] rotations) {
-        this.rotations = rotations;
     }
 }

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ClassifyDataJPanel.java
@@ -266,12 +266,11 @@ public class ClassifyDataJPanel extends javax.swing.JPanel {
              fileName.concat(currentExtension);
             try {
                 // getCurrentRotations into lastTransform
-                Transform dTransform = new Transform();
                 Vec3 rots = new Vec3();
+                double degToRadians = Math.toRadians(1.0);
                 for (int i=0; i<3; i++)
-                    rots.set(i, dMotion.getCurrentRotations()[i]);
-                dTransform.R().setRotationToBodyFixedXYZ(rots);
-                dMotion.saveAs(fileName, dTransform);
+                    rots.set(i, dMotion.getCurrentRotations()[i]*degToRadians);
+                dMotion.saveAs(fileName, rots);
                 success = true;
             } catch (FileNotFoundException ex) {
                 ex.printStackTrace();

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/MotionReclassifyAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/MotionReclassifyAction.java
@@ -36,6 +36,7 @@ import org.openide.util.HelpCtx;
 import org.openide.util.NbBundle;
 import org.openide.util.actions.CallableSystemAction;
 import org.opensim.view.ExplorerTopComponent;
+import org.opensim.view.motions.MotionsDB;
 import org.opensim.view.motions.OneMotionNode;
 
 public final class MotionReclassifyAction extends CallableSystemAction {
@@ -94,4 +95,17 @@ public final class MotionReclassifyAction extends CallableSystemAction {
         return false;
     }
     
+    public boolean isEnabled() {
+        Node[] selected = ExplorerTopComponent.findInstance().getExplorerManager().getSelectedNodes();
+        if (selected.length!=1 || (! (selected[0] instanceof OneMotionNode))) return false;
+        AnnotatedMotion amot = (AnnotatedMotion) ((OneMotionNode)(selected[0])).getMotion();
+        int numCurrent = MotionsDB.getInstance().getNumCurrentMotions();
+        boolean enabled=false;
+        for (int i=0; i<numCurrent; i++)
+            if (MotionsDB.getInstance().getCurrentMotion(i).motion == amot){
+                enabled=true;
+                break;
+            }
+        return enabled;
+    }
 }

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -2142,7 +2142,6 @@ public final class ViewDB extends Observable implements Observer, LookupListener
             guiJson.put("Op", "execute");
             JSONObject commandJson =  modelJson.createSetRotationCommand(modelJson.getModelUUID(), rotVec3);
             guiJson.put("command", commandJson);
-            System.out.println("Command:"+guiJson);
             websocketdb.broadcastMessageJson(guiJson, null);
         }          
     }

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -2135,20 +2135,16 @@ public final class ViewDB extends Observable implements Observer, LookupListener
         }
     }
     // Change orientation based on passed in 3 Rotations, used to visualize mocap data
-    public void setOrientation(Model model, double[] d) {
-        SingleModelVisuals visuals = getModelVisuals(model);
-        vtkMatrix4x4 currenTransform=getModelVisualsTransform(visuals);
-        // keep only translation
-        for(int i=0; i<3; i++)
-            for(int j=0; j<3; j++)
-                currenTransform.SetElement(i, j, (i==j)?1.0:0.);
-        vtkTransform newDisplayTransfrom = new vtkTransform(); //Identity
-        newDisplayTransfrom.RotateX(d[0]);
-        newDisplayTransfrom.RotateY(d[1]);
-        newDisplayTransfrom.RotateZ(d[2]);
-        newDisplayTransfrom.Concatenate(currenTransform);
-        getInstance().setModelVisualsTransform(visuals, newDisplayTransfrom.GetMatrix());
-  
+    public void setOrientation(Model model, Vec3 rotVec3) {
+        if (websocketdb!=null){
+            ModelVisualizationJson modelJson = getModelVisualizationJson(model);
+            JSONObject guiJson = new JSONObject();
+            guiJson.put("Op", "execute");
+            JSONObject commandJson =  modelJson.createSetRotationCommand(modelJson.getModelUUID(), rotVec3);
+            guiJson.put("command", commandJson);
+            System.out.println("Command:"+guiJson);
+            websocketdb.broadcastMessageJson(guiJson, null);
+        }          
     }
 
     private void removeAnnotationObjects(Model dModel) {


### PR DESCRIPTION
Fixes issue #894

### Brief summary of changes
moved code that transforms experimental data from using vtk objects/transforms to using SimTK::Transform iternally and communicating changes to visualizer using messages.

### Testing I've completed
Was able to load marker data, forces, rotates them, write down and reload transformed/rotated data.

### CHANGELOG.md (choose one)

- no need to update because this is a bugfix that restores functionality in earlier versions of OpenSim.
