### PR TITLE
AppVeyor: upload artifacts to Google Coud

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,8 +89,6 @@ after_test:
   - IF %APPVEYOR_REPO_BRANCH% EQU master SET DISTR=TRUE
   # Create and upload package.
   - cd %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\
-    # TODO - IF DEFINED DISTR "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
-    # TODO - IF DEFINED DISTR appveyor PushArtifact OpenSim-%VERSION%-win64.exe
   - "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
   - appveyor PushArtifact OpenSim-%VERSION%-win64.exe
   # - cd %APPVEYOR_BUILD_FOLDER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,9 +87,12 @@ after_test:
   # Detect if we are on the master branch.
   #- IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
   - IF %APPVEYOR_REPO_BRANCH% EQU master SET DISTR=TRUE
+  - SET DISTR=TRUE # TODO
   # Create and upload package.
   - cd %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\
-  - IF TRUE "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
+  - IF DEFINED DISTR "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
+  - IF DEFINED DISTR appveyor PushArtifact OpenSim-%VERSION%-win64.exe
+  - "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
   - appveyor PushArtifact OpenSim-%VERSION%-win64.exe
   # - cd %APPVEYOR_BUILD_FOLDER%
   # - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,8 +92,6 @@ after_test:
   - cd %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\
   - IF DEFINED DISTR "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
   - IF DEFINED DISTR appveyor PushArtifact OpenSim-%VERSION%-win64.exe
-  - "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
-  - appveyor PushArtifact OpenSim-%VERSION%-win64.exe
   # - cd %APPVEYOR_BUILD_FOLDER%
   # - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\
   # - IF DEFINED DISTR appveyor PushArtifact C:\OpenSim-%VERSION%.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,7 @@ deploy:
   password:
     secure: OlJM0z185NHw/D0pXoEZdw==
   folder: /home/frs/project/myosin/opensim-gui
-  artifact: %APPVEYOR_BUILD_FOLDER%/Gui/opensim/dist/installer/OpenSim-%VERSION%-win64.exe
+  artifact: OpenSim-%VERSION%-win64.exe
   # TODO   on:
   # TODO     branch: master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,9 @@ skip_branch_with_pr: true
 nuget:
   disable_publish_on_pr: true
 
+environment:
+  SOURCEFORGE_OPENSIM_BOT_PASSWORD:
+
 init:
   ## Set environment variables.
   - ps: $env:JAVA_HOME = "C:\Program Files\Java\jdk1.8.0"
@@ -91,3 +94,16 @@ after_test:
   # - cd %APPVEYOR_BUILD_FOLDER%
   # - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\
   # - IF DEFINED DISTR appveyor PushArtifact C:\OpenSim-%VERSION%.zip
+
+deploy:
+  provider: SFTP
+  protocol: ftps
+  host: frs.sourceforge.net
+  username: opensim-bot,myosin
+  password:
+    secure: OlJM0z185NHw/D0pXoEZdw==
+  folder: /home/frs/project/myosin/opensim-gui
+  artifact: %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\OpenSim-%VERSION%-win64.exe
+  # TODO   on:
+  # TODO     branch: master
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,8 +89,10 @@ after_test:
   - IF %APPVEYOR_REPO_BRANCH% EQU master SET DISTR=TRUE
   # Create and upload package.
   - cd %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\
-  - IF DEFINED DISTR "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
-  - IF DEFINED DISTR appveyor PushArtifact OpenSim-%VERSION%-win64.exe
+    # TODO - IF DEFINED DISTR "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
+    # TODO - IF DEFINED DISTR appveyor PushArtifact OpenSim-%VERSION%-win64.exe
+  - "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
+  - appveyor PushArtifact OpenSim-%VERSION%-win64.exe
   # - cd %APPVEYOR_BUILD_FOLDER%
   # - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\
   # - IF DEFINED DISTR appveyor PushArtifact C:\OpenSim-%VERSION%.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ nuget:
   disable_publish_on_pr: true
 
 environment:
+  # Avoid slow downloads on Azure.
   APPVEYOR_BUILD_ARTIFACT_STORAGE: gce-artifacts-us
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,7 @@ after_test:
   - IF %APPVEYOR_REPO_BRANCH% EQU master SET DISTR=TRUE
   # Create and upload package.
   - cd %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\
-  - "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
+  - IF TRUE "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
   - appveyor PushArtifact OpenSim-%VERSION%-win64.exe
   # - cd %APPVEYOR_BUILD_FOLDER%
   # - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ nuget:
   disable_publish_on_pr: true
 
 environment:
-  SOURCEFORGE_OPENSIM_BOT_PASSWORD:
+  APPVEYOR_BUILD_ARTIFACT_STORAGE: gce-artifacts-us
 
 init:
   ## Set environment variables.
@@ -95,15 +95,15 @@ after_test:
   # - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\
   # - IF DEFINED DISTR appveyor PushArtifact C:\OpenSim-%VERSION%.zip
 
-deploy:
-  provider: SFTP
-  protocol: ftps
-  host: frs.sourceforge.net
-  username: opensim-bot,myosin
-  password:
-    secure: OlJM0z185NHw/D0pXoEZdw==
-  folder: /home/frs/project/myosin/opensim-gui
-  artifact: OpenSim-%VERSION%-win64.exe
-  # TODO   on:
-  # TODO     branch: master
+# deploy:
+#   provider: SFTP
+#   protocol: ftps
+#   host: frs.sourceforge.net
+#   username: opensim-bot,myosin
+#   password:
+#     secure: OlJM0z185NHw/D0pXoEZdw==
+#   folder: /home/frs/project/myosin/opensim-gui
+#   artifact: OpenSim-%VERSION%-win64.exe
+#   # TODO   on:
+#   # TODO     branch: master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,7 +103,7 @@ deploy:
   password:
     secure: OlJM0z185NHw/D0pXoEZdw==
   folder: /home/frs/project/myosin/opensim-gui
-  artifact: %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\OpenSim-%VERSION%-win64.exe
+  artifact: %APPVEYOR_BUILD_FOLDER%/Gui/opensim/dist/installer/OpenSim-%VERSION%-win64.exe
   # TODO   on:
   # TODO     branch: master
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,14 +87,13 @@ after_test:
   # Detect if we are on the master branch.
   #- IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
   - IF %APPVEYOR_REPO_BRANCH% EQU master SET DISTR=TRUE
-  - SET DISTR=TRUE # TODO
   # Create and upload package.
   - cd %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\
   - IF DEFINED DISTR "C:/Program Files (x86)/NSIS/makensis.exe" make_installer.nsi
   - IF DEFINED DISTR appveyor PushArtifact OpenSim-%VERSION%-win64.exe
-  # - cd %APPVEYOR_BUILD_FOLDER%
-  # - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\
-  # - IF DEFINED DISTR appveyor PushArtifact C:\OpenSim-%VERSION%.zip
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - IF DEFINED DISTR 7z a C:\OpenSim-%VERSION%.zip %APPVEYOR_BUILD_FOLDER%\Gui\opensim\dist\installer\opensim\
+  - IF DEFINED DISTR appveyor PushArtifact C:\OpenSim-%VERSION%.zip
 
 # deploy:
 #   provider: SFTP


### PR DESCRIPTION
With this PR, artifacts are uploaded to Google Cloud instead of Azure, to improve download time.

We also upload a ZIP of the GUI in addition to the installer. If you use a program like 7-Zip, you can unzip the ZIP much faster than the installer, which could be good for testing.