### PR TITLE
Prserve rates as ints rather than doubles to make header parsing robust

### DIFF
--- a/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
+++ b/Gui/opensim/view/src/org/opensim/view/experimentaldata/AnnotatedMotion.java
@@ -72,9 +72,9 @@ public class AnnotatedMotion extends Storage {
     private double unitConversion = 1.0;
     private boolean boundingBoxComputed=false;
     private double[] currentRotations = new double[]{0., 0., 0.};
-    private double frameRate=0.;
-    private double cameraRate=0.;
-    private double dataRate=0.;
+    private int frameRate=0;
+    private int cameraRate=0;
+    private int dataRate=0;
     private MotionDisplayer motionDisplayer;
     private double displayForceScale = .001;
     private String displayForceShape = "arrow";
@@ -455,27 +455,27 @@ public class AnnotatedMotion extends Storage {
         writer.close();
     }
 
-    public void setDataRate(double d) {
+    public void setDataRate(int d) {
         this.dataRate = d;
     }
 
-    public void setCameraRate(double d) {
+    public void setCameraRate(int d) {
         this.cameraRate = d;
     }
 
-    public double getFrameRate() {
+    public int getFrameRate() {
         return frameRate;
     }
 
-    public void setFrameRate(double frameRate) {
+    public void setFrameRate(int frameRate) {
         this.frameRate = frameRate;
     }
 
-    public double getCameraRate() {
+    public int getCameraRate() {
         return cameraRate;
     }
 
-    public double getDataRate() {
+    public int getDataRate() {
         return dataRate;
     }
 

--- a/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/FileLoadDataAction.java
@@ -60,8 +60,8 @@ public final class FileLoadDataAction extends CallableSystemAction {
                     AnnotatedMotion amot = new AnnotatedMotion(newStorage, markerData.getMarkerNames());
                     amot.setUnitConversion(markerData.getUnits().convertTo(Units.UnitType.Meters));
                     amot.setName(new File(fileName).getName());
-                    amot.setDataRate(markerData.getDataRate());
-                    amot.setCameraRate(markerData.getCameraRate());
+                    amot.setDataRate((int)markerData.getDataRate());
+                    amot.setCameraRate((int)markerData.getCameraRate());
                     amot.setUnits(markerData.getUnits());
                     // Add the visuals to support it
                     ModelForExperimentalData modelForDataImport = new ModelForExperimentalData(nextNumber++, amot);

--- a/Gui/opensim/view/src/org/opensim/view/motions/MotionAssociateMotionAction.java
+++ b/Gui/opensim/view/src/org/opensim/view/motions/MotionAssociateMotionAction.java
@@ -62,8 +62,8 @@ public final class MotionAssociateMotionAction extends CallableSystemAction {
                     AnnotatedMotion amot = new AnnotatedMotion(newStorage, markerData.getMarkerNames());
                     amot.setUnitConversion(markerData.getUnits().convertTo(Units.UnitType.Meters));
                     amot.setName(new File(fileName).getName());
-                    amot.setDataRate(markerData.getDataRate());
-                    amot.setCameraRate(markerData.getCameraRate());
+                    amot.setDataRate((int)markerData.getDataRate());
+                    amot.setCameraRate((int)markerData.getCameraRate());
                     storage = amot;
                     amot.setModel(node.getModelForNode());
                }


### PR DESCRIPTION
Fixes issue #1344

### Brief summary of changes
Write frameRate, cameraRate etc. as ints to avoid confusing the parser built into MarkerData class (GUI doesn't have its own parser). Ideally we switch to the TimeSeriesTable to avoid duplicity but those need work to be usable by the GUI.

### Testing I've completed
Tested workflow suggested in issue and it all worked.

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
