### PR TITLE
Use model interfaces to add/remove markers rather than marker set

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/markerEditor/NewMarkerAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/markerEditor/NewMarkerAction.java
@@ -77,11 +77,8 @@ public class NewMarkerAction extends AbstractAction {
         Model model = markersNode.getModelForNode();
         Vec3 offset = new Vec3(0.11, 0.22, 0.33);
         MarkerSet markerset = model.getMarkerSet();
-        PhysicalFrame frameToUse;
-        if ( model.getBodySet().getSize()==0)
-            frameToUse = model.get_ground(); // model only has Ground
-        else// Model has at least one body in BodySet.
-            frameToUse = model.getBodyList().begin().__deref__();
+        // Alays create new marker in Ground, user can change that later
+        PhysicalFrame frameToUse = model.get_ground(); 
         String newMarkerName = makeUniqueMarkerName(markerset);
         Marker newMarker = new Marker();
         newMarker.setName(newMarkerName);

--- a/Gui/opensim/view/src/org/opensim/view/markerEditor/NewMarkerAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/markerEditor/NewMarkerAction.java
@@ -77,18 +77,19 @@ public class NewMarkerAction extends AbstractAction {
         Model model = markersNode.getModelForNode();
         Vec3 offset = new Vec3(0.11, 0.22, 0.33);
         MarkerSet markerset = model.getMarkerSet();
-        Body body = model.getBodySet().get(0);
-        if (body == null) {
-            return;
-        }
+        PhysicalFrame frameToUse;
+        if ( model.getBodySet().getSize()==0)
+            frameToUse = model.get_ground(); // model only has Ground
+        else// Model has at least one body in BodySet.
+            frameToUse = model.getBodyList().begin().__deref__();
         String newMarkerName = makeUniqueMarkerName(markerset);
         Marker newMarker = new Marker();
         newMarker.setName(newMarkerName);
         newMarker.set_location(offset);
-        newMarker.setParentFrame(body);
+        newMarker.setParentFrame(frameToUse);
         OpenSimContext context = OpenSimDB.getInstance().getContext(model);
         context.cacheModelAndState();
-        markerset.adoptAndAppend(newMarker);
+        model.addMarker(newMarker); // this makes the model adopt the newMarker internally
         try {
            context.restoreStateFromCachedModel();
        } catch (IOException ex) {

--- a/Gui/opensim/view/src/org/opensim/view/markerEditor/OneMarkerDeleteAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/markerEditor/OneMarkerDeleteAction.java
@@ -135,14 +135,12 @@ public final class OneMarkerDeleteAction extends CallableSystemAction {
         // Use Editing call sequence since removing a marker requires 
         // recreation of tree traversal/initialization
         OpenSimContext context = OpenSimDB.getInstance().getContext(model);
-        context.cacheModelAndState();
+        //context.cacheModelAndState();
         for (int i=0; i<markers.size(); i++)
             markerset.remove(Marker.safeDownCast(markers.get(i)));
-        try {
-            context.restoreStateFromCachedModel();
-        } catch (IOException ex) {
-            ErrorDialog.displayExceptionDialog(ex);
-        }
+        // invoke initSystem on the modified model so that traversal is updated and markers are 
+        // removed from component tree
+        context.recreateSystemAfterSystemExistsKeepStage();
         // Update the marker name list in the ViewDB.
         OpenSimDB.getInstance().getModelGuiElements(model).updateMarkerNames();
         SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);


### PR DESCRIPTION
Fixes issue #1008

### Brief summary of changes
Instead of performing edit operations on MarkerSet, addition of Markers, as well as loading from files now go through the Model class interfaces (addMarker and updateMarkerSet) after done with changes, full initSystem is invoked, enforcing that component traversal remains intact and that Component ownership tree is up-to-date.

### Testing I've completed
Loaded a model with markers, saved the markers to a file, deleted the markers form the model and then loaded the markers from the file, model files were identical before and after. Also tested loading a markerset file that contains names already in the model. In these cases, error is given and the new markers are ignored.

### CHANGELOG.md (choose one)

- no need to update because this is a bug fix
