### PR TITLE
Minor linux GUI layout improvements

### DIFF
--- a/Gui/opensim/coordinateViewer/src/org/opensim/coordinateviewer/CoordinateSliderWithBox.form
+++ b/Gui/opensim/coordinateViewer/src/org/opensim/coordinateviewer/CoordinateSliderWithBox.form
@@ -21,9 +21,9 @@
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
               <Component id="jCoordinateNameLabel" min="-2" pref="100" max="-2" attributes="0"/>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
-              <Component id="jFormattedTextField" min="-2" pref="55" max="-2" attributes="0"/>
-              <EmptySpace min="-2" pref="0" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Component id="jFormattedTextField" min="-2" pref="80" max="-2" attributes="0"/>
+              <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
               <Component id="jLockedCheckBox" min="-2" pref="20" max="-2" attributes="0"/>
               <EmptySpace min="-2" pref="0" max="-2" attributes="0"/>
               <Component id="jClampedCheckBox" min="-2" pref="20" max="-2" attributes="0"/>
@@ -76,9 +76,6 @@
         <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
           <Connection code="unclampedIcon" type="code"/>
         </Property>
-        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-          <Insets value="[0, 0, 0, 0]"/>
-        </Property>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[20, 20]"/>
         </Property>
@@ -112,9 +109,6 @@
         </Property>
         <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
           <Connection code="unlockedIcon" type="code"/>
-        </Property>
-        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-          <Insets value="[0, 0, 0, 0]"/>
         </Property>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[20, 20]"/>
@@ -177,9 +171,9 @@
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" alignment="0" attributes="0">
                   <Component id="jMinimumLabel" min="-2" pref="30" max="-2" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
                   <Component id="jXSlider" max="32767" attributes="0"/>
-                  <EmptySpace max="-2" attributes="0"/>
+                  <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
                   <Component id="jMaximumLabel" min="-2" pref="25" max="-2" attributes="0"/>
               </Group>
           </Group>
@@ -204,6 +198,9 @@
             <Property name="minorTickSpacing" type="int" value="10"/>
             <Property name="toolTipText" type="java.lang.String" value="Seek"/>
             <Property name="alignmentX" type="float" value="0.0"/>
+            <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+              <Color id="Default Cursor"/>
+            </Property>
             <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
               <Dimension value="[50, 25]"/>
             </Property>

--- a/Gui/opensim/coordinateViewer/src/org/opensim/coordinateviewer/CoordinateSliderWithBox.java
+++ b/Gui/opensim/coordinateViewer/src/org/opensim/coordinateviewer/CoordinateSliderWithBox.java
@@ -223,7 +223,6 @@ public class CoordinateSliderWithBox extends javax.swing.JPanel implements Chang
         jClampedCheckBox.setToolTipText("Toggle clamp to bounds");
         jClampedCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         jClampedCheckBox.setIcon(unclampedIcon);
-        jClampedCheckBox.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jClampedCheckBox.setMaximumSize(new java.awt.Dimension(20, 20));
         jClampedCheckBox.setMinimumSize(new java.awt.Dimension(20, 20));
         jClampedCheckBox.setPreferredSize(new java.awt.Dimension(20, 20));
@@ -239,7 +238,6 @@ public class CoordinateSliderWithBox extends javax.swing.JPanel implements Chang
         jLockedCheckBox.setToolTipText("Toggle lock value");
         jLockedCheckBox.setBorder(javax.swing.BorderFactory.createEmptyBorder(0, 0, 0, 0));
         jLockedCheckBox.setIcon(unlockedIcon);
-        jLockedCheckBox.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jLockedCheckBox.setMaximumSize(new java.awt.Dimension(20, 20));
         jLockedCheckBox.setMinimumSize(new java.awt.Dimension(20, 20));
         jLockedCheckBox.setPreferredSize(new java.awt.Dimension(20, 20));
@@ -278,6 +276,7 @@ public class CoordinateSliderWithBox extends javax.swing.JPanel implements Chang
         jXSlider.setMinorTickSpacing(10);
         jXSlider.setToolTipText("Seek");
         jXSlider.setAlignmentX(0.0F);
