### PR TITLE
Avoid special handling of path-segments with conditional path points

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -216,7 +216,7 @@ jobs:
         key: ${{ runner.os }}-dependencies-${{ hashFiles('opensim-core/dependencies/*') }}
         
     - name: Build opensim-core-dependencies
-      # if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         mkdir build_deps
         cd build_deps
@@ -248,7 +248,7 @@ jobs:
         make && make -j4 install
 
     - name: Build opensim-core
-      # if: steps.cache-core.outputs.cache-hit != 'true'
+      if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         mkdir build_core
         cd build_core

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1688,13 +1688,6 @@ public class ModelVisualizationJson extends JSONObject {
                 mapUUIDToComponent.put(pathpoint_uuid, cpp);                
                 pathpointActive_jsonArr.add(false);
                 pathpoint_jsonArr.add(pathpoint_uuid.toString());
-                // traverse backward to an active point
-                /*
-                int tempIndex = ppointSetIndex;
-                while (!pathPointSetFromProperty.get(tempIndex).isActive(state))
-                    tempIndex--;
-                secondPoint = pathPointSetFromProperty.get(tempIndex);
-                secondIndex = tempIndex;*/
             }
             else { // Wrapping encountered in createJsonForGeometryPath
                 int numWrapPoints = secondIndex - firstIndex -1;

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1689,11 +1689,12 @@ public class ModelVisualizationJson extends JSONObject {
                 pathpointActive_jsonArr.add(false);
                 pathpoint_jsonArr.add(pathpoint_uuid.toString());
                 // traverse backward to an active point
+                /*
                 int tempIndex = ppointSetIndex;
                 while (!pathPointSetFromProperty.get(tempIndex).isActive(state))
                     tempIndex--;
                 secondPoint = pathPointSetFromProperty.get(tempIndex);
-                secondIndex = tempIndex;
+                secondIndex = tempIndex;*/
             }
             else { // Wrapping encountered in createJsonForGeometryPath
                 int numWrapPoints = secondIndex - firstIndex -1;


### PR DESCRIPTION
Fixes issue #1351

### Brief summary of changes
Fix indexing issue when passing from one path-segment to the next (restore default behavior)
### Testing I've completed
Tested other models with visualization issues with conditional path points and multiple wrapping
### CHANGELOG.md (choose one)

- no need to update because this was a side-effect of earlier fix/internal
