### PR TITLE
Change default fwd time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,6 @@ request related to the change, then we may provide the commit.
 
 v4.1
 ====
-- Fix issue #1112: TRC file written by GUI cannot be read by TRCFileAdapter 
+- Fix issue #1112: TRC file written by GUI cannot be read by TRCFileAdapter
 - Fix issue #1105: GUI adding offset to Experimental Data by default
-
+- Fix issue #1127: Changes default time in the toolbar forward simulation tool to 5 seconds. 

--- a/Gui/opensim/tracking/src/org/opensim/tracking/tools/Bundle.properties
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/tools/Bundle.properties
@@ -14,4 +14,4 @@ SimulationJPanel.jRunButton.text=Run
 SimulationJPanel.jStopButton.text=Stop
 SpecifyFinalTimeJPanel.jLabel1.text=\ \ \ \ \ \ Simulate to
 SpecifyFinalTimeJPanel.jLabel2.text=sec.
-SpecifyFinalTimeJPanel.finalTimeTextField.text=1000.
+SpecifyFinalTimeJPanel.finalTimeTextField.text=5.

--- a/Gui/opensim/tracking/src/org/opensim/tracking/tools/ToolbarRunForwardAction.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/tools/ToolbarRunForwardAction.java
@@ -41,7 +41,7 @@ import org.opensim.view.pub.OpenSimDB;
 public final class ToolbarRunForwardAction extends CallableSystemAction implements Observer {
    
     private boolean enabled = true;
-    private double finalTime = 1000.0;
+    private double finalTime = 5.0;
     
     public ToolbarRunForwardAction() {
         SimulationDB.getInstance().addObserver(this);


### PR DESCRIPTION
Fixes issue #1127

### Brief summary of changes
- Changed the default time for the toolbar foward simulation tool from 1000 seconds to 5 seconds. 

### Testing I've completed
- No tests yet, will download the artifact and check 

### CHANGELOG.md 
- Change added to CHANGLOG for GUI
