### PR TITLE
Full refresh of model decorations on Frame edit 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ v4.4
 - Fix issue [#1319](https://github.com/opensim-org/opensim-gui/issues/1319): Undo/redo support for show-COM, show-Axes
 - Animate transition of camera to standard views.
 - Fix visualization of muscle paths in the presense of ConditionalPathPoints, multiple wrap objects or mixes of them. Fix issues [#1330][#1331].
+- Propagate frame changes to all components in the model either owned or connected by sockets to the frame, fix issue [#1340]
+
 
 v4.3
 ====

--- a/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
+++ b/Gui/opensim/view/src/org/opensim/view/nodes/OneFrameNode.java
@@ -186,8 +186,7 @@ public class OneFrameNode extends OneModelComponentNode {
             Exceptions.printStackTrace(ex);
         }
         Model model = getModelForNode();
-        Frame frame = Frame.safeDownCast(comp);
-        ViewDB.getInstance().updateDecorations(model, frame);
+        ViewDB.getInstance().updateDecorations(model);
         ViewDB.getInstance().updateModelDisplay(model);
         
     }

--- a/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
+++ b/Gui/opensim/view/src/org/opensim/view/pub/ViewDB.java
@@ -112,12 +112,11 @@ public final class ViewDB extends Observable implements Observer, LookupListener
         }
     }
     /*
-     * Update Decorations downstream from passed in Component.
+     * Update Decorations with full model refresh. Issue #1340
     */
-    public void updateDecorations(Model model, Component comp) {
+    public void updateDecorations(Model model) {
         if (websocketdb!=null){
-            ModelVisualizationJson modelJson = getModelVisualizationJson(model);
-             websocketdb.broadcastMessageJson(currentJson.createUpdateDecorationsMessageJson(comp), null);
+             websocketdb.broadcastMessageJson(currentJson.createUpdateDecorationsMessageJson(model), null);
         }
     }
 


### PR DESCRIPTION
Make sure to update components that are "connected-to" rather than only those "owned" by a Frame

Fixes issue #1340

### Brief summary of changes
When a Frame location/orientation are edited, refresh all model decorations rather than only subcomponents or owned components since there are other components that are connected to Frames via sockets (e.g. IMU)
  
### Testing I've completed
Tested model/change in issue #1340 

### CHANGELOG.md (choose one)
- updated...
