### PR TITLE
When showing list of Frames in dropdown, use correct model 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/editors/FrameNameEditor.java
+++ b/Gui/opensim/view/src/org/opensim/view/editors/FrameNameEditor.java
@@ -48,6 +48,7 @@ import org.openide.explorer.propertysheet.PropertyEnv;
 import org.openide.explorer.propertysheet.PropertyModel;
 import org.opensim.modeling.Model;
 import org.opensim.view.SingleModelGuiElements;
+import org.opensim.view.nodes.OpenSimObjectNode;
 import org.opensim.view.nodes.PropertyEditorAdaptor;
 import org.opensim.view.pub.OpenSimDB;
 import org.opensim.view.pub.ViewDB;
@@ -126,7 +127,12 @@ public class FrameNameEditor extends PropertyEditorSupport
         
         public void connect(PropertyEditor propertyEditor, PropertyEnv env) {
             editor = propertyEditor;
-            SingleModelGuiElements modelGuiElems = OpenSimDB.getInstance().getModelGuiElements(ViewDB.getCurrentModel());
+            Model model = ViewDB.getCurrentModel();
+            // replace ViewDB.getCurrentModel() with model from object being edited
+            if (env.getBeans().length >0 && env.getBeans()[0] instanceof OpenSimObjectNode){
+                model = ((OpenSimObjectNode) env.getBeans()[0]).getModelForNode();
+            }
+            SingleModelGuiElements modelGuiElems = OpenSimDB.getInstance().getModelGuiElements(model);
             picker.setModel(new DefaultComboBoxModel(modelGuiElems.getFrameNames()));
             reset();
         }

--- a/Gui/opensim/view/src/org/opensim/view/editors/FrameNameEditor.java
+++ b/Gui/opensim/view/src/org/opensim/view/editors/FrameNameEditor.java
@@ -97,10 +97,14 @@ public class FrameNameEditor extends PropertyEditorSupport
 
     public void attachEnv(PropertyEnv propertyEnv) {
         propertyEnv.registerInplaceEditorFactory(this);
+        if (propertyEnv.getBeans().length >0 && propertyEnv.getBeans()[0] instanceof OpenSimObjectNode){
+                mdl = ((OpenSimObjectNode) propertyEnv.getBeans()[0]).getModelForNode();
+        }
     }
 
     private InplaceEditor ed = null;
-
+    Model mdl = null;
+    
     public InplaceEditor getInplaceEditor() {
         if (ed == null) {
             ed = new Inplace();
@@ -110,9 +114,9 @@ public class FrameNameEditor extends PropertyEditorSupport
     }
 
     public void propertyChange(PropertyChangeEvent evt) {
-        // ignoe trivial events
+        // ignore trivial events
         if (evt.getNewValue()==null && evt.getOldValue()==null) return;
-        Model mdl = ViewDB.getCurrentModel();
+        
         PropertyEditorAdaptor pea = new PropertyEditorAdaptor(mdl); // Need Model, Object, Property, Node
         pea.handleModelChange();
     }
@@ -124,15 +128,16 @@ public class FrameNameEditor extends PropertyEditorSupport
     
         private final JComboBox picker = new JComboBox();
         private PropertyEditor editor = null;
+        private Model mdl = null;
         
         public void connect(PropertyEditor propertyEditor, PropertyEnv env) {
             editor = propertyEditor;
-            Model model = ViewDB.getCurrentModel();
+            mdl = ViewDB.getCurrentModel();
             // replace ViewDB.getCurrentModel() with model from object being edited
             if (env.getBeans().length >0 && env.getBeans()[0] instanceof OpenSimObjectNode){
-                model = ((OpenSimObjectNode) env.getBeans()[0]).getModelForNode();
+                mdl = ((OpenSimObjectNode) env.getBeans()[0]).getModelForNode();
             }
-            SingleModelGuiElements modelGuiElems = OpenSimDB.getInstance().getModelGuiElements(model);
+            SingleModelGuiElements modelGuiElems = OpenSimDB.getInstance().getModelGuiElements(mdl);
             picker.setModel(new DefaultComboBoxModel(modelGuiElems.getFrameNames()));
             reset();
         }


### PR DESCRIPTION
Pick model that the node belongs to rather than current model to create list of available frames

Fixes issue #1026 

### Brief summary of changes
FrameEditor now adjusts to the model of object being edited rather than assume current model regardless
### Testing I've completed
Loaded 2 models, tried editing joint frames, got correct frame selection/dropdown

### CHANGELOG.md (choose one)

- no need to update because bugfix
