### PR TITLE
Fix preference initialization in installer.java

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/Installer.java
+++ b/Gui/opensim/view/src/org/opensim/view/Installer.java
@@ -183,8 +183,8 @@ public class Installer extends ModuleInstall {
          String muscleRadius = "8";
          saved = TheApp.getCurrentVersionPreferences().get("Visualizer: Muscle Display Radius (mm)", muscleRadius);
          TheApp.getCurrentVersionPreferences().put("Visualizer: Muscle Display Radius (mm)", saved);
-
-         String experimentalMarkerDisplayScaleStr="5.0";
+         // The following value should stay the same as the value in MotionDisplayer constructor
+         String experimentalMarkerDisplayScaleStr="10";
          saved=TheApp.getCurrentVersionPreferences().get("Visualizer: Experimental Marker Radius (mm)", experimentalMarkerDisplayScaleStr);
          TheApp.getCurrentVersionPreferences().put("Visualizer: Experimental Marker Radius (mm)", saved);
          

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionDisplayer.java
@@ -375,6 +375,7 @@ public class MotionDisplayer {
     
     /** Creates a new instance of MotionDisplayer */
     public MotionDisplayer(Storage motionData, Model model) {
+         // The following value should stay the same as the value in Installer.java
         String defaultMarkerRadiusString = "10"; // new default per issue #643
         String currentSize =TheApp.getCurrentVersionPreferences().get("Visualizer: Experimental Marker Radius (mm)", 
                 defaultMarkerRadiusString);


### PR DESCRIPTION
Fixes issue #643 

### Brief summary of changes
Default Experimental Marker radius is specified in two places, one of them was not updated. Fixed in this PR and added comment to indicate that change in one place should update the other.  

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because bugfix
