### PR TITLE
Add tooltip for Restore button

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
@@ -753,6 +753,7 @@ public class OpenSimGeometryPathEditorPanel extends javax.swing.JPanel {
       RestoreButton = new javax.swing.JButton();
       RestoreButton.setText("Restore");
       RestoreButton.setBounds(X + 300, Y + 20 + numGuiLines * 25, 70, 21);
+      RestoreButton.setToolTipText("Restore current Path to status on entry.");
       RestoreButton.addActionListener(new ActionListener(){
 
             @Override


### PR DESCRIPTION
Fixes issue #817 
### Brief summary of changes
Add tooltip to Restore button to exaplin what it does.

### Testing I've completed
Built GUI, saw toolip on hovering over "Restore" button of Path editor.

### CHANGELOG.md (choose one)

- no need to update because tooltips aren't documented.
