### PR TITLE
Fixed bug in FileChooser for output directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ request related to the change, then we may provide the commit.
 
 v4.4.1
 ======
-
+- Fix issue [#1378](https://github.com/opensim-org/opensim-gui/issues/1378): In Static Optimization Tool, dialog box has wrong title for "Directory" in output section.
 
 v4.4
 ====

--- a/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/AnalyzeAndForwardToolPanel.java
@@ -152,7 +152,9 @@ public class AnalyzeAndForwardToolPanel extends BaseToolPanel implements Observe
       // File chooser settings
       outputDirectory.setIncludeOpenButton(true);
       outputDirectory.setDirectoriesOnly(true);
+      outputDirectory.setSaveMode(true);
       outputDirectory.setCheckIfFileExists(false);
+      outputDirectory.setDialogTitle("Choose Output Directory");
 
       setSettingsFileDescription("Settings file for "+modeName);
 

--- a/Gui/opensim/utils/src/org/opensim/swingui/FileTextFieldAndChooser.java
+++ b/Gui/opensim/utils/src/org/opensim/swingui/FileTextFieldAndChooser.java
@@ -43,7 +43,7 @@ public class FileTextFieldAndChooser extends javax.swing.JPanel implements Actio
 
    private FileFilter filter = null;
    private boolean directoriesOnly = false;
-
+   private String title;
    private String lastFileName; // keep track of previous value to avoid firing change events when name stays the same
    private boolean fileIsValid = true;
    private boolean treatUnassignedAsEmptyString = true;
@@ -83,6 +83,10 @@ public class FileTextFieldAndChooser extends javax.swing.JPanel implements Actio
 
    public void setFileFilter(FileFilter filter) {
       this.filter = filter;
+   }
+	
+   public void setDialogTitle(String title) {
+	  this.title = title;   
    }
 
    public void setIncludeOpenButton(boolean includeOpenButton) {
@@ -219,12 +223,12 @@ public class FileTextFieldAndChooser extends javax.swing.JPanel implements Actio
       String result =null;
      if (isSaveMode()){
          result = directoriesOnly ?
-                      FileUtils.getInstance().browseForFolder(ownerFrame, "", true) :
+                      FileUtils.getInstance().browseForFolder(ownerFrame, this.title, true) :
                       FileUtils.getInstance().browseForFilenameToSave(filter, true, "", ownerFrame);
      }
      else
          result = directoriesOnly ?
-                      FileUtils.getInstance().browseForFolder(ownerFrame, "", false) :
+                      FileUtils.getInstance().browseForFolder(ownerFrame, this.title, false) :
                       FileUtils.getInstance().browseForFilename(filter, ownerFrame);
       if(result != null) setFileName(result);
    }//GEN-LAST:event_browseButtonActionPerformed

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -262,7 +262,7 @@ public final class FileUtils {
         dlog.setCurrentDirectory(new File(defaultDir));
         dlog.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         
-		dlog.resetChoosableFileFilters();
+	dlog.resetChoosableFileFilters();
 		
         if(!description.equals("")) {
             dlog.setDialogTitle(description);

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -262,6 +262,8 @@ public final class FileUtils {
         dlog.setCurrentDirectory(new File(defaultDir));
         dlog.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
         
+		dlog.resetChoosableFileFilters();
+		
         if(!description.equals("")) {
             dlog.setDialogTitle(description);
         }


### PR DESCRIPTION
Fixes issue #1378 

### Brief summary of changes

When opening FileChooser to select the Output Directory on Analysis Tools, it was not updating the title and the filters. Thus, it was showing the title and filters set the last time you opened the FileChooser otherwhere (This is the reason the title and the filters were changing over time, it depends on the value assigned last time you opened a FileChooser). This has been solved by:

 - Added function to allow set title of the window without having to add elements to the FileFilter.
 - Reset FileFilter when the FileChooser is opened.
 - Make sure that the FileChooser is in save mode.

### Testing I've completed

Locally tested on Ubuntu 22.04.

### CHANGELOG.md (choose one)

- Updated.
