### PR TITLE
Update URL for doxygen to official 4.2 URL

### DIFF
--- a/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/OpenDoxygenAction.java
+++ b/Gui/opensim/helpUtils/src/org/opensim/helputils/helpmenu/OpenDoxygenAction.java
@@ -47,7 +47,7 @@ public final class OpenDoxygenAction extends CallableSystemAction {
     public void performAction() {
         try {
             String basePath = TheApp.getCrossPlatformInstallDir();
-            String doxygenPath = BrowserLauncher.isConnected() ? "https://simtk.org/api_docs/opensim/api_docs41/" :
+            String doxygenPath = BrowserLauncher.isConnected() ? "https://simtk.org/api_docs/opensim/api_docs42/" :
                     new File(basePath + "/sdk/doc/OpenSimAPI.html").toURI().toURL().toString();
             
             BrowserLauncher.openURL(doxygenPath);


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
Change URL for Doxygen to the 4.2 version/page on confluence

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because internal
