### PR TITLE
Replace reference to old/missing image for dialog icon

### DIFF
--- a/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/TheApp.java
@@ -111,7 +111,7 @@ public final class TheApp {
 
     public static Image getAppImage() {
         if (appImage==null)
-            appImage=ImageUtilities.loadImage("org/opensim/helputils/helpmenu/images/frame48.gif");
+            appImage=ImageUtilities.loadImage("org/opensim/helputils/helpmenu/images/logo_transparent_color.png");
         return appImage;
     }
     


### PR DESCRIPTION
Fixes issue #1260

### Brief summary of changes
Dialogs were not finding icon file and ending with generic java icon, fixed to find correct icon on path.
### Testing I've completed
Built and launched dialogs(Plotter, Excitation Editor) both now show correct icon
### CHANGELOG.md (choose one)

- no need to update because minor bugfix
