### PR TITLE
Update bindings and fix GUI to make standalone copies of tasks

### DIFF
--- a/Gui/opensim/modeling/src/org/opensim/modeling/IKMarkerTask.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/IKMarkerTask.java
@@ -58,7 +58,11 @@ public class IKMarkerTask extends IKTask {
   }
 
   public IKMarkerTask() {
-    this(opensimActuatorsAnalysesToolsJNI.new_IKMarkerTask(), true);
+    this(opensimActuatorsAnalysesToolsJNI.new_IKMarkerTask__SWIG_0(), true);
+  }
+
+  public IKMarkerTask(IKMarkerTask arg0) {
+    this(opensimActuatorsAnalysesToolsJNI.new_IKMarkerTask__SWIG_1(IKMarkerTask.getCPtr(arg0), arg0), true);
   }
 
 }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/opensimActuatorsAnalysesToolsJNI.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/opensimActuatorsAnalysesToolsJNI.java
@@ -1393,7 +1393,8 @@ public class opensimActuatorsAnalysesToolsJNI {
   public final static native String IKMarkerTask_getClassName();
   public final static native long IKMarkerTask_clone(long jarg1, IKMarkerTask jarg1_);
   public final static native String IKMarkerTask_getConcreteClassName(long jarg1, IKMarkerTask jarg1_);
-  public final static native long new_IKMarkerTask();
+  public final static native long new_IKMarkerTask__SWIG_0();
+  public final static native long new_IKMarkerTask__SWIG_1(long jarg1, IKMarkerTask jarg1_);
   public final static native void delete_IKMarkerTask(long jarg1);
   public final static native long IKCoordinateTask_safeDownCast(long jarg1, OpenSimObject jarg1_);
   public final static native void IKCoordinateTask_assign(long jarg1, IKCoordinateTask jarg1_, long jarg2, OpenSimObject jarg2_);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IKTasksModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IKTasksModel.java
@@ -159,7 +159,8 @@ class IKMarkerTasksModel extends IKTasksModel {
       for(int i=0; i<fullTaskSet.getSize(); i++) {
          if(IKMarkerTask.safeDownCast(fullTaskSet.get(i))!=null) {
             int index = model.getMarkerSet().getIndex(fullTaskSet.get(i).getName());
-            if(index >= 0) tasks.set(index, IKMarkerTask.safeDownCast(fullTaskSet.get(i).clone()));
+            if(index >= 0) tasks.set(index, 
+                    new IKMarkerTask(IKMarkerTask.safeDownCast(fullTaskSet.get(i)))); // Java-side copy
          }
       }
       setModified();


### PR DESCRIPTION
Fixes issue #1268 

### Brief summary of changes
Make local copies of IKTask(s) for GUI use so they don't get garbage collected using copy constructors (instead of using clone)

### Testing I've completed
Built GUI and couldn't cause the issue reported by Antoine to reproduce.

### CHANGELOG.md (choose one)

- no need to update because internal bugfix

