### PR TITLE
Drop downs for Frames will show full path names 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/SingleModelGuiElements.java
+++ b/Gui/opensim/view/src/org/opensim/view/SingleModelGuiElements.java
@@ -166,9 +166,9 @@ public class SingleModelGuiElements {
             ArrayList<String> bNames = new ArrayList<String>();
             ArrayList<String> phFrameNames = new ArrayList<String>();
             while (!bi.equals(frames.end())) {
-                bNames.add(bi.getName());
+                bNames.add(bi.getAbsolutePathString());
                 if (PhysicalFrame.safeDownCast(bi.__deref__())!= null)
-                    phFrameNames.add(bi.getName());
+                    phFrameNames.add(bi.getAbsolutePathString());
                 bi.next();
             }
             frameNames = new String[bNames.size()];


### PR DESCRIPTION
This will help disambiguate names that could be ambiguous

Fixes issue #1025

### Brief summary of changes
When populating lists of Frames, use AbsolutePathString rather than getName() this list is used in all places where Frames are used for selection

### Testing I've completed
Changed frames for Marker(s) without an issue

### CHANGELOG.md (choose one)

- May need to update because in the past we showed only names and they were short and unique
