### PR TITLE
add Dockerfile for building opensim-gui on Ubuntu Bionic

### DIFF
--- a/.docker/build_ubuntu_bionic.dockerfile
+++ b/.docker/build_ubuntu_bionic.dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:bionic
+
+WORKDIR /root
+
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+
+RUN apt update && apt install -y \
+                            liblapack-dev \
+                            freeglut3-dev \
+                            libxi-dev \
+                            libxmu-dev \
+                            doxygen \
+                            python3 \
+                            python3-dev \
+                            python3-numpy \
+                            python3-setuptools \
+                            swig \
+                            openjdk-8-jdk \
+                            build-essential \
+                            git \
+                            libgconf-2-4 \
+                            wget \
+                            cmake \
+                            gfortran \
+                            coinor-libipopt-dev \
+                            libcolpack-dev \
+                            pkg-config \
+                            autoconf libtool libtool-bin \
+                            ant
+RUN wget -q https://download.netbeans.org/netbeans/8.2/final/bundles/netbeans-8.2-javase-linux.sh && chmod +x netbeans-8.2-javase-linux.sh && ./netbeans-8.2-javase-linux.sh --jdkhome /usr/lib/jvm/java-8-openjdk-amd64 --silent && echo $(ls /usr/local/netbeans-8.2)
+RUN git clone https://github.com/opensim-org/opensim-gui.git && cd opensim-gui && git clone https://github.com/opensim-org/opensim-core.git
+RUN cd opensim-gui && mkdir build_deps && cd build_deps \
+    && cmake ../opensim-core/dependencies -DSUPERBUILD_ezc3d:BOOL=on -DCMAKE_INSTALL_PREFIX="/root/opensim_dependencies_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    && cmake . -LAH && make -j4 && cd .. \
+    && mkdir build_core && cd build_core \
+    && cmake ../opensim-core -DOPENSIM_DEPENDENCIES_DIR="/root/opensim_dependencies_install" -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX="/root/opensim-core-install" -DOPENSIM_INSTALL_UNIX_FHS=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    && cmake . -LAH && make -j4 && make install && cd .. \
+    && git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/threejs \
+    && mkdir build && cd build \
+    && cmake ../ -DCMAKE_PREFIX_PATH="/root/opensim-core-install" -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=/usr/local/netbeans-8.2;-Dnbplatform.default.harness.dir=/usr/local/netbeans-8.2/harness" && make CopyOpenSimCore && make PrepareInstaller


### PR DESCRIPTION
Fixes issues #1255 

### Brief summary of changes

Add Dockerfile for building `opensim-gui` in a clean environment.

### Testing I've completed

Tested it under the following Docker version:
```bash
Client: Docker Engine - Community
 Version:           19.03.5
 API version:       1.40
 Go version:        go1.12.12
 Git commit:        633a0ea838
 Built:             Wed Nov 13 07:50:12 2019
 OS/Arch:           linux/amd64
 Experimental:      false

Server: Docker Engine - Community
 Engine:
  Version:          19.03.5
  API version:      1.40 (minimum version 1.12)
  Go version:       go1.12.12
  Git commit:       633a0ea838
  Built:            Wed Nov 13 07:48:43 2019
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.2.10
  GitCommit:        b34a5c8af56e510852c35414db4c1f4fa6172339
 runc:
  Version:          1.0.0-rc8+dev
  GitCommit:        3e425f80a8c931f88e6d94a8c831b9d5aa481657
 docker-init:
  Version:          0.18.0
  GitCommit:        fec3683
```

### CHANGELOG.md

- no need to update because I added a new file

This PR aims to solve the difficulty I encountered when building the `opensim-gui` from source. I found the relevant [issue](https://github.com/opensim-org/opensim-gui/issues/1255) but the discussion there wasn't enough for me to overcome the issues I faced. After building successfully (so so many tries), I wrote this Dockerfile to aid the next Ubuntu Bionic users in their installation process (and debugging).

**Note 1:**  One of the main issues encountered, is the usage of `openjdk-8`. In my machine, I had installed the `openjdk-11` and had to remove it. I’m not sure if `update alternatives --config java` could be sufficient. I removed the other version, just to be on the safe side.

**Note 2:** For some reason, the proposed installation of `opensim-gui` from the [CI configuration file](https://github.com/opensim-org/opensim-gui/blob/master/.github/workflows/continuous-integration.yml) didn’t work. Especially the command `cmake --build . --config Release` for `opensim-core` didn’t work correctly, since there was no `~/opensim-core-install` directory created. This resulted in some commands in the `build.xml` of `opensim-gui` to not find some paths, which should have been created from the installation of `opensim-core`. I changed the previous command to `make -j4 && make install` and worked like a charm.