### PR TITLE
Remove Desktop shortcut that was created during installation

### DIFF
--- a/Gui/opensim/installer_files/Windows/make_installer.nsi
+++ b/Gui/opensim/installer_files/Windows/make_installer.nsi
@@ -124,6 +124,9 @@ Section "Uninstall"
   RMDir /r "$INSTDIR"
 
   DeleteRegKey /ifempty HKCU "Software\OpenSim@VERSION@"
+  ; delete start menu shortcuts
   Delete "$SMPROGRAMS\OpenSim\OpenSim @VERSION@.lnk"
   Delete "$SMPROGRAMS\OpenSim\Uninstall OpenSim @VERSION@.lnk"
+  ; Delete Desktop shortcut
+  Delete "$DESKTOP\OpenSim @VERSION@.lnk"
 SectionEnd


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Modified uninstall script on Windows to remove the Desktop shortcut created during install.

### Testing I've completed
Made installer, ran it, uninstalled, shortcut was removed.

### CHANGELOG.md (choose one)

- no need to update because bugfix
