### PR TITLE
Read whole data file to define external loads 

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/EditExternalLoadsPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/EditExternalLoadsPanel.java
@@ -131,7 +131,7 @@ public class EditExternalLoadsPanel extends javax.swing.JPanel
         if (dataFileName!="" && dataFileName !=null && new File(dataFileName).exists() && 
                 new File(dataFileName).isFile()){
             try {
-                externalLoadsStorage = new Storage(dataFileName, true);
+                externalLoadsStorage = new Storage(dataFileName);
             } catch (IOException ex) {
                 ErrorDialog.displayExceptionDialog(ex);
             }


### PR DESCRIPTION
not just header to workaround failure to handle read-headers-only in mot/sto version >= 2

Fixes issue #949

### Brief summary of changes
Used constructor of Storage that reads whole file rather than headers only.  

### Testing I've completed
Checked there's no other reference to the constructor that utilizes read-headers-only. Was able to define ExternalLoads without issue after building the GUI. 

### CHANGELOG.md (choose one)

- no need to update because this is internal.