### PR TITLE
remove_duplictae_ctrlS_shortcut

### DIFF
--- a/Gui/opensim/scriptingShell/src/org/opensim/console/layer.xml
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/layer.xml
@@ -77,7 +77,7 @@
         <file name="F5.shadow">  
         <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-console-ToolsRunCurrentScriptAction.instance"/> 
         </file>
-        <file name="C-s.shadow">  
+        <file name="C-W.shadow">  
         <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-console-ScriptsSaveAction.instance"/> 
         </file>
     </folder>


### PR DESCRIPTION
Fixes issue #840

### Brief summary of changes
Ctrl_S key combination was double-used for saveScript and saveModel. This changes saveScript to Ctrl_W so more common Save=Ctrl_S is preserved.

### Testing I've completed
Ctrl+S invokes save, with prompt if older version format

### CHANGELOG.md 
- Need to update shortcuts if listed somewhere, the application updates the Shortcut name automatically
