### PR TITLE
Enable undo

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/ExplorerTopComponent.java
+++ b/Gui/opensim/view/src/org/opensim/view/ExplorerTopComponent.java
@@ -89,7 +89,7 @@ final public class ExplorerTopComponent extends TopComponent
    private final BeanTreeView modelTree = new BeanTreeView();
    
    private static TopComponent visualizerTC = null;
-   private UndoRedo.Manager undoRedoManager = new UndoRedoManager();
+   private UndoRedo.Manager undoRedoManager = null;
 
    private ExplorerTopComponent() {
       initComponents();
@@ -471,6 +471,7 @@ final public class ExplorerTopComponent extends TopComponent
         }*/
         
         // Undo Support
+   @Override
         public UndoRedo getUndoRedo(){
             return getUndoRedoManager();
 }
@@ -535,22 +536,16 @@ final public class ExplorerTopComponent extends TopComponent
         
         public static void addUndoableEdit(AbstractUndoableEdit aUndoableEdit)
         {
-            getDefault().getUndoRedoManager().addEdit(aUndoableEdit);
-            TopComponent tc = getVisualizerTopComponent();
-            if (tc==null){ // No gfx window
-                tc = getDefault();
-            } 
-            if (tc==null) return;   // No tc to piggyback on
-            final TopComponent tcf = tc;
+            instance.getUndoRedoManager().addEdit(aUndoableEdit);
             if (java.awt.EventQueue.isDispatchThread()) {
-                tcf.requestActive();
+                instance.requestActive();
             }
             else {
                 SwingUtilities.invokeLater(new Runnable(){
 
                 @Override
                 public void run() {
-                    tcf.requestActive();
+                    instance.requestActive();
                 }
             });
             }


### PR DESCRIPTION
Fixes issue #512
### Brief summary of changes
Enablement of the undo button is handled by the NetBeans platform based on what windows (TopComponents) are "active" and if hey provide an undo support class. This PR unifies all editing to make one window Active and provide a singleton Undo support class across application windows.

### Testing I've completed
Edits in Properties window, context menus of the Navigator and graphically dragging PathPoints are all undoable and the undo button is enabled.

### CHANGELOG.md (choose one)

- no need to update because it is a bugfix
