### PR TITLE
[WIP] Support old states files

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionsDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionsDB.java
@@ -194,8 +194,10 @@ public class MotionsDB extends Observable // Observed by other entities in motio
       int numCoordinates = cs.getSize();
       int numUsedColumns = 0;    // Keep track of how many columns correspond to Coords or Markers
       for(int i=0; i<numCoordinates; i++){
+          String testName = cs.get(i).getRelativePathName(modelForMotion);
          if (newMotion.getStateIndex(cs.get(i).getName())!=-1 ||
-                 newMotion.getStateIndex(cs.get(i).getRelativePathName(modelForMotion)+"/value")!= -1){
+                 newMotion.getStateIndex(testName+"/value")!= -1 ||
+                 testName.length() > 9 && newMotion.getStateIndex(testName.substring(9)+"/value")!= -1) {
             numUsedColumns++;
             return true;
          }

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionsDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionsDB.java
@@ -197,6 +197,7 @@ public class MotionsDB extends Observable // Observed by other entities in motio
           String testName = cs.get(i).getRelativePathName(modelForMotion);
          if (newMotion.getStateIndex(cs.get(i).getName())!=-1 ||
                  newMotion.getStateIndex(testName+"/value")!= -1 ||
+                 // account for missing "/jointset" in state name specification
                  testName.length() > 9 && newMotion.getStateIndex(testName.substring(9)+"/value")!= -1) {
             numUsedColumns++;
             return true;


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
When loading states files from earlier Betas, column headers do not contain "jointset" for coordinates. 

### Testing I've completed
While I was able to associate the motion with the jumper model, motion doesn't play yet. Either because similar change needed for model.formStateStorage or storage.getStateIndex or on the GUI side/MotionDisplayer
### CHANGELOG.md (choose one)

- no need to update because...
- updated...
