### PR TITLE
Redo refactoring unit conversion of marker data

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -120,7 +120,7 @@ public class AnnotatedMotion extends Storage {
                 getBoundingBox()[4]+", "+
                 getBoundingBox()[5]
                 );
-        for (int i=0; i<6; i++) getBoundingBox()[i]/= getUnitConversion();
+        for (int i=0; i<6; i++) getBoundingBox()[i] *= getUnitConversion();
         setBoundingBoxComputed(true);
     }
 
@@ -273,7 +273,7 @@ public class AnnotatedMotion extends Storage {
 
     public void setUnitConversion(double unitConversion) {
         this.unitConversion = unitConversion;
-        for (int i=0; i<6; i++) getBoundingBox()[i]/= unitConversion;
+        for (int i=0; i<6; i++) getBoundingBox()[i] *= unitConversion;
     }
 
     public boolean isBoundingBoxComputed() {

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalMarker.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/ExperimentalMarker.java
@@ -87,9 +87,9 @@ public class ExperimentalMarker extends MotionObjectBodyPoint {
     @Override
     void updateDecorations(ArrayDouble interpolatedStates) {
         int idx = getStartIndexInFileNotIncludingTime();
-        setPoint(new double[]{interpolatedStates.get(idx)/conversion, 
-            interpolatedStates.get(idx+1)/conversion, 
-            interpolatedStates.get(idx+2)/conversion});
+        setPoint(new double[]{interpolatedStates.get(idx)*conversion, 
+            interpolatedStates.get(idx+1)*conversion, 
+            interpolatedStates.get(idx+2)*conversion});
     }
     
     // Create JSON object to represent ExperimentalMarker
@@ -115,7 +115,7 @@ public class ExperimentalMarker extends MotionObjectBodyPoint {
         conversion = mot.getUnitConversion();
         JSONArray pos = new JSONArray();
         for (int i = 0; i < 3; i++) {
-            pos.add(interpolatedStates.get(idx+i)/conversion);
+            pos.add(interpolatedStates.get(idx+i)*conversion);
         }
         expMarker_json.put("position", pos);
         expMarker_json.put("castShadow", false);

--- a/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
@@ -55,7 +55,7 @@ public final class FileLoadDataAction extends CallableSystemAction {
                     Storage newStorage = new Storage();
                     markerData.makeRdStorage(newStorage);
                     AnnotatedMotion amot = new AnnotatedMotion(newStorage, markerData.getMarkerNames());
-                    amot.setUnitConversion(1.0/(markerData.getUnits().convertTo(Units.UnitType.Meters)));
+                    amot.setUnitConversion(markerData.getUnits().convertTo(Units.UnitType.Meters));
                     amot.setName(new File(fileName).getName());
                     amot.setDataRate(markerData.getDataRate());
                     amot.setCameraRate(markerData.getCameraRate());

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionAssociateMotionAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionAssociateMotionAction.java
@@ -60,7 +60,7 @@ public final class MotionAssociateMotionAction extends CallableSystemAction {
                     Storage newStorage = new Storage();
                     markerData.makeRdStorage(newStorage);
                     AnnotatedMotion amot = new AnnotatedMotion(newStorage, markerData.getMarkerNames());
-                    amot.setUnitConversion(1.0/(markerData.getUnits().convertTo(Units.UnitType.Meters)));
+                    amot.setUnitConversion(markerData.getUnits().convertTo(Units.UnitType.Meters));
                     amot.setName(new File(fileName).getName());
                     amot.setDataRate(markerData.getDataRate());
                     amot.setCameraRate(markerData.getCameraRate());


### PR DESCRIPTION
Fixes issue #1069 

### Brief summary of changes
Undo #1069. Refactor was a positive change and the undo did not address the actual issue that there are two marker display pathways that load markers (and their unit conversion).  Previously "Preview Experimenal Data..." was used to verify the refactor however the "Asscociate Motion Data.." pathway was not tested.

Update to MotionAssociateMotionAction.java was all that was required to keep the refactor.

### Testing I've completed
The following marker data related tasks were tested loacally:
- "Preview Experimenal Data..."
-  "Asscociate Motion Data.."
- IK

### CHANGELOG.md (choose one)
- no need to update because just code cleanup