### PR TITLE
Fix issue 1354 exception if no weights button before IK

### DIFF
--- a/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/IMUIKToolModel.java
@@ -317,7 +317,8 @@ public class IMUIKToolModel extends Observable implements Observer {
        imuIkTool.set_report_errors(reportErrors);
        // Replace OrientationWeightSet in tool with new set.
        imuIkTool.upd_orientation_weights().setSize(0);
-       for (int j=0; j < orientation_weightset.getSize(); j++)
+       orientation_weightset = getOrientation_weightset(); // Guard against orientation_weightset being null
+       for (int j=0; j < orientation_weightset.getSize(); j++) 
         imuIkTool.upd_orientation_weights().adoptAndAppend(orientation_weightset.get(j));
    }
 


### PR DESCRIPTION
Fixes issue #1354 
### Brief summary of changes
Weights were initialized to null instead of using the getter that populates them if null. 
### Testing I've completed
Ran workflow in issue without exception being thrown
### CHANGELOG.md (choose one)

- not sure if it is worth including in change log considering it's a rare scenario
