### PR TITLE
Update "restore" button tooltip per feedback on PR, issue 817

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
@@ -753,7 +753,7 @@ public class OpenSimGeometryPathEditorPanel extends javax.swing.JPanel {
       RestoreButton = new javax.swing.JButton();
       RestoreButton.setText("Restore");
       RestoreButton.setBounds(X + 300, Y + 20 + numGuiLines * 25, 70, 21);
-      RestoreButton.setToolTipText("Restore current Path to status on entry.");
+      RestoreButton.setToolTipText("Undo all changes since opening the Geometry Path dialog");
       RestoreButton.addActionListener(new ActionListener(){
 
             @Override


### PR DESCRIPTION
Fixes issue #817

### Brief summary of changes
Tooltip text update
### Testing I've completed
Opened a model with a muscle, and opened GeometryPath dialog, Restore button now has correct tooltip.
### CHANGELOG.md (choose one)

- no need to update because tooltips are not documented anywhere.