### PR TITLE
Before trying to load SO results (activation) 

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeToolModel.java
@@ -169,10 +169,12 @@ public class AnalyzeToolModel extends AbstractToolModelWithExternalLoads {
             // Since the analysis will go out of scope and potentially get deleted
             // make a fresh copy of the activation Storage
             // it will be free'd when not in use anymore (gc)
-            Storage storageCopy = new Storage(soA.getActivationStorage(), true);
-            MuscleColoringFunction mcbya = new MuscleColorByActivationStorage(
-                OpenSimDB.getInstance().getContext(getOriginalModel()), storageCopy);
-            MotionsDB.getInstance().getDisplayerForMotion(motion).setMuscleColoringFunction(mcbya);
+            if (soA.getActivationStorage()!=null){ // This will be null if SO failed to run, don't try to load it
+                Storage storageCopy = new Storage(soA.getActivationStorage(), true);
+                MuscleColoringFunction mcbya = new MuscleColorByActivationStorage(
+                    OpenSimDB.getInstance().getContext(getOriginalModel()), storageCopy);
+                MotionsDB.getInstance().getDisplayerForMotion(motion).setMuscleColoringFunction(mcbya);
+            }
          } 
          getModel().removeAnalysis(animationCallback, false);
          getModel().removeAnalysis(interruptingCallback, false);


### PR DESCRIPTION
check that there are valid results before trying to visualize them

Fixes issue #1061 partly

### Brief summary of changes
Before loading activations, make sure the storage containing them is not null

### Testing I've completed
Run through issue steps and now only get first error due to missing/failed-to-locate force-data file.

### CHANGELOG.md (choose one)

- no need to update because bugfix