### PR TITLE
Clear point functions if not applying force in line with API

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/EditOneForceJPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/EditOneForceJPanel.java
@@ -677,6 +677,10 @@ public class EditOneForceJPanel extends javax.swing.JPanel {
                 jComboBoxFX.setSelectedItem("");
                 jComboBoxFY.setSelectedItem("");
                 jComboBoxFZ.setSelectedItem("");
+                externalForce.setPointIdentifier("");
+                jComboBoxPX.setSelectedItem("");
+                jComboBoxPY.setSelectedItem("");
+                jComboBoxPZ.setSelectedItem("");
             }
         }
         // Set torquefunctions if TorqueCheckBox is on


### PR DESCRIPTION


Fixes issue #1153 
### Brief summary of changes
Previous fix to enable unchecking the appliesForce box, left point specification alone. API throws if no Force is specified but a point is selected. This PR makes the change in GUI consistent with the embedded API check.
### Testing I've completed
Created, edited external loads files in GUI and edited files can be read/opened

### CHANGELOG.md (choose one)

- no need to update because this covers corner case of a change already in the log