### PR TITLE
Leave time range alone when loading initial states file.

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/ForwardToolModel.java
@@ -330,12 +330,13 @@ public class ForwardToolModel extends AbstractToolModelWithExternalLoads {
       if(!getInitialStatesFileName().equals(fileName)) {
          forwardTool().setStatesFileName(fileName);
          setModified(AbstractToolModel.Operation.InputDataChanged);
+         /*
          try {
             Storage s = new Storage(fileName);
             updateStatesTimeRange(s.getFirstTime(), s.getLastTime());
          } catch (IOException ex) {
              ErrorDialog.displayExceptionDialog(ex);
-         }
+         }*/
       }
    }
    public boolean getInitialStatesValid() { return true; }//(new File(getInitialStatesFileName()).exists()); }


### PR DESCRIPTION
Fixes issue #1274

### Brief summary of changes
Leave tool time alone when loading initial states file, the tool takes care of adjusting for initial states time downstream.

### Testing I've completed
Built GUI, tested that forward tool time is not affected when default states file is selected.

### CHANGELOG.md (choose one)

- no need to update because minor bugfix
