### PR TITLE
update "OpenSimResourcesDir" preference on successful install

### DIFF
--- a/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
@@ -273,6 +273,8 @@ public final class TheApp {
                 }
             }
             OpenSimLogger.logMessage("Done.", OpenSimLogger.INFO);
+            // Set preference to use the latest ResourcesDir from now on
+            TheApp.getCurrentVersionPreferences().put("Internal.OpenSimResourcesDir", userSelection);
             return userSelection;
         }
         else


### PR DESCRIPTION
 so that future calls from Scripts find the latest installed Scripts/models

Fixes issue #736 partially

### Brief summary of changes
Made installResources() internally updates OpenSimResourcesDir(). This may become less relevant when we installResources on every fresh install (issue #941)

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
