### PR TITLE
Use older xcode image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
 
 before_deploy:
   - ls $TRAVIS_BUILD_DIR/Gui/opensim/dist
-  - export PKGNAME=OpenSim-latest.pkg
+  - export PKGNAME=OpenSim-$TRAVIS_BRANCH.pkg
   - mkdir ~/to_deploy
   - mv $TRAVIS_BUILD_DIR/Gui/opensim/dist/OpenSim-$VERSION.pkg ~/to_deploy/$PKGNAME
 
@@ -84,7 +84,7 @@ deploy:
   skip_cleanup: true
   script: rsync --archive --compress --verbose ~/to_deploy/$PKGNAME opensim-bot@frs.sourceforge.net:/home/frs/project/myosin/opensim-gui
   on:
-    branch: master
+    # TODO branch: master
     condition: "$DEPLOY = yes"
  
 # Process for securely uploading files to Sourceforge, taken from

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ deploy:
   script: rsync --archive --compress --verbose ~/to_deploy/$PKGNAME opensim-bot@frs.sourceforge.net:/home/frs/project/myosin/opensim-gui
   on:
     # TODO branch: master
+    all_branches: true
     condition: "$DEPLOY = yes"
  
 # Process for securely uploading files to Sourceforge, taken from

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ git:
   # the submodules.
   submodules: false
 
+# Fixing https://github.com/opensim-org/opensim-gui/issues/931
+# https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+osx_image: xcode8.3
+
 matrix:
   include:
     - os: osx


### PR DESCRIPTION
Fixes #931.

### Brief summary of changes

Use an older xcode image that provides an older version of Java.

### Testing I've completed

Waiting to see if CI completes successfully.

### CHANGELOG.md (choose one)

- no need to update because...CI does not affect users.