### PR TITLE
Associate scaled model with file in same folder as input model 

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ScaleToolModel.java
@@ -313,7 +313,8 @@ public class ScaleToolModel extends Observable implements Observer {
          // Crash here
          processedModel = new Model(unscaledModel);
          processedModel.setName(scaleTool.getName());
-         processedModel.setInputFileName("");
+         String proposedFilename = unscaledModel.getInputFileName().replace(".osim", "_scaled.osim");
+         processedModel.setInputFileName(proposedFilename);
          processedModel.setOriginalModelPathFromModel(unscaledModel); // important to keep track of the original path so bone loading works
          //processedModel.setup();
 


### PR DESCRIPTION

Fixes issue #1182 

### Brief summary of changes
Associate the scaled model with a file (_scaled.osim) in the same folder as original model so that custom geometry is located using same mechanism as original model.

### Testing I've completed
Loaded Wu shoulder model and scaled it (manually) and got expected visualization.

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
