### PR TITLE
Update continuous-integration.yml

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -180,6 +180,7 @@ jobs:
         wget https://download.netbeans.org/netbeans/8.2/final/bundles/netbeans-8.2-javase-macosx.dmg
         hdiutil attach netbeans-8.2-javase-macosx.dmg
         sudo installer -pkg /Volumes/NetBeans\ 8.2/NetBeans\ 8.2.pkg -target /
+        sudo -k
 
     - name: Cache opensim-core-dependencies
       id: cache-dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -77,17 +77,24 @@ jobs:
         $env:CXXFLAGS = ""
         cmake . -LAH
         cmake --build . --config Release -- /maxcpucount:2 
+        
+    - name: Obtain opensim-core commit
+      id: opensim-core-commit
+      run: |
+        cd opensim-core
+        $opensim_core_commit=(git rev-parse HEAD)
+        echo "::set-output name=hash::$opensim_core_commit"
 
-    #- name: Cache opensim-core
-    #  id: cache-core
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ~/opensim-core-install
-    #    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-    #    key: ${{ runner.os }}-${{ hashFiles('opensim-core/*') }}
-    #
+    - name: Cache opensim-core
+      id: cache-core
+      uses: actions/cache@v1
+      with:
+        path: ~/opensim-core-install
+        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
+    
     - name: Build opensim-core
-      # if: steps.cache-core.outputs.cache-hit != 'true'
+      if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         echo $env:GITHUB_WORKSPACE\\build_core
         mkdir $env:GITHUB_WORKSPACE\\build_core
@@ -203,16 +210,23 @@ jobs:
         cmake ../opensim-core/dependencies -DSUPERBUILD_ezc3d:BOOL=on -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DCMAKE_BUILD_TYPE=Release
         cmake . -LAH
         cmake --build . --config Release
+        
+    - name: Obtain opensim-core commit
+      id: opensim-core-commit
+      run: |
+        cd opensim-core
+        opensim_core_commit=$(git rev-parse HEAD)
+        echo "::set-output name=hash::$opensim_core_commit"
           
-    #- name: Cache opensim-core
-    #  id: cache-core
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ~/opensim-core-install
-    #    key: ${{ runner.os }}-${{ hashFiles('opensim-core/*') }}
+    - name: Cache opensim-core
+      id: cache-core
+      uses: actions/cache@v1
+      with:
+        path: ~/opensim-core-install
+        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
     
     - name: Build opensim-core
-     # if: steps.cache-core.outputs.cache-hit != 'true'
+      if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         mkdir build_core
         cd build_core
@@ -310,16 +324,23 @@ jobs:
         cmake ../opensim-core/dependencies -DSUPERBUILD_ezc3d:BOOL=on -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install
         cmake . -LAH
         cmake --build . --config Release
-          
-    #- name: Cache opensim-core
-    #  id: cache-core
-    #  uses: actions/cache@v1
-    #  with:
-    #    path: ~/opensim-core-install
-    #    key: ${{ runner.os }}-${{ hashFiles('opensim-core/*') }}
-    #
+        
+    - name: Obtain opensim-core commit
+      id: opensim-core-commit
+      run: |
+        cd opensim-core
+        opensim_core_commit=$(git rev-parse HEAD)
+        echo "::set-output name=hash::$opensim_core_commit"
+
+    - name: Cache opensim-core
+      id: cache-core
+      uses: actions/cache@v1
+      with:
+        path: ~/opensim-core-install
+        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
+    
     - name: Build opensim-core
-      # if: steps.cache-core.outputs.cache-hit != 'true'
+      if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         mkdir build_core
         cd build_core

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -232,7 +232,10 @@
             value="${app.version}">
             <replacefilter token="@VERSION@" />
         </replace>
-        
+        <!-- Following chmods are needed so that the application                  is recognized as such by osx and shows in launchpad,                 these match local/dev environment --> 
+        <chmod file="${mac.dist.inner.dir}/etc/OpenSim.conf" perm="744"/>
+        <chmod file="dist/OpenSim.app/Contents/Info.plist" perm="644"/>
+
       <copy todir="dist/OpenSim.app/Contents/Resources/"
             file="installer_files/OSX/OpenSimDocument.icns" />
 

--- a/Gui/opensim/build.xml
+++ b/Gui/opensim/build.xml
@@ -232,10 +232,7 @@
             value="${app.version}">
             <replacefilter token="@VERSION@" />
         </replace>
-        <!-- Following chmods are needed so that the application                  is recognized as such by osx and shows in launchpad,                 these match local/dev environment --> 
-        <chmod file="${mac.dist.inner.dir}/etc/OpenSim.conf" perm="744"/>
-        <chmod file="dist/OpenSim.app/Contents/Info.plist" perm="644"/>
-
+        
       <copy todir="dist/OpenSim.app/Contents/Resources/"
             file="installer_files/OSX/OpenSimDocument.icns" />
 


### PR DESCRIPTION
exit sudo mode after installing tools on osx

Fixes issue #1204 

### Brief summary of changes
exit sudo in workflow, remove extra chmods from build.xml

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
