### PR TITLE
Keep track of trc file units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ v4.2
 - When recording videos, if the user starts playing back a motion, recording is restarted to first animation frame.
 - Allow users to change video format from scripting shell (support gif, jpg, png with setVisualizerOption("video_format", "png")). 
 - Add Tools for Calibrating model based on IMU data and to solve Inverse Kinematics problem from IMU data.
+- Fix issue where transforming trc marker data in the application always produces a file with "m" as units in header.
 
 v4.1
 ====

--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -46,6 +46,7 @@ import org.opensim.modeling.Model;
 import org.opensim.modeling.StateVector;
 import org.opensim.modeling.Storage;
 import org.opensim.modeling.Transform;
+import org.opensim.modeling.Units;
 import org.opensim.modeling.Vec3;
 import org.opensim.view.motions.MotionControlJPanel;
 import org.opensim.view.motions.MotionDisplayer;
@@ -75,6 +76,7 @@ public class AnnotatedMotion extends Storage {
     private double displayForceScale = .001;
     private String displayForceShape = "arrow";
     private Model model;
+    private Units units;
     /** Creates a new instance of AnnotatedMotion 
      * This constructor is called when a trc file is read (so we know it is 
      * Marker only data already.
@@ -416,7 +418,9 @@ public class AnnotatedMotion extends Storage {
    */
         writer.write(getDataRate()+"\t"+
                 getCameraRate()+"\t"+
-                getSize()+"\t"+markerNames.size()+"\tmm\t"+
+                getSize()+"\t"+markerNames.size()+"\t"+
+                (units.getType()==Units.UnitType.Millimeters?"mm":"m")
+                        +"\t"+
                 getDataRate()+"\t"+ "1\t"+getSize());
         writer.newLine();
         writer.write("Frame#\tTime\t");
@@ -533,4 +537,8 @@ public class AnnotatedMotion extends Storage {
             }
         }
     }    
+
+    public void setUnits(Units units) {
+        this.units = units;
+    }
 }

--- a/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
@@ -62,6 +62,7 @@ public final class FileLoadDataAction extends CallableSystemAction {
                     amot.setName(new File(fileName).getName());
                     amot.setDataRate(markerData.getDataRate());
                     amot.setCameraRate(markerData.getCameraRate());
+                    amot.setUnits(markerData.getUnits());
                     // Add the visuals to support it
                     ModelForExperimentalData modelForDataImport = new ModelForExperimentalData(nextNumber++, amot);
                     modelForDataImport.initSystem();


### PR DESCRIPTION
Fixes issue #2938

### Brief summary of changes
When extracting data from trc file, keep track of units, write back on save

### Testing I've completed
Tested with file from issue

### CHANGELOG.md (choose one)

- will update before merging
