### PR TITLE
Remove start menu shortcuts on uninstall

### DIFF
--- a/Gui/opensim/installer_files/Windows/make_installer.nsi
+++ b/Gui/opensim/installer_files/Windows/make_installer.nsi
@@ -124,5 +124,6 @@ Section "Uninstall"
   RMDir /r "$INSTDIR"
 
   DeleteRegKey /ifempty HKCU "Software\OpenSim@VERSION@"
-
+  Delete "$SMPROGRAMS\OpenSim\OpenSim @VERSION@.lnk"
+  Delete "$SMPROGRAMS\OpenSim\Uninstall OpenSim @VERSION@.lnk"
 SectionEnd


### PR DESCRIPTION
Fixes issue #979
### Brief summary of changes
Add lines to remove shortcuts from start menu upon uninstall on windows
### Testing I've completed
Created installer locally ran it then ran uninstall and the shortcuts were removed. This is important in developers/testers environment where multiple installations are commonplace.

### CHANGELOG.md (choose one)

- no need to update because bugfix
