### PR TITLE
Use OpenSimContext setLocation method

### DIFF
--- a/Gui/opensim/modeling/src/org/opensim/modeling/OpenSimContext.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/OpenSimContext.java
@@ -218,7 +218,11 @@ public class OpenSimContext extends OpenSimObject {
   }
 
   public void setLocation(PathPoint mp, int i, double d) {
-    opensimActuatorsAnalysesToolsJNI.OpenSimContext_setLocation(swigCPtr, this, PathPoint.getCPtr(mp), mp, i, d);
+    opensimActuatorsAnalysesToolsJNI.OpenSimContext_setLocation__SWIG_0(swigCPtr, this, PathPoint.getCPtr(mp), mp, i, d);
+  }
+
+  public void setLocation(PathPoint mp, Vec3 newLocation) {
+    opensimActuatorsAnalysesToolsJNI.OpenSimContext_setLocation__SWIG_1(swigCPtr, this, PathPoint.getCPtr(mp), mp, Vec3.getCPtr(newLocation), newLocation);
   }
 
   public void setEndPoint(PathWrap mw, int newEndPt) {

--- a/Gui/opensim/view/src/org/opensim/view/nodes/PathPointAdapter.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/PathPointAdapter.java
@@ -75,7 +75,7 @@ public class PathPointAdapter  {
         final Vec3 oldLocation = new Vec3(pathpoint.get_location());
         //System.out.println("oldLocation:"+oldLocation.get(1));
         context.cacheModelAndState();
-        pathpoint.set_location(newLocation);
+        context.setLocation(pathpoint, newLocation);
         try {
             context.restoreStateFromCachedModel();
         } catch (IOException ex) {
@@ -85,7 +85,8 @@ public class PathPointAdapter  {
         if (!hasWrapping)
             updateDisplay(); 
         else{
-            ViewDB.getInstance().updateModelDisplay(model);
+           ViewDB.getInstance().updatePathDisplay(pathpoint.getModel(), currentPath, 0, -1);
+           ViewDB.getInstance().updateModelDisplay(model);
         }
         if (enableUndo){
              AbstractUndoableEdit auEdit = new AbstractUndoableEdit(){


### PR DESCRIPTION
Properly edit GeometryPath point location and recreate the system, also refresh path display on edit/undo.

Fixes issue #816

### Brief summary of changes
In the past, graphical editing of pathpoint called set_location directly on the pathpoint which is incomplete since Path cache entry and system underneath weren't updated. This PR (along with opensim-core https://github.com/opensim-org/opensim-core/pull/2234) fixes this by making the right call sequence when doing graphical editing consistent with how it's done in path edit dialog.

### Testing I've completed
Can move pathpoints on GeometryPaths with wrapping and undo the changes

### CHANGELOG.md (choose one)

- no need to update because bugfix