### PR TITLE
Avoid crash in runTutorialThree.py by cloning the model.

### DIFF
--- a/Gui/opensim/Scripts/runTutorialThree.py
+++ b/Gui/opensim/Scripts/runTutorialThree.py
@@ -69,8 +69,8 @@ scaleTool.run();
 ## load Scaled Model
 # Load model 
 loadModel(scaleModelName)
-# Get a handle to the current model
-myModel = getCurrentModel()
+# Create a copy of the scaled model for use with the tools.
+myModel = getCurrentModel().clone()
 #initialize
 myModel.initSystem()
 myState = myModel.initSystem()


### PR DESCRIPTION
This is a workaround for #1044.

### Brief summary of changes

- We avoid letting the InverseDynamics tool use the same model that the GUI has loaded.

### Testing I've completed

- Ensured the updated script does not cause the GUI to crash (after hitting the play button).

### CHANGELOG.md (choose one)

- no need to update because...this is within 4.0 development.

