### PR TITLE
Create symbolic link to opensense on osx

### DIFF
--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -261,6 +261,9 @@
         <symlink action="single" link="${mac.dist.outer.dir}/bin/opensim-cmd"
             resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-cmd"
             overwrite="true"/>
+        <symlink action="single" link="${mac.dist.outer.dir}/bin/opensense"
+            resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensense"
+            overwrite="true"/>
         <symlink action="single" link="${mac.dist.outer.dir}/cmake"
             resource="${mac.final.app.name}/Contents/Resources/OpenSim/cmake/"
             overwrite="true"/>


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Update build script to account for opensense on osx

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because internal
