### PR TITLE
Remove bogus Deg./Rad. from display names in Plotter

### DIFF
--- a/Gui/opensim/plotter/src/org/opensim/plotter/PlotterSourceMotion.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/PlotterSourceMotion.java
@@ -61,9 +61,5 @@ public class PlotterSourceMotion extends PlotterSourceStorage {
    void updateMotionName() {  // Update display name after a motion rename
      displayName = storage.getName();
    }
-
-    public String getDisplayName() {
-        return displayName+"(Deg.)";
-    }
    
 }

--- a/Gui/opensim/plotter/src/org/opensim/plotter/PlotterSourceStorage.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/PlotterSourceStorage.java
@@ -108,7 +108,7 @@ public class PlotterSourceStorage implements PlotterSourceInterface {
    }
 
    public String getDisplayName() {
-      return displayName+"("+(storage.isInDegrees()?"Deg.":"Rad.")+")";
+      return displayName;
    }
 
    public Storage getStorage() {


### PR DESCRIPTION
Fixes issue #669 Partially

### Brief summary of changes
Removed qualification of Deg/Rad. from display name of storages as confusing to users per issue #669
### Testing I've completed
Ran simulation, plotted results and loaded files in plotter, got no (Deg. or Rad.) qualification/label

### CHANGELOG.md (choose one)
Not sure if this is worth mention in changelog.