### PR TITLE
Allow non Muscle components that contain path to provide colors

### DIFF
--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -790,7 +790,8 @@ public class ModelVisualizationJson extends JSONObject {
                 UUID pathUUID = pathList.get(geomPathObject);
                 JSONObject pathUpdate_json = new JSONObject();
                 pathUpdate_json.put("uuid", pathUUID.toString());
-                if (Muscle.safeDownCast(geomPathObject.getOwner())!= null){
+                // Special handling of Muscles here, could be extended to Ligaments?
+                //if (Muscle.safeDownCast(geomPathObject.getOwner())!= null){
                     Vec3 pathColor = colorByState ? currentPathColorMap.getColor(geomPathObject, state, -1) : geomPathObject.getDefaultColor();
                 
                     if (verbose)
@@ -798,7 +799,7 @@ public class ModelVisualizationJson extends JSONObject {
                     String colorString = JSONUtilities.mapColorToRGBA(pathColor);
                     pathUpdate_json.put("color", colorString);
                     geompaths_json.add(pathUpdate_json);
-                }
+                //}
             }
             // Have AddOns update their tranasforms
             for (VisualizerAddOn nextAddOn:visualizerAddOns){


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
GUI used to treat Muscles as special owners of GeometryPath to get colors during simulation/animation. This is unnecessray and prevents custom components (e.g. Ligaments) from providing state dependent colors.
### Testing I've completed
Loaded model with a ligament and allowed it to run FD, display turned gray rather than state-independent green. Will be useful for Smith2016Ligament class.

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
