### PR TITLE
Added links to referenced issues in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ request related to the change, then we may provide the commit.
 
 v4.1
 ====
-- Fix issue #1112: TRC file written by GUI cannot be read by TRCFileAdapter
-- Fix issue #1105: GUI adding offset to Experimental Data by default
-- Fix issue #1123: GUI displays disabled muscles in red-blue range during/after StaticOptimization.
-- Fix issue #1127: Changes default time in the toolbar forward simulation tool to 5 seconds. 
+- Fix issue [#1112](https://github.com/opensim-org/opensim-gui/issues/1112): TRC file written by GUI cannot be read by TRCFileAdapter
+- Fix issue [#1105](https://github.com/opensim-org/opensim-gui/issues/1105): GUI adding offset to Experimental Data by default
+- Fix issue [#1123](https://github.com/opensim-org/opensim-gui/issues/1123): GUI displays disabled muscles in red-blue range during/after StaticOptimization.
+- Fix issue [#1127](https://github.com/opensim-org/opensim-gui/issues/1127): Change default time in the toolbar forward simulation tool to 5 seconds. 
 


### PR DESCRIPTION
This doesn't happen automatically in markdown files. I think we should make sure these are included in updates to this doc going forward.
