### PR TITLE
Initialize arrow size property to 1.0 

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -76,7 +76,7 @@ public class AnnotatedMotion extends Storage {
     private double cameraRate=0.;
     private double dataRate=0.;
     private MotionDisplayer motionDisplayer;
-    private double displayForceScale = .001;
+    private double displayForceScale = 1.0;
     private String displayForceShape = "arrow";
     private Model model;
     private Units units;


### PR DESCRIPTION
Make displayed arrow size consistent with value sent to visualizer

Fixes issue #1320

### Brief summary of changes
Update internally maintained initial value to 1.0

### Testing I've completed
Loaded motions and GRFs and it performed as expected.

### CHANGELOG.md (choose one)

- no need to update because mostly internal but open to including in changelog
