### PR TITLE
Change ID tool panel to take an output path

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolModel.java
@@ -522,5 +522,12 @@ public class InverseDynamicsToolModel extends AbstractToolModelWithExternalLoads
         return idTool.getExternalLoads();
     }
 
+    public String getOutputGenForceFileName() { return idTool.getOutputGenForceFileName(); }
+    public void setOutputGenSetForceFileName(String name) {
+      if (!getOutputGenForceFileName().equals(name)) {
+         idTool.setOutputGenForceFileName(name);
+         setModified(Operation.OutputDataChanged);
+      }
+    }
 }
 

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.form
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.3" maxVersion="1.3" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <NonVisualComponents>
@@ -154,7 +154,7 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jTabbedPane1" pref="459" max="32767" attributes="0"/>
+              <Component id="jTabbedPane1" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -163,7 +163,7 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="jTabbedPane1" pref="267" max="32767" attributes="0"/>
+              <Component id="jTabbedPane1" max="32767" attributes="0"/>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
@@ -231,7 +231,7 @@
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="jLabel11" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="outputDirectory" pref="354" max="32767" attributes="3"/>
+                          <Component id="outputDirectory" pref="343" max="32767" attributes="3"/>
                           <EmptySpace max="-2" attributes="0"/>
                       </Group>
                   </Group>
@@ -252,7 +252,7 @@
               <SubComponents>
                 <Component class="javax.swing.JLabel" name="jLabel11">
                   <Properties>
-                    <Property name="text" type="java.lang.String" value="Directory"/>
+                    <Property name="text" type="java.lang.String" value="Storage file"/>
                   </Properties>
                 </Component>
                 <Component class="org.opensim.swingui.FileTextFieldAndChooser" name="outputDirectory">

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
@@ -58,6 +58,9 @@ import org.opensim.view.ModelEvent;
 import org.opensim.view.excitationEditor.ExcitationEditorJFrame;
 import org.opensim.view.pub.OpenSimDB;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  *
  * @author  erang
@@ -93,9 +96,11 @@ public class InverseDynamicsToolPanel extends BaseToolPanel implements Observer 
       //rraPanel.setBorder(new ComponentTitledBorder(rraPanelCheckBox, rraPanel, BorderFactory.createEtchedBorder()));
 
       // File chooser settings
-      outputDirectory.setIncludeOpenButton(true);
-      outputDirectory.setDirectoriesOnly(true);
+      outputDirectory.setIncludeOpenButton(false);
+      outputDirectory.setExtensionsAndDescription(".sto", "Storage file for inverse dynamics analysis");
+      outputDirectory.setDirectoriesOnly(false);
       outputDirectory.setCheckIfFileExists(false);
+      outputDirectory.setSaveMode(true);
 
       setSettingsFileDescription("Settings file for "+modeName);
 
@@ -182,7 +187,8 @@ public class InverseDynamicsToolPanel extends BaseToolPanel implements Observer 
       
       // Output
       outputName.setText(toolModel.getOutputPrefix());
-      outputDirectory.setFileName(toolModel.getResultsDirectory(),false);
+      Path p = Paths.get(toolModel.getResultsDirectory(), toolModel.getOutputGenForceFileName());
+      outputDirectory.setFileName(p.toString(),false);
       //outputPrecision.setText(numFormat.format(toolModel.getOutputPrecision()));
 
       // Actuators & external loads
@@ -389,7 +395,7 @@ public class InverseDynamicsToolPanel extends BaseToolPanel implements Observer 
 
         outputPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(javax.swing.BorderFactory.createEtchedBorder(), "Output"));
 
-        jLabel11.setText("Directory");
+        jLabel11.setText("Storage file");
 
         outputDirectory.addChangeListener(new javax.swing.event.ChangeListener() {
             public void stateChanged(javax.swing.event.ChangeEvent evt) {
@@ -405,7 +411,7 @@ public class InverseDynamicsToolPanel extends BaseToolPanel implements Observer 
                 .addContainerGap()
                 .add(jLabel11)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(outputDirectory, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 354, Short.MAX_VALUE)
+                .add(outputDirectory, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 343, Short.MAX_VALUE)
                 .addContainerGap())
         );
         outputPanelLayout.setVerticalGroup(
@@ -608,14 +614,14 @@ public class InverseDynamicsToolPanel extends BaseToolPanel implements Observer 
             layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(layout.createSequentialGroup()
                 .addContainerGap()
-                .add(jTabbedPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 459, Short.MAX_VALUE)
+                .add(jTabbedPane1)
                 .addContainerGap())
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(layout.createSequentialGroup()
                 .addContainerGap()
-                .add(jTabbedPane1, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 267, Short.MAX_VALUE)
+                .add(jTabbedPane1)
                 .addContainerGap())
         );
     }// </editor-fold>//GEN-END:initComponents
@@ -752,7 +758,9 @@ private void reuseSelectedQuantitiesCheckBoxActionPerformed(java.awt.event.Actio
    //------------------------------------------------------------------------
 
    private void outputDirectoryStateChanged(javax.swing.event.ChangeEvent evt) {//GEN-FIRST:event_outputDirectoryStateChanged
-      toolModel.setResultsDirectory(outputDirectory.getFileName());
+      Path p = Paths.get(outputDirectory.getFileName());
+       toolModel.setResultsDirectory(p.getParent().toString());
+       toolModel.setOutputGenSetForceFileName(p.getFileName().toString());
    }//GEN-LAST:event_outputDirectoryStateChanged
 
    private void outputNameFocusLost(java.awt.event.FocusEvent evt) {//GEN-FIRST:event_outputNameFocusLost


### PR DESCRIPTION
Fixes issue #1146 (the part about the inverse dynamics tool)

### Brief summary of changes
Instead of choosing a directory output, users must choose output file for the generalized forces. Currently the ID tool always writes an inverse_dynamics.sto file to the chosen directory, which will overwrite the result of previous ID analyses if users are not careful to rename the file before running the ID tool again.

I assume the current behavior is due to the ID tool being able to write two files (generalized forces and body forces), but I don't believe the ability to write body forces is exposed in GUI, although I might be wrong. If that is true, this change does not introduce limited capabilities of the GUI, but IMO makes it more intuitive to use.

Another (personal) objective was to get started with opensim-gui development, which already was fulfilled, so feel free to reject this PR, if the proposed behavior is not wanted.

### Testing I've completed
Tested on Windows 10.

### CHANGELOG.md (choose one)
- NOT updated as I'm not entire sure what the convention about updating the changelog is..
