### PR TITLE
Update continuous-integration.yml to force py3.8 on osx

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -160,6 +160,8 @@ jobs:
     - name: Install packages
       run: |
         brew install cmake pkgconfig autoconf libtool automake wget pcre doxygen python@3.8
+        brew unlink python@3.9
+        brew link python@3.8
         brew reinstall gcc
         pip3 install numpy==1.20.2
         gfortran -v


### PR DESCRIPTION
Fixes issue #<issue_number>

### Brief summary of changes

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
