### PR TITLE
Update Frame visuals due to edit

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -180,6 +180,7 @@ public class ModelVisualizationJson extends JSONObject {
         ComponentsList mcList = subtreeRoot.getComponentsList();
         ComponentIterator mcIter = mcList.begin();
         mcIter = mcList.begin();
+        mdh.set_show_frames(true); // This is needed so that Frames that are optionally visible are accounted for
         while (!mcIter.equals(mcList.end())) {
             Component comp = mcIter.__deref__();
             boolean visibleStatus = true;
@@ -212,6 +213,7 @@ public class ModelVisualizationJson extends JSONObject {
             }
             mcIter.next();
         }
+        mdh.set_show_frames(false);
         return msg;
     }
 


### PR DESCRIPTION
make sure Frames are marked as viible in ModelDisplayHints so they're not skipped over by the Geometry classes in opensim-core

Fixes issue #843
### Brief summary of changes
The function to update visualization on edit was skipping over Frames because the ModelDisplayHints defaults to Frames being not visible.

### Testing I've completed
Edit offset frames in tug-of-war and both the axes and attached Geometry are moved upon edit

### CHANGELOG.md (choose one)

- no need to update because bugfix
