### PR TITLE
Fix edit wrap geometry

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
@@ -332,7 +332,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("radius", arg0.getRadius()*visualizerScaleFactor);
         dg_json.put("widthSegments", 32);
         dg_json.put("heightSegments", 16);
-        if (quadrants.equals("")){
+        if (quadrants.equals("")||quadrants.equalsIgnoreCase("all")){
             dg_json.put("phiStart", 0);
             dg_json.put("phiLength", 2*Math.PI);
             dg_json.put("thetaStart", 0);
@@ -395,7 +395,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("height", arg0.getHalfHeight()*2*visualizerScaleFactor);
         dg_json.put("radialSegments", 32);
         dg_json.put("heightSegments", 1);
-        if (!quadrants.equals("") && !quadrants.equals("all")){
+        if (!quadrants.equals("") && !quadrants.equalsIgnoreCase("all")){
             dg_json.put("thetaLength", Math.PI);
             if (quadrants.equalsIgnoreCase("-y"))
                 dg_json.put("thetaStart", -0.5*Math.PI);

--- a/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/DecorativeGeometryImplementationJS.java
@@ -395,7 +395,7 @@ public class DecorativeGeometryImplementationJS extends DecorativeGeometryImplem
         dg_json.put("height", arg0.getHalfHeight()*2*visualizerScaleFactor);
         dg_json.put("radialSegments", 32);
         dg_json.put("heightSegments", 1);
-        if (!quadrants.equals("")){
+        if (!quadrants.equals("") && !quadrants.equals("all")){
             dg_json.put("thetaLength", Math.PI);
             if (quadrants.equalsIgnoreCase("-y"))
                 dg_json.put("thetaStart", -0.5*Math.PI);

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -947,8 +947,8 @@ public class ModelVisualizationJson extends JSONObject {
         if (hasAppearance && !visibleStatus)
             PropertyHelper.setValueBool(visibleStatus, visibleProp);
         WrapObject wo = WrapObject.safeDownCast(mc);
-        boolean partialWrapObject = (wo != null) && !wo.get_quadrant().toLowerCase().equals("all");
-        if (partialWrapObject)
+        boolean isWrapObject = (wo != null);
+        if (isWrapObject)
             dgimp.setQuadrants(wo.get_quadrant());
         ArrayList<UUID> uuids = findUUIDForObject(mc);
         if (adg.size() == uuids.size()){

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
@@ -40,6 +40,7 @@ import org.openide.nodes.Sheet;
 import static org.openide.nodes.Sheet.createExpertSet;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
+import org.opensim.modeling.AnalyticGeometry;
 import org.opensim.modeling.Component;
 import org.opensim.modeling.Cone;
 import org.opensim.modeling.Frame;
@@ -106,13 +107,16 @@ public class OneGeometryNode extends OneComponentWithGeometryNode {
     public Sheet createSheet() {
         Sheet sheet;
         sheet = super.createSheet();
+        Sheet.Set set = sheet.get(Sheet.PROPERTIES);
         // Remove Properties for origin, direction as not supported 
         if (Cone.safeDownCast(comp)!=null){
-            Sheet.Set set = sheet.get(Sheet.PROPERTIES);
             set.remove("origin");
             set.remove("direction");
+        }
+        if (AnalyticGeometry.safeDownCast(comp)!=null){
             set.remove("quadrants");
         }
+        set.remove("scale_factors");
         return sheet;
     }
     

--- a/Gui/opensim/view/src/org/opensim/view/nodes/PropertyEditorAdaptor.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/PropertyEditorAdaptor.java
@@ -117,7 +117,9 @@ public class PropertyEditorAdaptor {
     }
     
     public void handlePropertyChangeCommon() {
-        if (Geometry.safeDownCast(obj)!= null){
+        if (Geometry.safeDownCast(obj)!= null ||
+                WrapObject.safeDownCast(obj) != null ||
+                ContactGeometry.safeDownCast(obj)!=null){
             Component mc = Component.safeDownCast(obj);
             ViewDB.getInstance().updateComponentDisplay(model, mc, prop);
         }

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -1413,11 +1413,7 @@ public final class ViewDB extends Observable implements Observer, LookupListener
        if (websocketdb != null){
            if (applyAppearanceChange){
                 ModelVisualizationJson modelJson = getInstance().getModelVisualizationJson(model);
-                if (Geometry.safeDownCast(mc)!=null && Mesh.safeDownCast(mc)==null){
-                    JSONObject msg = new JSONObject();
-                    if (modelJson.createReplaceGeometryMessage(Geometry.safeDownCast(mc), msg))
-                        websocketdb.broadcastMessageJson(msg, null);
-                }
+                sendGeometryUpdateMessageIfNeeded(mc, modelJson);
                 JSONObject msg = modelJson.createAppearanceMessage(mc, prop);
                 websocketdb.broadcastMessageJson(msg, null);
            }
@@ -1428,6 +1424,20 @@ public final class ViewDB extends Observable implements Observer, LookupListener
                
        }
    }
+
+    private void sendGeometryUpdateMessageIfNeeded(Component mc, ModelVisualizationJson modelJson) {
+        if (componentHasAnalyticGeometry(mc)){
+            JSONObject msg = new JSONObject();
+            if (modelJson.createReplaceGeometryMessage(mc, msg))
+                websocketdb.broadcastMessageJson(msg, null);
+        }
+    }
+
+    private static boolean componentHasAnalyticGeometry(Component mc) {
+        return (Geometry.safeDownCast(mc)!=null && Mesh.safeDownCast(mc)==null)||
+                ContactGeometry.safeDownCast(mc)!=null ||
+                WrapObject.safeDownCast(mc)!=null;
+    }
 
    public void applyTimeToViews(double time) {
       Iterator<ModelWindowVTKTopComponent> windowIter = openWindows.iterator();


### PR DESCRIPTION
Fixes issue #844

### Brief summary of changes
Edits of parameters of analytical shapes requires recreation of geometry. This was not done for wrapObjects and ContactGeometry.

### Testing I've completed
Loaded models, modified paramaters, transforms and quadrants of wrapObjects and ContactSpheres and all worked as expected.

### CHANGELOG.md (choose one)

- no need to update because bugfix