### PR TITLE
Restore branding that was lost by earlier commit

### DIFF
--- a/Gui/opensim/nbproject/project.properties
+++ b/Gui/opensim/nbproject/project.properties
@@ -1,6 +1,6 @@
 app.icon=branding/core/core.jar/org/netbeans/core/startup/frame48.gif
 app.icon.icns=installer_files/OSX/opensim.icns
-app.name=${branding.token}
+app.name=OpenSim
 app.title=OpenSim
 auxiliary.org-netbeans-modules-apisupport-installer.license-type=no
 auxiliary.org-netbeans-modules-apisupport-installer.os-linux=false


### PR DESCRIPTION
Fixes issue #1013 

### Brief summary of changes
Restore branding/application name that was modified by commit removing dead code.
### Testing I've completed
None, will test on OSX artifact when PR is built.
### CHANGELOG.md (choose one)

- no need to update because bugfix