### PR TITLE
Adjust filtering out of Properties that are sockets

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimObjectNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OpenSimObjectNode.java
@@ -378,8 +378,8 @@ public class OpenSimObjectNode extends OpenSimNode {
                 AbstractProperty ap = obj.getPropertyByIndex(p);  
                 String propname = ap.getName();
                 // Skip over sockets and inputs per github issue
-                if (propname.matches("socket_(.*)_connectee_name") || 
-                        propname.matches("input_(.*)_connectee_name"))
+                if (propname.matches("socket_(.*)") || 
+                        propname.matches("input_(.*)"))
                     continue;
                 if (!ap.isListProperty()) {
                     if (ap.isObjectProperty() && ap.size() == 1) {


### PR DESCRIPTION
 Update to account for the removal of the connectee_name suffix from Property names

Fixes issue #1019

### Brief summary of changes
Filtering of Properties with name "socket_*_connectee_name" modified to "socket_*"

### Testing I've completed
Loaded model, verified sockets for joint displayed in one place as expected.

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
