### PR TITLE
Fix scaleup factor for  path points to 1.05 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -151,7 +151,7 @@ public class ModelVisualizationJson extends JSONObject {
     // Preferences
     private double prefMuscleDisplayRadius=0.005;
     private int NUM_PATHPOINTS_PER_WRAP_OBJECT=8;
-    private double PATHPOINT_SCALEUP=1.0;
+    private double PATHPOINT_SCALEUP=1.05;
     
     public Boolean getFrameVisibility(Frame b) {
         return visualizerFrames.get(b).visible;
@@ -417,10 +417,6 @@ public class ModelVisualizationJson extends JSONObject {
         Preferences.userNodeForPackage(TheApp.class).put("Muscle Display Radius", currentSize);
         prefMuscleDisplayRadius = Double.parseDouble(currentSize);
         actualMuscleDisplayRadius = 8*200*prefMuscleDisplayRadius;
-        saved = "1.0";
-        currentSize= Preferences.userNodeForPackage(TheApp.class).get("PathPoint Scaleup", saved);
-        Preferences.userNodeForPackage(TheApp.class).put("PathPoint Scaleup", currentSize);
-        PATHPOINT_SCALEUP = Double.parseDouble(currentSize);
         createJsonForModel(model);
         ready = true;
         if (verbose)


### PR DESCRIPTION
Fixes issue #796

### Brief summary of changes
Removed use of preference and fixed the number used to scaleup pathpoint to 1.05, stale preference will be handled with issue that handles new preferences in 4.0

### Testing I've completed
Loaded model, got reasonable sized pathpoints similar to 3.3, changed preferences had no effect on reloading

### CHANGELOG.md (choose one)

- no need to update because restores old behavior