+        jXSlider.setCursor(new java.awt.Cursor(java.awt.Cursor.DEFAULT_CURSOR));
         jXSlider.setMinimumSize(new java.awt.Dimension(50, 25));
         jXSlider.setPreferredSize(new java.awt.Dimension(50, 25));
 
@@ -305,9 +304,9 @@ public class CoordinateSliderWithBox extends javax.swing.JPanel implements Chang
             jPanel1Layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
             .add(jPanel1Layout.createSequentialGroup()
                 .add(jMinimumLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 30, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(0, 0, 0)
                 .add(jXSlider, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
+                .add(0, 0, 0)
                 .add(jMaximumLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 25, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
         );
         jPanel1Layout.setVerticalGroup(
@@ -327,7 +326,7 @@ public class CoordinateSliderWithBox extends javax.swing.JPanel implements Chang
             .add(layout.createSequentialGroup()
                 .add(jCoordinateNameLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 100, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
-                .add(jFormattedTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 55, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                .add(jFormattedTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 80, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .add(0, 0, 0)
                 .add(jLockedCheckBox, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 20, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .add(0, 0, 0)

--- a/Gui/opensim/tracking/src/org/opensim/tracking/tools/ToolbarSimulationAction.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/tools/ToolbarSimulationAction.java
@@ -82,7 +82,7 @@ public final class ToolbarSimulationAction extends CallableSystemAction {
       //tb.addSeparator(new Dimension(10,40));
         try {
             JLabel jLabel1 = new JLabel("Simulate");
-            jLabel1.setFont(new java.awt.Font("Tahoma", 1, 11));
+            jLabel1.setFont(jLabel1.getFont().deriveFont(jLabel1.getFont().getStyle() | java.awt.Font.BOLD));
             tb.add(jLabel1);
             ImageIcon icon = new ImageIcon(getClass().getResource("/org/opensim/tracking/tools/run.png"));
             JButton dropdownButton = DropDownButtonFactory.createDropDownButton(icon, popup);

--- a/Gui/opensim/view/src/org/opensim/view/Installer.java
+++ b/Gui/opensim/view/src/org/opensim/view/Installer.java
@@ -78,6 +78,11 @@ public class Installer extends ModuleInstall {
         super.restored();
         try {
              // Put your startup code here.
+
+            // Fix Slider value always shown on GTK
+            // https://bugs.openjdk.java.net/browse/JDK-6350767
+            UIManager.put("Slider.paintValue", false);
+
             UIManager.setLookAndFeel( UIManager.getSystemLookAndFeelClassName() );
             if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) {
                 // The native slider on macOS looks somewhat nice.

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.form
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<Form version="1.3" maxVersion="1.3">
+<Form version="1.5" maxVersion="1.9">
   <Properties>
     <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
       <Color blue="ff" green="ff" red="ff" type="rgb"/>
@@ -22,7 +22,7 @@
     </Property>
     <Property name="opaque" type="boolean" value="false"/>
     <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[645, 50]"/>
+      <Dimension value="[700, 50]"/>
     </Property>
   </Properties>
   <AuxValues>
@@ -46,24 +46,24 @@
               <Component id="jMotionNameLabel" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="separate" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="jLabelForSpeedSpinner" alignment="0" min="-2" max="-2" attributes="0"/>
-                  <Component id="jLabelForTimeTextField" alignment="0" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabelForSpeedSpinner" alignment="0" max="-2" attributes="0"/>
+                  <Component id="jLabelForTimeTextField" alignment="0" max="-2" attributes="0"/>
               </Group>
               <EmptySpace min="-2" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="jTimeTextField" alignment="0" min="-2" max="-2" attributes="0"/>
                   <Component id="jSpeedSpinner" alignment="0" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Group type="102" alignment="0" attributes="0">
                       <Component id="jStartTimeTextField" min="-2" pref="50" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" max="-2" attributes="0"/>
+                      <EmptySpace max="-2" attributes="0"/>
                       <Component id="jPlaybackButtonsPanel" max="32767" attributes="1"/>
                       <EmptySpace max="-2" attributes="0"/>
                       <Component id="jEndTimeTextField" min="-2" pref="50" max="-2" attributes="0"/>
                   </Group>
-                  <Component id="jMotionSlider" alignment="0" max="32767" attributes="3"/>
+                  <Component id="jMotionSlider" alignment="0" pref="292" max="32767" attributes="3"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
               <Component id="jWrapToggleButton" min="-2" max="-2" attributes="0"/>
@@ -82,9 +82,9 @@
                               <Component id="jTimeTextField" alignment="3" min="-2" max="-2" attributes="0"/>
                               <Component id="jLabelForTimeTextField" alignment="3" min="-2" max="-2" attributes="0"/>
                           </Group>
-                          <Component id="jMotionSlider" alignment="0" max="32767" attributes="1"/>
+                          <Component id="jMotionSlider" alignment="0" max="-2" attributes="1"/>
                       </Group>
-                      <EmptySpace min="-2" pref="0" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
                           <Component id="jStartTimeTextField" alignment="0" min="-2" max="-2" attributes="0"/>
                           <Component id="jEndTimeTextField" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -99,18 +99,17 @@
                   </Group>
                   <Group type="102" attributes="0">
                       <EmptySpace min="22" pref="22" max="-2" attributes="0"/>
-                      <Component id="jSpeedSpinner" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" attributes="0">
-                      <EmptySpace min="23" pref="23" max="-2" attributes="0"/>
-                      <Component id="jLabelForSpeedSpinner" min="-2" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="3" attributes="0">
+                          <Component id="jSpeedSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
+                          <Component id="jLabelForSpeedSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
+                      </Group>
                   </Group>
                   <Group type="102" alignment="0" attributes="0">
                       <EmptySpace min="22" pref="22" max="-2" attributes="0"/>
                       <Component id="jPlaybackButtonsPanel" min="-2" pref="16" max="-2" attributes="1"/>
                   </Group>
               </Group>
-              <EmptySpace max="32767" attributes="0"/>
+              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -147,9 +146,6 @@
             <Property name="borderPainted" type="boolean" value="false"/>
             <Property name="contentAreaFilled" type="boolean" value="false"/>
             <Property name="focusPainted" type="boolean" value="false"/>
-            <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[0, 0, 0, 0]"/>
-            </Property>
             <Property name="pressedIcon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/org/opensim/view/motions/images/rewindToStart_beveled_selected.png"/>
             </Property>
@@ -179,9 +175,6 @@
             <Property name="borderPainted" type="boolean" value="false"/>
             <Property name="contentAreaFilled" type="boolean" value="false"/>
             <Property name="focusPainted" type="boolean" value="false"/>
-            <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[0, 0, 0, 0]"/>
-            </Property>
             <Property name="pressedIcon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/org/opensim/view/motions/images/reverseStep_beveled.png"/>
             </Property>
@@ -211,9 +204,6 @@
             <Property name="borderPainted" type="boolean" value="false"/>
             <Property name="contentAreaFilled" type="boolean" value="false"/>
             <Property name="focusPainted" type="boolean" value="false"/>
-            <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[0, 0, 0, 0]"/>
-            </Property>
             <Property name="pressedIcon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/org/opensim/view/motions/images/reverse_beveled_selected.png"/>
             </Property>
@@ -243,9 +233,6 @@
             <Property name="borderPainted" type="boolean" value="false"/>
             <Property name="contentAreaFilled" type="boolean" value="false"/>
             <Property name="focusPainted" type="boolean" value="false"/>
-            <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[0, 0, 0, 0]"/>
-            </Property>
             <Property name="pressedIcon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/org/opensim/view/motions/images/pause_beveled_selected.png"/>
             </Property>
@@ -275,9 +262,6 @@
             <Property name="borderPainted" type="boolean" value="false"/>
             <Property name="contentAreaFilled" type="boolean" value="false"/>
             <Property name="focusPainted" type="boolean" value="false"/>
-            <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[0, 0, 0, 0]"/>
-            </Property>
             <Property name="pressedIcon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/org/opensim/view/motions/images/play_beveled_selected.png"/>
             </Property>
@@ -307,9 +291,6 @@
             <Property name="borderPainted" type="boolean" value="false"/>
             <Property name="contentAreaFilled" type="boolean" value="false"/>
             <Property name="focusPainted" type="boolean" value="false"/>
-            <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[0, 0, 0, 0]"/>
-            </Property>
             <Property name="pressedIcon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/org/opensim/view/motions/images/step_beveled_selected.png"/>
             </Property>
@@ -339,9 +320,6 @@
             <Property name="borderPainted" type="boolean" value="false"/>
             <Property name="contentAreaFilled" type="boolean" value="false"/>
             <Property name="focusPainted" type="boolean" value="false"/>
-            <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-              <Insets value="[0, 0, 0, 0]"/>
-            </Property>
             <Property name="pressedIcon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
               <Image iconType="3" name="/org/opensim/view/motions/images/fastforwardToEnd_beveled_selected.png"/>
             </Property>
@@ -376,7 +354,7 @@
           <Dimension value="[168, 22]"/>
         </Property>
         <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[168, 22]"/>
+          <Dimension value="[400, 22]"/>
         </Property>
       </Properties>
     </Component>
@@ -384,18 +362,18 @@
       <Properties>
         <Property name="toolTipText" type="java.lang.String" value="Current time"/>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[50, 19]"/>
+          <Dimension value="[80, 19]"/>
         </Property>
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[50, 19]"/>
         </Property>
         <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[50, 19]"/>
+          <Dimension value="[75, 19]"/>
         </Property>
       </Properties>
       <Events>
-        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTimeTextFieldActionPerformed"/>
         <EventHandler event="focusLost" listener="java.awt.event.FocusListener" parameters="java.awt.event.FocusEvent" handler="jTimeTextFieldFocusLost"/>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTimeTextFieldActionPerformed"/>
         <EventHandler event="propertyChange" listener="java.beans.PropertyChangeListener" parameters="java.beans.PropertyChangeEvent" handler="jTimeTextFieldPropertyChange"/>
       </Events>
     </Component>
@@ -411,8 +389,8 @@
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[50, 19]"/>
         </Property>
-        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[50, 19]"/>
+        <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection component="jTimeTextField" name="preferredSize" type="property"/>
         </Property>
       </Properties>
     </Component>
@@ -423,13 +401,13 @@
         </Property>
         <Property name="text" type="java.lang.String" value="Speed"/>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[37, 19]"/>
+          <Dimension value="[50, 19]"/>
         </Property>
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[37, 19]"/>
+          <Dimension value="[45, 19]"/>
         </Property>
         <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[37, 19]"/>
+          <Dimension value="[40, 19]"/>
         </Property>
       </Properties>
     </Component>
@@ -439,14 +417,11 @@
           <ComponentRef name="jTimeTextField"/>
         </Property>
         <Property name="text" type="java.lang.String" value="Time"/>
-        <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[31, 19]"/>
-        </Property>
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[31, 19]"/>
         </Property>
         <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[31, 19]"/>
+          <Dimension value="[40, 19]"/>
         </Property>
       </Properties>
     </Component>
@@ -464,9 +439,6 @@
         <Property name="focusPainted" type="boolean" value="false"/>
         <Property name="focusable" type="boolean" value="false"/>
         <Property name="iconTextGap" type="int" value="0"/>
-        <Property name="margin" type="java.awt.Insets" editor="org.netbeans.beaninfo.editors.InsetsEditor">
-          <Insets value="[0, 0, 0, 0]"/>
-        </Property>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[24, 42]"/>
         </Property>
@@ -508,13 +480,13 @@
         </Property>
         <Property name="focusable" type="boolean" value="false"/>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[50, 16]"/>
+          <Dimension value="[80, 16]"/>
         </Property>
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[50, 16]"/>
         </Property>
         <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[50, 16]"/>
+          <Dimension value="[80, 16]"/>
         </Property>
       </Properties>
     </Component>
@@ -524,7 +496,6 @@
         <Property name="background" type="java.awt.Color" editor="org.netbeans.beaninfo.editors.ColorEditor">
           <Color blue="e3" green="df" red="e0" type="rgb"/>
         </Property>
-        <Property name="horizontalAlignment" type="int" value="11"/>
         <Property name="text" type="java.lang.String" value="100"/>
         <Property name="toolTipText" type="java.lang.String" value="Final time"/>
         <Property name="autoscrolls" type="boolean" value="false"/>
@@ -533,20 +504,25 @@
         </Property>
         <Property name="focusable" type="boolean" value="false"/>
         <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[50, 16]"/>
+          <Dimension value="[80, 16]"/>
         </Property>
         <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
           <Dimension value="[50, 16]"/>
         </Property>
         <Property name="preferredSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-          <Dimension value="[50, 16]"/>
+          <Dimension value="[80, 16]"/>
         </Property>
       </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jEndTimeTextFieldActionPerformed"/>
+      </Events>
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel1">
       <Properties>
-        <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
-          <Font name="Tahoma" size="11" style="1"/>
+        <Property name="font" type="java.awt.Font" editor="org.netbeans.modules.form.editors2.FontEditor">
+          <FontInfo relative="true">
+            <Font bold="true" component="jLabel1" property="font" relativeSize="true" size="0"/>
+          </FontInfo>
         </Property>
         <Property name="text" type="java.lang.String" value="   Motion: "/>
       </Properties>
@@ -554,6 +530,9 @@
     <Component class="javax.swing.JLabel" name="jMotionNameLabel">
       <Properties>
         <Property name="text" type="java.lang.String" value="No Motions             "/>
+        <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection component="jMotionNameLabel" name="getText" type="method"/>
+        </Property>
         <Property name="border" type="javax.swing.border.Border" editor="org.netbeans.modules.form.editors2.BorderEditor">
           <Border info="org.netbeans.modules.form.compat2.border.EtchedBorderInfo">
             <EtchetBorder/>

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionControlJPanel.java
@@ -174,7 +174,7 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         setMaximumSize(new java.awt.Dimension(32767, 50));
         setMinimumSize(new java.awt.Dimension(0, 50));
         setOpaque(false);
-        setPreferredSize(new java.awt.Dimension(645, 50));
+        setPreferredSize(new java.awt.Dimension(700, 50));
 
         jPlaybackButtonsPanel.setToolTipText("Motion Controls");
         jPlaybackButtonsPanel.setMaximumSize(new java.awt.Dimension(32767, 16));
@@ -188,7 +188,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jRestartButton.setBorderPainted(false);
         jRestartButton.setContentAreaFilled(false);
         jRestartButton.setFocusPainted(false);
-        jRestartButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jRestartButton.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/rewindToStart_beveled_selected.png"))); // NOI18N
         jRestartButton.setRolloverIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/rewindToStart_beveled_rollover.png"))); // NOI18N
         jRestartButton.setRolloverSelectedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/rewindToStart_beveled_rollover_selected.png"))); // NOI18N
@@ -206,7 +205,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jBackButton.setBorderPainted(false);
         jBackButton.setContentAreaFilled(false);
         jBackButton.setFocusPainted(false);
-        jBackButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jBackButton.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/reverseStep_beveled.png"))); // NOI18N
         jBackButton.setRolloverIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/reverseStep_beveled_rollover.png"))); // NOI18N
         jBackButton.setRolloverSelectedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/reverseStep_beveled_rollover_selected.png"))); // NOI18N
@@ -224,7 +222,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jReverseButton.setBorderPainted(false);
         jReverseButton.setContentAreaFilled(false);
         jReverseButton.setFocusPainted(false);
-        jReverseButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jReverseButton.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/reverse_beveled_selected.png"))); // NOI18N
         jReverseButton.setRolloverIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/reverse_beveled_rollover.png"))); // NOI18N
         jReverseButton.setRolloverSelectedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/reverse_beveled_rollover_selected.png"))); // NOI18N
@@ -242,7 +239,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jStopButton.setBorderPainted(false);
         jStopButton.setContentAreaFilled(false);
         jStopButton.setFocusPainted(false);
-        jStopButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jStopButton.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/pause_beveled_selected.png"))); // NOI18N
         jStopButton.setRolloverIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/pause_beveled_rollover.png"))); // NOI18N
         jStopButton.setRolloverSelectedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/pause_beveled_rollover_selected.png"))); // NOI18N
@@ -260,7 +256,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jPlayButton.setBorderPainted(false);
         jPlayButton.setContentAreaFilled(false);
         jPlayButton.setFocusPainted(false);
-        jPlayButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jPlayButton.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/play_beveled_selected.png"))); // NOI18N
         jPlayButton.setRolloverIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/play_beveled_rollover.png"))); // NOI18N
         jPlayButton.setRolloverSelectedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/play_beveled_rollover_selected.png"))); // NOI18N
@@ -278,7 +273,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jAdvanceButton.setBorderPainted(false);
         jAdvanceButton.setContentAreaFilled(false);
         jAdvanceButton.setFocusPainted(false);
-        jAdvanceButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jAdvanceButton.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/step_beveled_selected.png"))); // NOI18N
         jAdvanceButton.setRolloverIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/step_beveled_rollover.png"))); // NOI18N
         jAdvanceButton.setRolloverSelectedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/step_beveled_rollover_selected.png"))); // NOI18N
@@ -296,7 +290,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jFinishButton.setBorderPainted(false);
         jFinishButton.setContentAreaFilled(false);
         jFinishButton.setFocusPainted(false);
-        jFinishButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jFinishButton.setPressedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/fastforwardToEnd_beveled_selected.png"))); // NOI18N
         jFinishButton.setRolloverIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/fastforwardToEnd_beveled_rollover.png"))); // NOI18N
         jFinishButton.setRolloverSelectedIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/fastforwardToEnd_beveled_rollover_selected.png"))); // NOI18N
@@ -316,20 +309,20 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jMotionSlider.setFocusable(false);
         jMotionSlider.setMaximumSize(new java.awt.Dimension(32767, 22));
         jMotionSlider.setMinimumSize(new java.awt.Dimension(168, 22));
-        jMotionSlider.setPreferredSize(new java.awt.Dimension(168, 22));
+        jMotionSlider.setPreferredSize(new java.awt.Dimension(400, 22));
 
         jTimeTextField.setToolTipText("Current time");
-        jTimeTextField.setMaximumSize(new java.awt.Dimension(50, 19));
+        jTimeTextField.setMaximumSize(new java.awt.Dimension(80, 19));
         jTimeTextField.setMinimumSize(new java.awt.Dimension(50, 19));
-        jTimeTextField.setPreferredSize(new java.awt.Dimension(50, 19));
-        jTimeTextField.addActionListener(new java.awt.event.ActionListener() {
-            public void actionPerformed(java.awt.event.ActionEvent evt) {
-                jTimeTextFieldActionPerformed(evt);
-            }
-        });
+        jTimeTextField.setPreferredSize(new java.awt.Dimension(75, 19));
         jTimeTextField.addFocusListener(new java.awt.event.FocusAdapter() {
             public void focusLost(java.awt.event.FocusEvent evt) {
                 jTimeTextFieldFocusLost(evt);
+            }
+        });
+        jTimeTextField.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jTimeTextFieldActionPerformed(evt);
             }
         });
         jTimeTextField.addPropertyChangeListener(new java.beans.PropertyChangeListener() {
@@ -342,19 +335,18 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jSpeedSpinner.setToolTipText("Play speed");
         jSpeedSpinner.setMaximumSize(new java.awt.Dimension(50, 19));
         jSpeedSpinner.setMinimumSize(new java.awt.Dimension(50, 19));
-        jSpeedSpinner.setPreferredSize(new java.awt.Dimension(50, 19));
+        jSpeedSpinner.setPreferredSize(jTimeTextField.getPreferredSize());
 
         jLabelForSpeedSpinner.setLabelFor(jSpeedSpinner);
         jLabelForSpeedSpinner.setText("Speed");
-        jLabelForSpeedSpinner.setMaximumSize(new java.awt.Dimension(37, 19));
-        jLabelForSpeedSpinner.setMinimumSize(new java.awt.Dimension(37, 19));
-        jLabelForSpeedSpinner.setPreferredSize(new java.awt.Dimension(37, 19));
+        jLabelForSpeedSpinner.setMaximumSize(new java.awt.Dimension(50, 19));
+        jLabelForSpeedSpinner.setMinimumSize(new java.awt.Dimension(45, 19));
+        jLabelForSpeedSpinner.setPreferredSize(new java.awt.Dimension(40, 19));
 
         jLabelForTimeTextField.setLabelFor(jTimeTextField);
         jLabelForTimeTextField.setText("Time");
-        jLabelForTimeTextField.setMaximumSize(new java.awt.Dimension(31, 19));
         jLabelForTimeTextField.setMinimumSize(new java.awt.Dimension(31, 19));
-        jLabelForTimeTextField.setPreferredSize(new java.awt.Dimension(31, 19));
+        jLabelForTimeTextField.setPreferredSize(new java.awt.Dimension(40, 19));
 
         jWrapToggleButton.setIcon(new javax.swing.ImageIcon(getClass().getResource("/org/opensim/view/motions/images/wrap_beveled.png"))); // NOI18N
         jWrapToggleButton.setToolTipText("Loop motion");
@@ -364,7 +356,6 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jWrapToggleButton.setFocusPainted(false);
         jWrapToggleButton.setFocusable(false);
         jWrapToggleButton.setIconTextGap(0);
-        jWrapToggleButton.setMargin(new java.awt.Insets(0, 0, 0, 0));
         jWrapToggleButton.setMaximumSize(new java.awt.Dimension(24, 42));
         jWrapToggleButton.setMinimumSize(new java.awt.Dimension(24, 42));
         jWrapToggleButton.setPreferredSize(new java.awt.Dimension(24, 42));
@@ -386,26 +377,31 @@ public class MotionControlJPanel extends javax.swing.JToolBar
         jStartTimeTextField.setAutoscrolls(false);
         jStartTimeTextField.setBorder(null);
         jStartTimeTextField.setFocusable(false);
-        jStartTimeTextField.setMaximumSize(new java.awt.Dimension(50, 16));
+        jStartTimeTextField.setMaximumSize(new java.awt.Dimension(80, 16));
         jStartTimeTextField.setMinimumSize(new java.awt.Dimension(50, 16));
-        jStartTimeTextField.setPreferredSize(new java.awt.Dimension(50, 16));
+        jStartTimeTextField.setPreferredSize(new java.awt.Dimension(80, 16));
 
         jEndTimeTextField.setEditable(false);
         jEndTimeTextField.setBackground(new java.awt.Color(224, 223, 227));
-        jEndTimeTextField.setHorizontalAlignment(javax.swing.JTextField.TRAILING);
         jEndTimeTextField.setText("100");
         jEndTimeTextField.setToolTipText("Final time");
         jEndTimeTextField.setAutoscrolls(false);
         jEndTimeTextField.setBorder(null);
         jEndTimeTextField.setFocusable(false);
-        jEndTimeTextField.setMaximumSize(new java.awt.Dimension(50, 16));
+        jEndTimeTextField.setMaximumSize(new java.awt.Dimension(80, 16));
         jEndTimeTextField.setMinimumSize(new java.awt.Dimension(50, 16));
-        jEndTimeTextField.setPreferredSize(new java.awt.Dimension(50, 16));
+        jEndTimeTextField.setPreferredSize(new java.awt.Dimension(80, 16));
+        jEndTimeTextField.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                jEndTimeTextFieldActionPerformed(evt);
+            }
+        });
 
-        jLabel1.setFont(new java.awt.Font("Tahoma", 1, 11)); // NOI18N
+        jLabel1.setFont(jLabel1.getFont().deriveFont(jLabel1.getFont().getStyle() | java.awt.Font.BOLD));
         jLabel1.setText("   Motion: ");
 
         jMotionNameLabel.setText("No Motions             ");
+        jMotionNameLabel.setToolTipText(jMotionNameLabel.getText());
         jMotionNameLabel.setBorder(javax.swing.BorderFactory.createEtchedBorder());
         jMotionNameLabel.setMaximumSize(new java.awt.Dimension(130, 18));
         jMotionNameLabel.setMinimumSize(new java.awt.Dimension(130, 18));
@@ -421,8 +417,8 @@ public class MotionControlJPanel extends javax.swing.JToolBar
                 .add(jMotionNameLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .add(18, 18, 18)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
-                    .add(jLabelForSpeedSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
-                    .add(jLabelForTimeTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                    .add(jLabelForSpeedSpinner, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                    .add(jLabelForTimeTextField, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                     .add(jTimeTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
@@ -435,7 +431,7 @@ public class MotionControlJPanel extends javax.swing.JToolBar
                         .add(jPlaybackButtonsPanel, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                         .add(jEndTimeTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 50, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                    .add(jMotionSlider, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .add(jMotionSlider, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, 292, Short.MAX_VALUE))
                 .addPreferredGap(org.jdesktop.layout.LayoutStyle.RELATED)
                 .add(jWrapToggleButton, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                 .addContainerGap())
@@ -450,7 +446,7 @@ public class MotionControlJPanel extends javax.swing.JToolBar
                             .add(org.jdesktop.layout.GroupLayout.LEADING, layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
                                 .add(jTimeTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
                                 .add(jLabelForTimeTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                            .add(org.jdesktop.layout.GroupLayout.LEADING, jMotionSlider, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                            .add(org.jdesktop.layout.GroupLayout.LEADING, jMotionSlider, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
                         .add(0, 0, 0)
                         .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.LEADING)
                             .add(jStartTimeTextField, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
@@ -462,14 +458,13 @@ public class MotionControlJPanel extends javax.swing.JToolBar
                             .add(jMotionNameLabel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
                     .add(layout.createSequentialGroup()
                         .add(22, 22, 22)
-                        .add(jSpeedSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
-                    .add(layout.createSequentialGroup()
-                        .add(23, 23, 23)
-                        .add(jLabelForSpeedSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE))
+                        .add(layout.createParallelGroup(org.jdesktop.layout.GroupLayout.BASELINE)
+                            .add(jSpeedSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)
+                            .add(jLabelForSpeedSpinner, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
                     .add(layout.createSequentialGroup()
                         .add(22, 22, 22)
                         .add(jPlaybackButtonsPanel, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE, 16, org.jdesktop.layout.GroupLayout.PREFERRED_SIZE)))
-                .addContainerGap(org.jdesktop.layout.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .add(0, 0, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -583,6 +578,10 @@ public class MotionControlJPanel extends javax.swing.JToolBar
           jPlayButton.setSelected(true);
       }
     }//GEN-LAST:event_jPlayButtonActionPerformed
+
+    private void jEndTimeTextFieldActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jEndTimeTextFieldActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_jEndTimeTextFieldActionPerformed
     
     
     public void stateChanged(ChangeEvent e) 
@@ -652,6 +651,7 @@ public class MotionControlJPanel extends javax.swing.JToolBar
          if (getMasterMotion().getNumMotions()>=1){
             //this.setBorder(BorderFactory.createTitledBorder(null, getMasterMotion().getDisplayName(), TitledBorder.CENTER, TitledBorder.TOP));
             jMotionNameLabel.setText(getMasterMotion().getDisplayName());
+            jMotionNameLabel.setToolTipText(getMasterMotion().getDisplayName());
             setTimeTextField(getMasterMotion().getCurrentTime());
             setStartTimeTextField(getMasterMotion().getStartTime());
             setEndTimeTextField(getMasterMotion().getEndTime());


### PR DESCRIPTION
### Brief summary of changes

There are 2 layout problems in the Linux build (at least with Gnome/GTK) when compared to Windows:
1. All sliders show their current value above the slider, which uses more vertical space and pushes the slider/track down, cutting off the top and bottom of the slider value and slider track, respectively. (See first image)
2. Text size in text fields is too large to show all the text, which leads to cut off text which is hard to read. (Check out the coordinate value text field and the "Time" and "Speed" text in the motion control panel.)

Additionally, I added a tool tip for the current motion text field, which also cuts off filenames which are too long, and I changed the font for the "Simulate" and "Motion" labels to be based on the system font but bolded. The previous font was small in comparison to the rest of the text in the GUI.

#### Before
![image](https://user-images.githubusercontent.com/7356205/115264799-a085da80-a104-11eb-960c-95be33fdaa4b.png)
![image](https://user-images.githubusercontent.com/7356205/115263074-1be68c80-a103-11eb-9348-6516d6c2384e.png)

#### After
![image](https://user-images.githubusercontent.com/7356205/115262125-3ec47100-a102-11eb-9710-839e04fb17c3.png)
![image](https://user-images.githubusercontent.com/7356205/115264172-0faeff00-a104-11eb-9c7f-206b6897eca3.png)


### Testing I've completed

I don't have a build environment setup for Windows, so I will use the Windows build generated by CI to look for undesired changes on Windows; I don't have access to a Mac.

### CHANGELOG.md

Not sure if/what y'all would want in the changelog, so I will leave that alone for now.
