### PR TITLE
Rather than name use full path as comment 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneComponentNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneComponentNode.java
@@ -120,6 +120,8 @@ public class OneComponentNode extends OpenSimObjectNode {
             nextNodeProp.setValue("canEditAsText", Boolean.FALSE);
             nextNodeProp.setValue("suppressCustomEditor", Boolean.TRUE);
             nextNodeProp.setName(outputName);
+            // String to show at bottom of Properties panel 
+            nextNodeProp.setShortDescription(anOutput.getPathName());
             sheetSet.put(nextNodeProp);
         } catch (NoSuchMethodException ex) {
             Exceptions.printStackTrace(ex);


### PR DESCRIPTION
This will allow output path to show at the bottom of Properties window, so it can be entered in OutputReporter by users

Fixes issue #0

### Brief summary of changes

### Testing I've completed
Loaded model, selected output and Fulll path displayed at the bottom

### CHANGELOG.md 

- We should update user guide to indicate how to use this OutputPath. Current format is not final pending opensim-core changes
