### PR TITLE
Save/Restore state around running the analyzeTool (by the plotter)

### DIFF
--- a/Gui/opensim/plotter/src/org/opensim/plotter/JPlotterPanel.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/JPlotterPanel.java
@@ -1635,9 +1635,11 @@ public class JPlotterPanel extends javax.swing.JPanel
       //double[] saveStates = new double[numStates];
       // FIX40 openSimContext.getStates(saveStates);
       State saveState = openSimContext.getCurrentStateCopy();
-      //openSimContext.cacheModelAndState();
-      Storage extendedMotionStorage;
-      int key = (int) (java.lang.Math.random()*100);
+      // We'll cache in the Y vector of the state to restore it after running the tool since the tool
+      // leaves the model at an undefined position 
+       org.opensim.modeling.Vector saveY = new org.opensim.modeling.Vector(saveState.getY());
+
+       int key = (int) (java.lang.Math.random()*100);
       if (motion != null && motion instanceof PlotterSourceMotion){
          tool.setStartTime( motion.getStorage().getFirstTime());
          tool.setFinalTime( motion.getStorage().getLastTime());
@@ -1702,13 +1704,10 @@ public class JPlotterPanel extends javax.swing.JPanel
       } catch (IOException ex) {
          ErrorDialog.displayExceptionDialog(ex);
       }
-      /*
-        try {
-            openSimContext.restoreStateFromCachedModel();
-        } catch (IOException ex) {
-            Exceptions.printStackTrace(ex);
-        } */
+      // Restore the state vector we saved beforehand so the model pose doesn't change in GUI (issue #1052)
+      openSimContext.getCurrentStateRef().setY(saveY);
       openSimContext.realizeVelocity();
+
       MuscleAnalysis analysis = MuscleAnalysis.safeDownCast(currentModel.getAnalysisSet().get("MuscleAnalysis"));
       analysisSource.updateStorage(analysis);
       //analysisSource.getStorage().print("toolOutput"/*+key*/+".sto");


### PR DESCRIPTION
 This is necessary since the GUI and tool share the same State reference.

Fixes issue #1052

### Brief summary of changes
Save/restore the State's Y vector so it doesn't get polluted by the plot/analyzeTool run.

### Testing I've completed
Tested workflow in bug report and got correct behavior

### CHANGELOG.md (choose one)

- no need to update because bugfix