### PR TITLE
Use Ctrl-D on windows, Cmd-D on osx to save scripts

### DIFF
--- a/Gui/opensim/scriptingShell/src/org/opensim/console/layer.xml
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/layer.xml
@@ -77,7 +77,7 @@
         <file name="F5.shadow">  
         <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-console-ToolsRunCurrentScriptAction.instance"/> 
         </file>
-        <file name="C-W.shadow">  
+        <file name="C-D.shadow">  
         <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-console-ScriptsSaveAction.instance"/> 
         </file>
     </folder>

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/layer.xml
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/layer.xml
@@ -77,7 +77,7 @@
         <file name="F5.shadow">  
         <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-console-ToolsRunCurrentScriptAction.instance"/> 
         </file>
-        <file name="C-D.shadow">  
+        <file name="D-D.shadow">  
         <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-console-ScriptsSaveAction.instance"/> 
         </file>
     </folder>


### PR DESCRIPTION
Fixes issue #963

### Brief summary of changes
Use C-D instead of C-W in layer.xml to save scripts (this translates to Ctrl-D on Winodws, Cmd-D on osx)

### Testing I've completed
Tested on windows, loading a script, modify, save with Ctrl-D works as expected.

### CHANGELOG.md (choose one)

- Need to update user guide screencap