### PR TITLE
Fix imu gui issues 0221

### DIFF
--- a/Gui/opensim/modeling/src/org/opensim/modeling/OrientationWeightSet.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/OrientationWeightSet.java
@@ -58,7 +58,11 @@ public class OrientationWeightSet extends SetOientationWeights {
   }
 
   public OrientationWeightSet() {
-    this(opensimActuatorsAnalysesToolsJNI.new_OrientationWeightSet(), true);
+    this(opensimActuatorsAnalysesToolsJNI.new_OrientationWeightSet__SWIG_0(), true);
+  }
+
+  public OrientationWeightSet(OrientationWeightSet arg0) {
+    this(opensimActuatorsAnalysesToolsJNI.new_OrientationWeightSet__SWIG_1(OrientationWeightSet.getCPtr(arg0), arg0), true);
   }
 
 }

--- a/Gui/opensim/modeling/src/org/opensim/modeling/opensimActuatorsAnalysesToolsJNI.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/opensimActuatorsAnalysesToolsJNI.java
@@ -2163,7 +2163,8 @@ public class opensimActuatorsAnalysesToolsJNI {
   public final static native String OrientationWeightSet_getClassName();
   public final static native long OrientationWeightSet_clone(long jarg1, OrientationWeightSet jarg1_);
   public final static native String OrientationWeightSet_getConcreteClassName(long jarg1, OrientationWeightSet jarg1_);
-  public final static native long new_OrientationWeightSet();
+  public final static native long new_OrientationWeightSet__SWIG_0();
+  public final static native long new_OrientationWeightSet__SWIG_1(long jarg1, OrientationWeightSet jarg1_);
   public final static native void delete_OrientationWeightSet(long jarg1);
   public final static native long IMUInverseKinematicsTool_safeDownCast(long jarg1, OpenSimObject jarg1_);
   public final static native void IMUInverseKinematicsTool_assign(long jarg1, IMUInverseKinematicsTool jarg1_, long jarg2, OpenSimObject jarg2_);

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IMUCalibrateModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IMUCalibrateModel.java
@@ -79,8 +79,8 @@ public class IMUCalibrateModel extends Observable implements Observer {
             sensorOrientationsFileName = fileName;
             sensorData = new TimeSeriesTableQuaternion(sensorOrientationsFileName);
             sensorDataLabels = sensorData.getColumnLabels();
-            if (sensorDataLabels.size()>0)
-                imuLabel = sensorDataLabels.get(0);
+            //if (sensorDataLabels.size()>0)
+            //    imuLabel = sensorDataLabels.get(0);
             setModified(Operation.AllDataChanged);
         }
     }
