### PR TITLE
Cache resulting folder name before changing dialog settings

### DIFF
--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -281,13 +281,14 @@ public final class FileUtils {
            // TODO: prompt to create directory if it doesn't exist?
            break;
        }
-       File selectedFileOrFolder = dlog.getSelectedFile();
-       dlog.setFileSelectionMode(JFileChooser.FILES_ONLY);
        
        if(outFilename != null){
+           File selectedFileOrFolder = dlog.getSelectedFile();
            String workDirectoryString = selectedFileOrFolder.getParentFile().toString();
            setWorkingDirectoryPreference( workDirectoryString);
        }
+       // Change settings to default (FILES_ONLY) so dialog isn't stuck in browse for folders mode
+       dlog.setFileSelectionMode(JFileChooser.FILES_ONLY);
        return outFilename;
     }
     /**

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -281,9 +281,11 @@ public final class FileUtils {
            // TODO: prompt to create directory if it doesn't exist?
            break;
        }
+       File selectedFileOrFolder = dlog.getSelectedFile();
        dlog.setFileSelectionMode(JFileChooser.FILES_ONLY);
+       
        if(outFilename != null){
-           String workDirectoryString = dlog.getSelectedFile().getParent();
+           String workDirectoryString = selectedFileOrFolder.getParentFile().toString();
            setWorkingDirectoryPreference( workDirectoryString);
        }
        return outFilename;

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -283,8 +283,7 @@ public final class FileUtils {
        }
        
        if(outFilename != null){
-           File selectedFileOrFolder = dlog.getSelectedFile();
-           String workDirectoryString = selectedFileOrFolder.getParentFile().toString();
+           String workDirectoryString = dlog.getSelectedFile().getParent();
            setWorkingDirectoryPreference( workDirectoryString);
        }
        // Change settings to default (FILES_ONLY) so dialog isn't stuck in browse for folders mode

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -287,7 +287,7 @@ public final class FileUtils {
            setWorkingDirectoryPreference( workDirectoryString);
        }
        // Change settings to default (FILES_ONLY) so dialog isn't stuck in browse for folders mode
-       // This has to be done as last step since it wipes selectedFile value
+       // This has to be done as last step since it wipes selectedFile value (on OSX, issue 869)
        dlog.setFileSelectionMode(JFileChooser.FILES_ONLY);
        return outFilename;
     }

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -287,6 +287,7 @@ public final class FileUtils {
            setWorkingDirectoryPreference( workDirectoryString);
        }
        // Change settings to default (FILES_ONLY) so dialog isn't stuck in browse for folders mode
+       // This has to be done as last step since it wipes selectedFile value
        dlog.setFileSelectionMode(JFileChooser.FILES_ONLY);
        return outFilename;
     }


### PR DESCRIPTION
Fixes issue #869

### Brief summary of changes
When user makes selection of Folder on OSX, we use that as the new WorkingDirectory for future browsing. This minor refactoring avoids using selectedFile after changing the file browser settings (which wipes out the selected file on OSX but not windows)

### Testing I've completed
Launched browse for folder dialog from scripting shell on osx and selected folders without issue or null ponters
### CHANGELOG.md (choose one)

- no need to update because bugfix
