### PR TITLE
Force component display

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/MotionObjectBodyPoint.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/MotionObjectBodyPoint.java
@@ -25,8 +25,15 @@ package org.opensim.view.experimentaldata;
 import java.util.ArrayList;
 import java.util.UUID;
 import org.json.simple.JSONObject;
+import org.opensim.modeling.ArrayDouble;
+import org.opensim.modeling.Body;
+import org.opensim.modeling.Component;
+import org.opensim.modeling.Model;
+import org.opensim.modeling.OpenSimContext;
+import org.opensim.modeling.PhysicalFrame;
 import org.opensim.modeling.Sphere;
 import org.opensim.view.motions.MotionDisplayer;
+import org.opensim.view.pub.OpenSimDB;
 
 /**
  *
@@ -86,10 +93,22 @@ public class MotionObjectBodyPoint extends ExperimentalDataObject {
      * @param point the point to set
      */
     public void setPoint(double[] point) {
-        this.point = point;
+        if (pointExpressedInBody.equalsIgnoreCase("ground"))
+           this.point = point;
+        else {
+            // Transform point to ground 
+            Model model = getModel();
+            OpenSimContext dContext= OpenSimDB.getInstance().getContext(model);
+            Component c = model.getComponent(pointExpressedInBody);
+            PhysicalFrame f = PhysicalFrame.safeDownCast(c);
+            double[] pointGlobal = new double[3]; 
+            dContext.transformPosition(f, point, pointGlobal);
+            this.point = pointGlobal;
+        }
     }
 
     boolean appliesForce() {
         return false;
     }
-}
+
+ }

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/MotionObjectPointForce.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/MotionObjectPointForce.java
@@ -185,8 +185,17 @@ public class MotionObjectPointForce extends MotionObjectBodyPoint {
     void updateDecorations(ArrayDouble interpolatedStates) {
         int idx = getStartIndexInFileNotIncludingTime();
         setPoint(new double[]{interpolatedStates.get(idx+3), interpolatedStates.get(idx+4), interpolatedStates.get(idx+5)});
-        for (int i=0; i<3; i++) 
-            getDirection().set(i, interpolatedStates.get(idx+i));
+        if (forceComponent.equalsIgnoreCase("all")){
+            for (int i=0; i<3; i++) 
+                getDirection().set(i, interpolatedStates.get(idx+i));
+        }
+        else {
+            String componentNames = "xyz";
+            int componentIndex = componentNames.indexOf(forceComponent);
+            for (int i=0; i<3; i++) 
+                getDirection().set(i, 0);
+            getDirection().set(componentIndex, interpolatedStates.get(idx+componentIndex));
+        }
     }
     // Create JSON object to represent ExperimentalForce
     @Override


### PR DESCRIPTION
Fixes issue #27

### Brief summary of changes
Replaced vtk based code to select Point-expressed-in, Force-expressed-in to new visualizer code base where slections change transforms and final transformed data is sent to visualizer.

### Testing I've completed
Loaded mocap data and tchanged Point and Force selection of PhysicalFrame and got same behavior as in version 3.3

### CHANGELOG.md (choose one)

- no need to update because bugfix