### PR TITLE
Make model marker less shiny

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@ v4.1
 - Fix issue [#1105](https://github.com/opensim-org/opensim-gui/issues/1105): GUI adding offset to Experimental Data by default
 - Fix issue [#1123](https://github.com/opensim-org/opensim-gui/issues/1123): GUI displays disabled muscles in red-blue range during/after StaticOptimization.
 - Fix issue [#1127](https://github.com/opensim-org/opensim-gui/issues/1127): Change default time in the toolbar forward simulation tool to 5 seconds. 
+- Fix issue [#1107](https://github.com/opensim-org/opensim-gui/issues/1107): Shading of model markers is not consistent with experimental markers
 

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1013,15 +1013,15 @@ public class ModelVisualizationJson extends JSONObject {
         UUID mat_uuid = UUID.randomUUID();
         mat_json.put("uuid", mat_uuid.toString());
         mat_json.put("name", "MarkerMat");
-        mat_json.put("type", "MeshStandardMaterial");
+        mat_json.put("type", "MeshPhongMaterial");
         mat_json.put("transparent", true);
-        mat_json.put("metalness", 0);
-        mat_json.put("roughness", .0);
+        mat_json.put("shininess", 30);
         mat_json.put("side", 2);
         //mat_json.put("transparent", true);
         String colorString = JSONUtilities.mapColorToRGBA(hints.get_marker_color());
         mat_json.put("color", colorString);
         mat_json.put("emissive", JSONUtilities.mapColorToRGBA(new Vec3(0.0)));
+        mat_json.put("specular", JSONUtilities.mapColorToRGBA(new Vec3(0.0)));
         json_materials.add(mat_json);
         marker_mat_json = mat_json;
         return mat_uuid;

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1016,12 +1016,12 @@ public class ModelVisualizationJson extends JSONObject {
         mat_json.put("type", "MeshStandardMaterial");
         mat_json.put("transparent", true);
         mat_json.put("metalness", 0);
-        mat_json.put("roughness", 1.0);
+        mat_json.put("roughness", .0);
         mat_json.put("side", 2);
         //mat_json.put("transparent", true);
         String colorString = JSONUtilities.mapColorToRGBA(hints.get_marker_color());
         mat_json.put("color", colorString);
-        mat_json.put("emissive", colorString);
+        mat_json.put("emissive", JSONUtilities.mapColorToRGBA(new Vec3(0.0)));
         json_materials.add(mat_json);
         marker_mat_json = mat_json;
         return mat_uuid;


### PR DESCRIPTION
Fixes issue #1107
### Brief summary of changes
Change material specification of model markers to match those of experimental markers for consistency. Along with opensim-core fix to scale factors these two fixes combined result in better looking model markers.
### Testing I've completed

Created new markers, loaded models with markers and inspected visualization

### CHANGELOG.md (choose one)
-updated
