### PR TITLE
Restore scripts menu to standard layout

### DIFF
--- a/Gui/opensim/scriptingShell/src/org/opensim/console/ScriptsRunBrowseAction.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/ScriptsRunBrowseAction.java
@@ -26,13 +26,8 @@
  */
 package org.opensim.console;
 
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
 import org.openide.cookies.OpenCookie;
 import org.openide.filesystems.FileObject;
 import org.openide.filesystems.FileUtil;
@@ -41,7 +36,6 @@ import org.openide.util.HelpCtx;
 import org.openide.util.actions.CallableSystemAction;
 import org.opensim.utils.ErrorDialog;
 import org.opensim.utils.FileUtils;
-import org.opensim.utils.TheApp;
 
 public final class ScriptsRunBrowseAction extends CallableSystemAction {
 
@@ -71,7 +65,7 @@ public final class ScriptsRunBrowseAction extends CallableSystemAction {
     public HelpCtx getHelpCtx() {
          return HelpCtx.DEFAULT_HELP;
     }
-
+/*
     public JMenuItem getMenuPresenter() {
         JMenu scriptsMenu = new JMenu("Open");
         FileFilter fileFilter = new FileFilter() {
@@ -80,7 +74,7 @@ public final class ScriptsRunBrowseAction extends CallableSystemAction {
                 return (!file.isDirectory() && file.getName().endsWith(".py"));
             }
         };
-        final String ScriptsRootDirectory = TheApp.getCurrentVersionPreferences().get("Paths: Scripts Path", TheApp.getResourcesDir()+"/Code/GUI/");
+        final String ScriptsRootDirectory = TheApp.getCurrentVersionPreferences().get("Paths: Scripts Path", "Scripts");
         File rootHelpDirectory = new File(ScriptsRootDirectory);
         final String fullPath = rootHelpDirectory.getAbsolutePath();
         File[] files = rootHelpDirectory.listFiles(fileFilter);
@@ -115,7 +109,7 @@ public final class ScriptsRunBrowseAction extends CallableSystemAction {
         scriptsMenu.add(browseItem);
         return scriptsMenu;
     }
-
+*/
     /**
      * execute passed in scriptFilename in Scripting shell and echo contents
      * @param scriptFilename 

--- a/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
@@ -274,7 +274,8 @@ public final class TheApp {
             }
             OpenSimLogger.logMessage("Done.", OpenSimLogger.INFO);
             // Set preference to use the latest ResourcesDir from now on
-            TheApp.getCurrentVersionPreferences().put("Internal.OpenSimResourcesDir", userSelection);
+            TheApp.getCurrentVersionPreferences().put("Internal.OpenSimResourcesDir", userSelection);                 String defaultScriptsPath = userDir+"/Code/GUI/";
+            TheApp.getCurrentVersionPreferences().put("Paths: Scripts Path", userSelection+"/Code/GUI/");
             return userSelection;
         }
         else


### PR DESCRIPTION
Fixes issue #955 

### Brief summary of changes
PR #981 had a side effect of changing the Scripts menu. This PR undoes this change and also sets the ScriptsPath preference when user forces installResources()

### Testing I've completed
Tested on Mac (where Preferences are not persistent) and all worked as expected
### CHANGELOG.md (choose one)

- no need to update because bugfix
