### PR TITLE
Pass modelname2visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@ request related to the change, then we may provide the commit.
 v4.1
 ====
 - Fix issue #1112: TRC file written by GUI cannot be read by TRCFileAdapter 
-- 
+- Fix issue #1105: GUI adding offset to Experimental Data by default
+

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -623,7 +623,7 @@ public class ModelVisualizationJson extends JSONObject {
         model_object.put("uuid", modelUUID.toString());
         model_object.put("type", "Group");
         model_object.put("opensimType", "Model");
-        model_object.put("name", "OpenSimModel");
+        model_object.put("name", model.getName());
         model_object.put("children", new JSONArray());
         model_object.put("matrix", JSONUtilities.createMatrixFromTransform(getTransformWRTScene(), new Vec3(1.), 1.0));
         put("object", model_object);


### PR DESCRIPTION
Fixes issue #1105 

### Brief summary of changes
Visualizer (now responsible for adding visuals/offsets) now respects ExperimentalData (models). Test was there already but didn't work because of late scene graph changes in 4.0.

### Testing I've completed
Loaded trc, grf data for Gait10dof18musc model, synchronized them and all showed with no offset. Also tested that we're able to move using display_offset.

### CHANGELOG.md (choose one)
- Updated
