### PR TITLE
Symlink opensim-install-command-line.sh

### DIFF
--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -252,12 +252,9 @@
             <!-- '-f': overwrite if files already exist. -->
             <arg line="-f dist/OpenSim.app '${mac.dist.outer.dir}/${mac.final.app.name}'" />
         </exec>
-        <!-- copy shell script to install command-line tools to top level folder -->
-        <exec executable="mv">
-            <!-- '-f': overwrite if files already exist. -->
-            <arg line="-f '../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-install-command-line.sh' 
-                       '${mac.dist.outer.dir}/bin/opensim-install-command-line.sh'" />
-        </exec>
+        <!-- Move shell script to install command-line tools to top level folder -->
+        <move file="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-install-command-line.sh"
+              todir="${mac.dist.outer.dir}/bin" />
         <!-- Symlinks in the outer OpenSim 4.0 folder.-->
         <symlink action="single" link="${mac.dist.outer.dir}/Geometry"
             resource="${mac.final.app.name}/Contents/Resources/OpenSim/Geometry/"

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -252,7 +252,12 @@
             <!-- '-f': overwrite if files already exist. -->
             <arg line="-f dist/OpenSim.app '${mac.dist.outer.dir}/${mac.final.app.name}'" />
         </exec>
-
+        <!-- copy shell script to install command-line tools to top level folder -->
+        <exec executable="mv">
+            <!-- '-f': overwrite if files already exist. -->
+            <arg line="-f '${mac.dist.outer.dir}/bin/opensim-install-command-line.sh' 
+                       '${mac.dist.outer.dir}/bin/opensim-install-command-line.sh'" />
+        </exec>
         <!-- Symlinks in the outer OpenSim 4.0 folder.-->
         <symlink action="single" link="${mac.dist.outer.dir}/Geometry"
             resource="${mac.final.app.name}/Contents/Resources/OpenSim/Geometry/"
@@ -263,9 +268,6 @@
             overwrite="true"/>
         <symlink action="single" link="${mac.dist.outer.dir}/bin/opensense"
             resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensense"
-            overwrite="true"/>
-        <symlink action="single" link="${mac.dist.outer.dir}/bin/opensim-install-command-line.sh"
-            resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-install-command-line.sh"
             overwrite="true"/>
         <symlink action="single" link="${mac.dist.outer.dir}/cmake"
             resource="${mac.final.app.name}/Contents/Resources/OpenSim/cmake/"

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -252,9 +252,7 @@
             <!-- '-f': overwrite if files already exist. -->
             <arg line="-f dist/OpenSim.app '${mac.dist.outer.dir}/${mac.final.app.name}'" />
         </exec>
-        <!-- Move shell script to install command-line tools to top level folder -->
-        <move file="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-install-command-line.sh"
-              todir="${mac.dist.outer.dir}/bin" />
+
         <!-- Symlinks in the outer OpenSim 4.0 folder.-->
         <symlink action="single" link="${mac.dist.outer.dir}/Geometry"
             resource="${mac.final.app.name}/Contents/Resources/OpenSim/Geometry/"
@@ -265,6 +263,9 @@
             overwrite="true"/>
         <symlink action="single" link="${mac.dist.outer.dir}/bin/opensense"
             resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensense"
+            overwrite="true"/>
+        <symlink action="single" link="${mac.dist.outer.dir}/bin/opensim-install-command-line.sh"
+            resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-install-command-line.sh"
             overwrite="true"/>
         <symlink action="single" link="${mac.dist.outer.dir}/cmake"
             resource="${mac.final.app.name}/Contents/Resources/OpenSim/cmake/"

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -264,6 +264,9 @@
         <symlink action="single" link="${mac.dist.outer.dir}/bin/opensense"
             resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensense"
             overwrite="true"/>
+        <symlink action="single" link="${mac.dist.outer.dir}/bin/opensim-install-command-line.sh"
+            resource="../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-install-command-line.sh"
+            overwrite="true"/>
         <symlink action="single" link="${mac.dist.outer.dir}/cmake"
             resource="${mac.final.app.name}/Contents/Resources/OpenSim/cmake/"
             overwrite="true"/>

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -255,7 +255,7 @@
         <!-- copy shell script to install command-line tools to top level folder -->
         <exec executable="mv">
             <!-- '-f': overwrite if files already exist. -->
-            <arg line="-f '${mac.dist.outer.dir}/bin/opensim-install-command-line.sh' 
+            <arg line="-f '../${mac.final.app.name}/Contents/Resources/OpenSim/bin/opensim-install-command-line.sh' 
                        '${mac.dist.outer.dir}/bin/opensim-install-command-line.sh'" />
         </exec>
         <!-- Symlinks in the outer OpenSim 4.0 folder.-->


### PR DESCRIPTION
### Brief summary of changes

This PR causes a symlink for the `opensim-install-command-line.sh` script to be created.

### Testing I've completed

I did not build the GUI; I simply created the symlink in an existing GUI installation and ensuerd it worked.

### CHANGELOG.md (choose one)

- no need to update because...no release yet
