### PR TITLE
Marker location update

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/JSONMessageHandler.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/JSONMessageHandler.java
@@ -31,10 +31,12 @@ import java.util.UUID;
 import javax.swing.SwingUtilities;
 import org.json.simple.JSONObject;
 import org.opensim.modeling.AbstractProperty;
+import org.opensim.modeling.Marker;
 import org.opensim.modeling.Model;
 import org.opensim.modeling.OpenSimObject;
 import org.opensim.modeling.PathPoint;
 import org.opensim.modeling.Vec3;
+import org.opensim.view.nodes.MarkerAdapter;
 import org.opensim.view.nodes.PathPointAdapter;
 import org.opensim.view.nodes.PropertyEditorAdaptor;
 import org.opensim.view.pub.ViewDB;
@@ -67,6 +69,14 @@ public class JSONMessageHandler {
                         JSONObject locationJson = (JSONObject) jsonObject.get("location");
                         Vec3 locationVec3 = convertJsonXYZToVec3(locationJson);
                         pptAdapter.setLocation(locationVec3, true);
+                        return;
+                    }
+                    if (Marker.safeDownCast(opensimObj)!=null){
+                        Marker mkr = Marker.safeDownCast(opensimObj);
+                        MarkerAdapter markerAdapter = new MarkerAdapter(mkr);
+                        JSONObject locationJson = (JSONObject) jsonObject.get("location");
+                        Vec3 locationVec3 = convertJsonXYZToVec3(locationJson);
+                        markerAdapter.setLocation(locationVec3, true);
                         return;
                     }
                     if (opensimObj != null && opensimObj.hasProperty("location")){

--- a/Gui/opensim/view/src/org/opensim/view/nodes/MarkerAdapter.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/MarkerAdapter.java
@@ -122,23 +122,22 @@ public class MarkerAdapter  {
         //    Exceptions.printStackTrace(ex);
         //    return;
         //}
-       setOffset(d, true);
+       setLocation(d.getAsVec3(), true);
     }
-    private void setOffset(final ArrayDouble newOffset, boolean enableUndo) {
+    public void setLocation(final Vec3 newOffset, boolean enableUndo) {
         Vec3 rOffest = marker.get_location();
-        final ArrayDouble oldOffset = new ArrayDouble(3);
-        for(int i=0; i<3; i++) oldOffset.set(i, rOffest.get(i));
-         marker.set_location(newOffset.getAsVec3());
+        final Vec3 oldOffset = new Vec3(rOffest);
+        marker.set_location(newOffset);
         updateDisplay(); 
         if (enableUndo){
              AbstractUndoableEdit auEdit = new AbstractUndoableEdit(){
                public void undo() throws CannotUndoException {
                    super.undo();
-                   setOffset(oldOffset, false);
+                   setLocation(oldOffset, false);
                }
                public void redo() throws CannotRedoException {
                    super.redo();
-                   setOffset(newOffset, true);
+                   setLocation(newOffset, true);
                }
             };
             ExplorerTopComponent.addUndoableEdit(auEdit);            
@@ -183,5 +182,4 @@ public class MarkerAdapter  {
         SingleModelGuiElements guiElem = OpenSimDB.getInstance().getModelGuiElements(model);
         guiElem.setUnsavedChangesFlag(true);
     }
-
 }


### PR DESCRIPTION
Fixes issue #1060 
### Brief summary of changes
Instead of setting the location property of Marker thru graphical edit directly, invoke the PropertyEditor workflow to updated location so users get feedback immediately.

### Testing I've completed
Editing markers graphically updates properties window immediately now, likely avoid the situation leading to 1060 where graphical display and numbers are not in sync.. 

### CHANGELOG.md (choose one)

- no need to update because bugfix
