### PR TITLE
Updated deprecated environments in CI.

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -145,7 +145,7 @@ jobs:
   mac:
     name: Mac
 
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - name: Checkout opensim-gui
@@ -294,7 +294,7 @@ jobs:
   ubuntu:
     name: Ubuntu
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -145,7 +145,7 @@ jobs:
   mac:
     name: Mac
 
-    runs-on: macos-10.15
+    runs-on: macos-latest
 
     steps:
     - name: Checkout opensim-gui
@@ -294,7 +294,7 @@ jobs:
   ubuntu:
     name: Ubuntu
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
 


### PR DESCRIPTION
Fixes issue #1388

### Brief summary of changes

Updated environment versions for Mac and Ubuntu to latest.

### Testing I've completed

Running CI job.

### CHANGELOG.md (choose one)

- no need to update because this is a CI matter.
