### PR TITLE
No need to hide quadrants since they were removed from opensim-core

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneGeometryNode.java
@@ -113,9 +113,6 @@ public class OneGeometryNode extends OneComponentWithGeometryNode {
             set.remove("origin");
             set.remove("direction");
         }
-        if (AnalyticGeometry.safeDownCast(comp)!=null){
-            set.remove("quadrants");
-        }
         set.remove("scale_factors");
         return sheet;
     }


### PR DESCRIPTION
Fixes issue #346

### Brief summary of changes
Remove the line that hides quadrants Property from PropertyEditor in the GUI since Property "quadrants" has been removed from "AnalyticGeometry" types.

### Testing I've completed
Built gui and verified all the checkmarks tested earlier by @carmichaelong still check and that no quadrants property is shown in the GUI

### CHANGELOG.md (choose one)

- no need to update because Geometry is a new feature in 4.0