### PR TITLE
Remove comma from format of large numbers

### DIFF
--- a/Gui/opensim/plotter/src/org/opensim/plotter/JPlotterPanel.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/JPlotterPanel.java
@@ -1985,7 +1985,7 @@ public class JPlotterPanel extends javax.swing.JPanel
               try {
                  NumberFormat numFormat = NumberFormat.getInstance();
                  if (numFormat instanceof DecimalFormat) {
-                    ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+                    ((DecimalFormat) numFormat).applyPattern("###0.#########");
                  }
                  double valueFromTextField = numFormat.parse(text).doubleValue();
                  jFormattedTextField.setText(numFormat.format(valueFromTextField));

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ActuatorsAndExternalLoadsPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ActuatorsAndExternalLoadsPanel.java
@@ -80,7 +80,7 @@ public class ActuatorsAndExternalLoadsPanel extends javax.swing.JPanel {
       this.model = model;
 
       if (numFormat instanceof DecimalFormat) {
-        ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+        ((DecimalFormat) numFormat).applyPattern("###0.#########");
       }
 
       initComponents();

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
@@ -139,7 +139,7 @@ public class AnalyzeAndForwardToolPanel extends BaseToolPanel implements Observe
       });
              
       if (numFormat instanceof DecimalFormat) {
-        ((DecimalFormat) numFormat).applyPattern("#,##0.############");
+        ((DecimalFormat) numFormat).applyPattern("###0.############");
       }
 
       initComponents();

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IKTaskSetPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IKTaskSetPanel.java
@@ -63,7 +63,7 @@ public class IKTaskSetPanel extends javax.swing.JPanel implements ListSelectionL
       ikCoordinateTasksTableModel = new IKTasksTableModel(ikCommonModel.getIKCoordinateTasksModel(), "Coordinate");
 
       if (numFormat instanceof DecimalFormat) {
-        ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+        ((DecimalFormat) numFormat).applyPattern("###0.#########");
       }
 
       initComponents();

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IKToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IKToolPanel.java
@@ -59,7 +59,7 @@ public class IKToolPanel extends BaseToolPanel implements Observer {
       ikToolModel = new IKToolModel(model);
 
       if (numFormat instanceof DecimalFormat) {
-        ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+        ((DecimalFormat) numFormat).applyPattern("###0.#########");
       }
       
       helpButton.addActionListener(new ActionListener() {

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
@@ -75,7 +75,7 @@ public class InverseDynamicsToolPanel extends BaseToolPanel implements Observer 
    public InverseDynamicsToolPanel(Model model) throws IOException {
       toolModel = new InverseDynamicsToolModel(model);
       if (numFormat instanceof DecimalFormat) {
-        ((DecimalFormat) numFormat).applyPattern("#,##0.############");
+        ((DecimalFormat) numFormat).applyPattern("###0.############");
       }
       
       initComponents();

--- a/Gui/opensim/tracking/src/org/opensim/tracking/MarkerDataInfoPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/MarkerDataInfoPanel.java
@@ -46,7 +46,7 @@ public class MarkerDataInfoPanel extends javax.swing.JPanel {
    /** Creates new form TRCFileInfoPanel */
    public MarkerDataInfoPanel() {
       if (doubleFormat instanceof DecimalFormat) {
-        ((DecimalFormat) doubleFormat).applyPattern("#,##0.#########");
+        ((DecimalFormat) doubleFormat).applyPattern("###0.#########");
       }
 
       initComponents();

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleFactorsPanel.form
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleFactorsPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.3" maxVersion="1.3" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <NonVisualComponents>

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleFactorsPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleFactorsPanel.java
@@ -64,7 +64,7 @@ public class ScaleFactorsPanel extends javax.swing.JPanel implements Observer {
       this.measurementSetDialog = measurementSetDialog;
 
       if (numFormat instanceof DecimalFormat) {
-        ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+        ((DecimalFormat) numFormat).applyPattern("###0.#########");
       }
 
       initComponents();

--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolPanel.java
@@ -85,7 +85,7 @@ public class ScaleToolPanel extends BaseToolPanel implements Observer {
       //scaleToolModel.loadSettings("C:\\eran\\dev\\simbios\\opensim\\Trunk\\OpenSim\\Examples\\Gait2354\\subject01_Setup_Scale.xml");
 
       if (numFormat instanceof DecimalFormat) {
-        ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+        ((DecimalFormat) numFormat).applyPattern("###0.#########");
       }
 
       

--- a/Gui/opensim/view/src/org/opensim/view/TextSliderJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/TextSliderJPanel.java
@@ -62,7 +62,7 @@ public class TextSliderJPanel extends javax.swing.JPanel implements ChangeListen
     /** Creates new form TextSliderJPanel */
     public TextSliderJPanel() {
        if (numFormat instanceof DecimalFormat) {
-         ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+         ((DecimalFormat) numFormat).applyPattern("###0.#########");
        }
 
        initComponents();

--- a/Gui/opensim/view/src/org/opensim/view/editors/OpenSimObjectModel.java
+++ b/Gui/opensim/view/src/org/opensim/view/editors/OpenSimObjectModel.java
@@ -96,7 +96,7 @@ public class OpenSimObjectModel extends AbstractTreeTableModel {
     this.isEditable = isEditable;
     root = new PropertyNode(obj);
     if (numFormat instanceof DecimalFormat) {
-      ((DecimalFormat) numFormat).applyPattern("#,##0.#########");
+      ((DecimalFormat) numFormat).applyPattern("###0.#########");
     }
   }
 


### PR DESCRIPTION
Fixes issue #1057

### Brief summary of changes
Changed format string to not include commas

### Testing I've completed


### CHANGELOG.md (choose one)

- no need to update because bugfix