### PR TITLE
Recreate path visualization on pathpoint type edit

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimGeometryPathEditorPanel.java
@@ -1451,10 +1451,11 @@ public class OpenSimGeometryPathEditorPanel extends javax.swing.JPanel {
                  break;
          }
          newPoint.setParentFrame(mp.getParentFrame());
-         openSimContext.realizeVelocity();
+         ViewDB.getInstance().removePathDisplay(currentPath);
          boolean result = openSimContext.replacePathPoint(currentPath, mp, newPoint);
          if (result == false) {
             // Reset the combo box state without triggering an event
+            updatePathDisplay(EditOperation.Recreate, -1);
             musclePointTypeComboBox.setEnabled(false);
             musclePointTypeComboBox.setSelectedIndex(oldType);
             musclePointTypeComboBox.setEnabled(true);
@@ -1478,6 +1479,7 @@ public class OpenSimGeometryPathEditorPanel extends javax.swing.JPanel {
          // update the panels
          updateAttachmentPanel();
          updateCurrentPathPanel();
+         updatePathDisplay(EditOperation.Recreate, -1);
       }
    }
    public void AttachmentPointEntered(javax.swing.JTextField field, int attachmentNum, int coordNum) {


### PR DESCRIPTION
Fixes issue #817

### Brief summary of changes
Edits to type of PathPoint were not following the standard workflow of removing the visualization then recreating it. Changed to follow the workflow.

### Testing I've completed
Followed scenario in issue #817 and got correct behavior, no exceptions

### CHANGELOG.md (choose one)

- no need to update because bugfix
