### PR TITLE
Send visualizer options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ v4.2
 - Support new logging system utilizing spdlog introduced in opensim-core.
 - Removed reference to kinematics of external loads from External Loads creation/editing dialog
 - Added option to visualize sensor data (quaternions) in the application (File ->Load Sensor Data)
-
+- When recording videos, if the user starts playing back a motion, recording is restarted to first animation frame.
 
 v4.1
 ====

--- a/Gui/opensim/scriptingShell/nbproject/project.xml
+++ b/Gui/opensim/scriptingShell/nbproject/project.xml
@@ -16,6 +16,15 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.libs.json_simple</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <specification-version>0.12.1</specification-version>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.settings</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/Gui/opensim/scriptingShell/src/org/opensim/console/gui.java
+++ b/Gui/opensim/scriptingShell/src/org/opensim/console/gui.java
@@ -30,6 +30,7 @@ import javax.swing.JFrame;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
+import org.json.simple.JSONObject;
 import org.openide.ErrorManager;
 import org.openide.cookies.InstanceCookie;
 import org.openide.filesystems.FileObject;
@@ -465,5 +466,20 @@ public final class gui {
         } catch (ClassNotFoundException ex) {
             Exceptions.printStackTrace(ex);
         }
+    }
+    
+    static void sendVisulaizerMessage(JSONObject json){
+            ViewDB.getInstance().broadcastVisulaizerMessage(json);
+    }
+    //  setVisualizerOption("video_format", "png")
+    //  setVisualizerOption("frame_rate", "60")
+    static public void setVisualizerOption(String key, String value){
+        JSONObject msg = new JSONObject();
+        msg.put("Op", "setOption");
+        JSONObject option = new JSONObject();
+        option.put("key", key);
+        option.put("value", value);
+        msg.put("data", option);
+        sendVisulaizerMessage(msg);
     }
 }

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -176,6 +176,10 @@ public final class ViewDB extends Observable implements Observer, LookupListener
             websocketdb.broadcastMessageJson(topMsg, null);
         }
     }
+
+    public void broadcastVisulaizerMessage(JSONObject json) {
+        websocketdb.broadcastMessageJson(json, null);
+    }
   
    class AppearanceChange {
        Model model;
@@ -1457,5 +1461,8 @@ public final class ViewDB extends Observable implements Observer, LookupListener
         double zValue = JSONMessageHandler.convertObjectFromJsonToDouble(zString);
         Vec3 offsetAsVec3 = new Vec3(xValue, yValue, zValue);
         return offsetAsVec3;
+    }
+    public void broadcastVisualizerMessage(JSONObject json){
+        websocketdb.broadcastMessageJson(json, null);
     }
 }


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Allow sending options  to the visualizer from the scripting shell to change video capture options:

### Testing I've completed
try either of these in scripting shell:
 setVisualizerOption("video_format", "png") // supported gif, jpg, png
 setVisualizerOption("frame_rate", "60")

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