@@ -242,8 +242,8 @@ public class IMUCalibrateModel extends Observable implements Observer {
        Vec3 rotationsInRadians = new Vec3(rotations).scalarTimesEq(Math.toRadians(1.0));
        imuPlacerTool.set_sensor_to_opensim_rotations(rotationsInRadians);
        imuPlacerTool.set_orientation_file_for_calibration(sensorOrientationsFileName);
-       imuPlacerTool.set_base_imu_label(imuLabel);
-       imuPlacerTool.set_base_heading_axis(imuAxis);
+       imuPlacerTool.set_base_imu_label(imuLabel.trim());
+       imuPlacerTool.set_base_heading_axis(imuAxis.trim());
    }
 
    public void execute() {  

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
@@ -316,7 +316,9 @@ public class IMUIKToolModel extends Observable implements Observer {
        imuIkTool.set_time_range(1, timeRange[1]);
        imuIkTool.set_report_errors(reportErrors);
        // Replace OrientationWeightSet in tool with new set.
-       imuIkTool.set_orientation_weights(getOrientation_weightset());
+       imuIkTool.upd_orientation_weights().setSize(0);
+       for (int j=0; j < orientation_weightset.getSize(); j++)
+        imuIkTool.upd_orientation_weights().adoptAndAppend(orientation_weightset.get(j));
    }
 
    public void execute() {  

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
@@ -316,11 +316,7 @@ public class IMUIKToolModel extends Observable implements Observer {
        imuIkTool.set_time_range(1, timeRange[1]);
        imuIkTool.set_report_errors(reportErrors);
        // Replace OrientationWeightSet in tool with new set.
-       OrientationWeightSet owsetRef = imuIkTool.get_orientation_weights();
-       owsetRef.setSize(0);
-       OrientationWeightSet newOwsetRef = getOrientation_weightset();
-       for (int i=0; i < newOwsetRef.getSize(); i++)
-            owsetRef.cloneAndAppend(newOwsetRef.get(i));
+       imuIkTool.set_orientation_weights(getOrientation_weightset());
    }
 
    public void execute() {  
@@ -444,11 +440,6 @@ public class IMUIKToolModel extends Observable implements Observer {
 
    public boolean saveSettings(String fileName) {
       String fullFilename = FileUtils.addExtensionIfNeeded(fileName, ".xml");
-      /*
-      XMLExternalFileChooserHelper helper = new XMLExternalFileChooserHelper(fullFilename);
-      helper.addObject(imuIkTool.getIKTaskSet(), "IK Task Set");
-      if(!helper.promptUser()) return false;*/
-      //imuIkTool.getIKTaskSet().setInlined(true);
       updateIKTool();
       AbsoluteToRelativePaths(fullFilename);
       imuIkTool.print(fullFilename);
@@ -510,6 +501,6 @@ public class IMUIKToolModel extends Observable implements Observer {
      * @param orientation_weightset the orientation_weightset to set
      */
     public void setOrientation_weightset(OrientationWeightSet orientation_weightset) {
-        this.orientation_weightset = orientation_weightset;
+        this.orientation_weightset = new OrientationWeightSet(orientation_weightset);
     }
 }

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
@@ -78,7 +78,7 @@ public class IMUIKToolModel extends Observable implements Observer {
      * @return the sensorData
      */
     public TimeSeriesTableQuaternion getSensorData() {
-        if (sensorData == null)
+        if (sensorData == null && sensorOrientationsFileName!="")
             sensorData = new TimeSeriesTableQuaternion(sensorOrientationsFileName);
         return sensorData;
     }
@@ -389,7 +389,7 @@ public class IMUIKToolModel extends Observable implements Observer {
    //------------------------------------------------------------------------
 
    public boolean isValid() {
-      return sensorData!=null;
+      return getSensorData()!=null;
    }
 
    //------------------------------------------------------------------------

--- a/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolPanel.java
@@ -533,7 +533,7 @@ private void outputMotionFilePathStateChanged(javax.swing.event.ChangeEvent evt)
     private void jWeightsButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jWeightsButtonActionPerformed
         // TODO add your handling code here:
         OrientationWeightSet currentWeights = ikToolModel.getOrientation_weightset();
-        OrientationWeightSet saveWeights = OrientationWeightSet.safeDownCast(currentWeights.clone());
+        OrientationWeightSet saveWeights = new OrientationWeightSet(currentWeights);
         OrientationWeightsJPanel weightsPanel = new OrientationWeightsJPanel(currentWeights);
         Object [] options =  {  NotifyDescriptor.OK_OPTION,
             NotifyDescriptor.CANCEL_OPTION};
@@ -543,8 +543,12 @@ private void outputMotionFilePathStateChanged(javax.swing.event.ChangeEvent evt)
         Object userInput = weightsDialog.getValue();
         if (((Integer)userInput).compareTo((Integer)DialogDescriptor.OK_OPTION)!=0){
             // Uer cancelled
-            currentWeights = OrientationWeightSet.safeDownCast(saveWeights.clone());
+            currentWeights = OrientationWeightSet.safeDownCast(saveWeights);
             ikToolModel.setOrientation_weightset(currentWeights);
+        }
+        else {
+            //System.out.println(weightsPanel.getOrientationWeightSet().dump());
+            ikToolModel.setOrientation_weightset(weightsPanel.getOrientationWeightSet());
         }
     }//GEN-LAST:event_jWeightsButtonActionPerformed
 

--- a/Gui/opensim/tracking/src/org/opensim/tracking/OrientationWeightsJPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/OrientationWeightsJPanel.java
@@ -16,9 +16,9 @@ import org.opensim.utils.ErrorDialog;
  * @author Ayman-NMBL
  */
 public class OrientationWeightsJPanel extends javax.swing.JPanel {
-
+    WeightsTableModel tableModel;
     class WeightsTableModel extends AbstractTableModel {
-        OrientationWeightSet owSet= null;
+        private OrientationWeightSet owSet= null;
         WeightsTableModel(OrientationWeightSet owSet){
             this.owSet = owSet;
         }
@@ -76,13 +76,20 @@ public class OrientationWeightsJPanel extends javax.swing.JPanel {
                     ErrorDialog.showMessageDialog("Weights need to be between 0 and 1");
             }
         }
+
+        /**
+         * @return the owSet
+         */
+        public OrientationWeightSet getOwSet() {
+            return owSet;
+        }
         
     }
     /**
      * Creates new form WeightsJPanel
      */
     public OrientationWeightsJPanel(OrientationWeightSet owSet) {
-        WeightsTableModel tableModel = new WeightsTableModel(owSet);
+        tableModel = new WeightsTableModel(owSet);
         initComponents();
         jWeightsTable.setModel(tableModel);
         jWeightsTable.putClientProperty("terminateEditOnFocusLost", Boolean.TRUE);
@@ -140,7 +147,9 @@ public class OrientationWeightsJPanel extends javax.swing.JPanel {
         );
     }// </editor-fold>//GEN-END:initComponents
 
-
+    public OrientationWeightSet getOrientationWeightSet() {
+        return tableModel.getOwSet();
+    }
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JTable jWeightsTable;


### PR DESCRIPTION
Fixes issue #1272, #1273

### Brief summary of changes
Create a  copy constructor for OrientationWeightSet and utilize it to keep GUI side copy of OrientationWeightSet for editing and setting back in tool.

### Testing I've completed
Scenarios described in issues 1272, 1273 work as expected now.

### CHANGELOG.md (choose one)

- no need to update because bugfix
