### PR TITLE
Undo refactoring unit conversion of marker data

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -120,7 +120,7 @@ public class AnnotatedMotion extends Storage {
                 getBoundingBox()[4]+", "+
                 getBoundingBox()[5]
                 );
-        for (int i=0; i<6; i++) getBoundingBox()[i] *= getUnitConversion();
+        for (int i=0; i<6; i++) getBoundingBox()[i]/= getUnitConversion();
         setBoundingBoxComputed(true);
     }
 
@@ -273,7 +273,7 @@ public class AnnotatedMotion extends Storage {
 
     public void setUnitConversion(double unitConversion) {
         this.unitConversion = unitConversion;
-        for (int i=0; i<6; i++) getBoundingBox()[i]*= unitConversion;
+        for (int i=0; i<6; i++) getBoundingBox()[i]/= unitConversion;
     }
 
     public boolean isBoundingBoxComputed() {

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalMarker.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalMarker.java
@@ -87,9 +87,9 @@ public class ExperimentalMarker extends MotionObjectBodyPoint {
     @Override
     void updateDecorations(ArrayDouble interpolatedStates) {
         int idx = getStartIndexInFileNotIncludingTime();
-        setPoint(new double[]{interpolatedStates.get(idx)*conversion, 
-            interpolatedStates.get(idx+1)*conversion, 
-            interpolatedStates.get(idx+2)*conversion});
+        setPoint(new double[]{interpolatedStates.get(idx)/conversion, 
+            interpolatedStates.get(idx+1)/conversion, 
+            interpolatedStates.get(idx+2)/conversion});
     }
     
     // Create JSON object to represent ExperimentalMarker
@@ -115,7 +115,7 @@ public class ExperimentalMarker extends MotionObjectBodyPoint {
         conversion = mot.getUnitConversion();
         JSONArray pos = new JSONArray();
         for (int i = 0; i < 3; i++) {
-            pos.add(interpolatedStates.get(idx+i)*conversion);
+            pos.add(interpolatedStates.get(idx+i)/conversion);
         }
         expMarker_json.put("position", pos);
         expMarker_json.put("castShadow", false);

--- a/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
@@ -55,7 +55,7 @@ public final class FileLoadDataAction extends CallableSystemAction {
                     Storage newStorage = new Storage();
                     markerData.makeRdStorage(newStorage);
                     AnnotatedMotion amot = new AnnotatedMotion(newStorage, markerData.getMarkerNames());
-                    amot.setUnitConversion(markerData.getUnits().convertTo(Units.UnitType.Meters));
+                    amot.setUnitConversion(1.0/(markerData.getUnits().convertTo(Units.UnitType.Meters)));
                     amot.setName(new File(fileName).getName());
                     amot.setDataRate(markerData.getDataRate());
                     amot.setCameraRate(markerData.getCameraRate());


### PR DESCRIPTION
Fixes issue #0

Can't associate marker data trc file with IK motion in tutorial 3

### Brief summary of changes
Undo seemingly innocent refactoring to unit conversion, that resulted in marker data not showing altogether

### Testing I've completed
Ran IK, loaded motion, associate marker data, and force data successfully and animated
Loaded trc files in (meters) and in mm and played them back without an issue.

### CHANGELOG.md (choose one)

- no need to update because bugfix