### PR TITLE
Remove ci warnings

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,7 +89,7 @@ jobs:
       run: |
         cd opensim-core
         $opensim_core_commit=(git rev-parse HEAD)
-        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
+        echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
 
     - name: Cache opensim-core
       id: cache-core
@@ -130,7 +130,7 @@ jobs:
         $version = $env:match.split('=')[1]
         echo $version
         echo "name=VERSION::$version" >> $GITHUB_ENV
-        echo "name=version::$version" >> $GITHUB_OUTPUT
+        echo "version=$version" >> $GITHUB_OUTPUT
         
     - name: Build GUI installer
       run: |
@@ -236,7 +236,7 @@ jobs:
       run: |
         cd opensim-core
         opensim_core_commit=$(git rev-parse HEAD)
-        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
+        echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
           
     - name: Cache opensim-core
       id: cache-core
@@ -282,7 +282,7 @@ jobs:
         VERSION=`cmake -L . | grep OPENSIMGUI_BUILD_VERSION | cut -d "=" -f2`
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "name=version::$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         cd $GITHUB_WORKSPACE
         ls Gui/opensim/dist
         mv Gui/opensim/dist/OpenSim-$VERSION.pkg $GITHUB_WORKSPACE
@@ -385,7 +385,7 @@ jobs:
       run: |
         cd opensim-core
         opensim_core_commit=$(git rev-parse HEAD)
-        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
+        echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
           
     - name: Cache opensim-core
       id: cache-core
@@ -431,7 +431,7 @@ jobs:
         VERSION=`cmake -L . | grep OPENSIMGUI_BUILD_VERSION | cut -d "=" -f2`
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "name=version::$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         cd $GITHUB_WORKSPACE
         ls Gui/opensim/dist
         mv Gui/opensim/dist/OpenSim-$VERSION.pkg $GITHUB_WORKSPACE
@@ -518,7 +518,7 @@ jobs:
       run: |
         cd opensim-core
         opensim_core_commit=$(git rev-parse HEAD)
-        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
+        echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
 
     - name: Cache opensim-core
       id: cache-core
@@ -552,7 +552,7 @@ jobs:
         VERSION=`cmake -L . | grep OPENSIMGUI_BUILD_VERSION | cut -d "=" -f2`
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "name=version::$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         cd $GITHUB_WORKSPACE
         ls Gui/opensim/dist
         mv Gui/opensim/dist/OpenSim-$VERSION.tar.gz $GITHUB_WORKSPACE

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 1.8
+        java-version: 8
 
     - name: Install Netbeans 12.3
       # Make sure the NetBeans installer is not corrupted.
@@ -176,7 +176,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 1.8
+        java-version: 8
 
     # - name: Setup tmate session to debug the workflow through SSH.
     #   uses: mxschmitt/action-tmate@v2
@@ -325,7 +325,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 1.8
+        java-version: 8
 
     # - name: Setup tmate session to debug the workflow through SSH.
     #   uses: mxschmitt/action-tmate@v2
@@ -474,7 +474,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         distribution: 'temurin'
-        java-version: 1.8
+        java-version: 8
 
     - name: Cache Netbeans
       id: cache-netbeans

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -130,7 +130,7 @@ jobs:
         $version = $env:match.split('=')[1]
         echo $version
         echo "name=VERSION::$version" >> $GITHUB_ENV
-        echo "version=$version" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
         
     - name: Build GUI installer
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -439,7 +439,7 @@ jobs:
     - name: Upload GUI installer
       uses: actions/upload-artifact@v3
       with:
-        name: OpenSim-${{ steps.build-gui.outputs.version }}
+        name: OpenSim-${{ steps.build-gui.outputs.version }}-mac
         path: OpenSim-${{ steps.build-gui.outputs.version }}.pkg
 
   ubuntu:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -127,9 +127,9 @@ jobs:
         cmake --build . --target CopyVisualizer --config Release
         # Read the value of the cache variable storing the GUI build version.
         $env:match = cmake -L . | Select-String -Pattern OPENSIMGUI_BUILD_VERSION
-        $version = $env:match.split('=')[1]
-        echo $version
-        echo "name=VERSION::$version" >> $GITHUB_ENV
+        $VERSION = $env:match.split('=')[1]
+        echo $VERSION
+        echo "name=VERSION::$VERSION" >> $GITHUB_ENV
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         
     - name: Build GUI installer

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
       run: pip3.8 install numpy==1.20.2
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 8
@@ -173,7 +173,7 @@ jobs:
         gfortran -v &> gfortran_version/gfortran_version.txt
     
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 8
@@ -322,7 +322,7 @@ jobs:
         gfortran -v &> gfortran_version/gfortran_version.txt
     
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 8
@@ -471,7 +471,7 @@ jobs:
         make && make -j4 install  
         
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
         java-version: 8

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -130,7 +130,7 @@ jobs:
         $VERSION = $env:match.split('=')[1]
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $env:$GITHUB_OUTPUT
+        echo "version=$VERSION" >> $env:GITHUB_OUTPUT
         
     - name: Build GUI installer
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,13 +20,13 @@ jobs:
 
     steps:
     - name: Checkout opensim-gui
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install SWIG
       run: choco install swig --version 4.0.2 --yes --limit-output --allow-downgrade
       
     - name: Install Python packages
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.8'
         
@@ -34,8 +34,9 @@ jobs:
       run: pip3.8 install numpy==1.20.2
 
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: 1.8
 
     - name: Install Netbeans 12.3
@@ -49,14 +50,14 @@ jobs:
         echo "ANT_HOME=C:\\Program Files\\NetBeans-12.0\\netbeans\\extide\\ant" >> $GITHUB_ENV
       
     - name: Checkout opensim-core master
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
     
     - name: Cache opensim-core-dependencies
       id: cache-dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim_dependencies_install
         # Every time a cache is created, it's stored with this key.
@@ -92,7 +93,7 @@ jobs:
 
     - name: Cache opensim-core
       id: cache-core
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim-core-install
         # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
@@ -137,7 +138,7 @@ jobs:
         makensis.exe make_installer.nsi
         mv OpenSim-${{ steps.build-gui.outputs.version }}-win64.exe $env:GITHUB_WORKSPACE
     - name: Upload GUI installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: OpenSim-${{ steps.build-gui.outputs.version }}-win64
         path: OpenSim-${{ steps.build-gui.outputs.version }}-win64.exe
@@ -149,10 +150,10 @@ jobs:
 
     steps:
     - name: Checkout opensim-gui
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout opensim-core master
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
@@ -172,8 +173,9 @@ jobs:
         gfortran -v &> gfortran_version/gfortran_version.txt
     
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: 1.8
 
     # - name: Setup tmate session to debug the workflow through SSH.
@@ -209,7 +211,7 @@ jobs:
 
     - name: Cache opensim-core-dependencies
       id: cache-dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim_dependencies_install
         # Every time a cache is created, it's stored with this key.
@@ -238,7 +240,7 @@ jobs:
           
     - name: Cache opensim-core
       id: cache-core
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim-core-install
         key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
@@ -286,7 +288,7 @@ jobs:
         mv Gui/opensim/dist/OpenSim-$VERSION.pkg $GITHUB_WORKSPACE
 
 #    - name: Upload GUI installer
-#      uses: actions/upload-artifact@v2
+#      uses: actions/upload-artifact@v3
 #      with:
 #        name: OpenSim-${{ steps.build-gui.outputs.version }}-mac
 #        path: OpenSim-${{ steps.build-gui.outputs.version }}.pkg
@@ -298,10 +300,10 @@ jobs:
 
     steps:
     - name: Checkout opensim-gui
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Checkout opensim-core master
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
@@ -320,8 +322,9 @@ jobs:
         gfortran -v &> gfortran_version/gfortran_version.txt
     
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: 1.8
 
     # - name: Setup tmate session to debug the workflow through SSH.
@@ -357,7 +360,7 @@ jobs:
 
     - name: Cache opensim-core-dependencies
       id: cache-dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim_dependencies_install
         # Every time a cache is created, it's stored with this key.
@@ -386,7 +389,7 @@ jobs:
           
     - name: Cache opensim-core
       id: cache-core
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim-core-install
         key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
@@ -434,7 +437,7 @@ jobs:
         mv Gui/opensim/dist/OpenSim-$VERSION.pkg $GITHUB_WORKSPACE
 
     - name: Upload GUI installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: OpenSim-${{ steps.build-gui.outputs.version }}
         path: OpenSim-${{ steps.build-gui.outputs.version }}.pkg
@@ -447,10 +450,10 @@ jobs:
     steps:
 
     - name: Checkout opensim-gui
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Checkout opensim-core master
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
@@ -468,13 +471,14 @@ jobs:
         make && make -j4 install  
         
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: 1.8
 
     - name: Cache Netbeans
       id: cache-netbeans
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/netbeans-12.3
         key: netbeans-12.3
@@ -489,7 +493,7 @@ jobs:
 
     - name: Cache opensim-core-dependencies
       id: cache-dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim_dependencies_install
         # Every time a cache is created, it's stored with this key.
@@ -518,7 +522,7 @@ jobs:
 
     - name: Cache opensim-core
       id: cache-core
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/opensim-core-install
         key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
@@ -554,7 +558,7 @@ jobs:
         mv Gui/opensim/dist/OpenSim-$VERSION.tar.gz $GITHUB_WORKSPACE
 
     - name: Upload GUI installer
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: OpenSim-${{ steps.build-gui.outputs.version }}-linux
         path: OpenSim-${{ steps.build-gui.outputs.version }}.tar.gz

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -130,7 +130,7 @@ jobs:
         $VERSION = $env:match.split('=')[1]
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        echo "version=$VERSION" >> $env:$GITHUB_OUTPUT
         
     - name: Build GUI installer
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         cd opensim-core
         $opensim_core_commit=(git rev-parse HEAD)
-        echo "::set-output name=hash::$opensim_core_commit"
+        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
 
     - name: Cache opensim-core
       id: cache-core
@@ -129,7 +129,7 @@ jobs:
         $version = $env:match.split('=')[1]
         echo $version
         echo "name=VERSION::$version" >> $GITHUB_ENV
-        echo "::set-output name=version::$version"
+        echo "name=version::$version" >> $GITHUB_OUTPUT
         
     - name: Build GUI installer
       run: |
@@ -234,7 +234,7 @@ jobs:
       run: |
         cd opensim-core
         opensim_core_commit=$(git rev-parse HEAD)
-        echo "::set-output name=hash::$opensim_core_commit"
+        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
           
     - name: Cache opensim-core
       id: cache-core
@@ -280,7 +280,7 @@ jobs:
         VERSION=`cmake -L . | grep OPENSIMGUI_BUILD_VERSION | cut -d "=" -f2`
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "::set-output name=version::$VERSION"
+        echo "name=version::$VERSION" >> $GITHUB_OUTPUT
         cd $GITHUB_WORKSPACE
         ls Gui/opensim/dist
         mv Gui/opensim/dist/OpenSim-$VERSION.pkg $GITHUB_WORKSPACE
@@ -382,7 +382,7 @@ jobs:
       run: |
         cd opensim-core
         opensim_core_commit=$(git rev-parse HEAD)
-        echo "::set-output name=hash::$opensim_core_commit"
+        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
           
     - name: Cache opensim-core
       id: cache-core
@@ -428,7 +428,7 @@ jobs:
         VERSION=`cmake -L . | grep OPENSIMGUI_BUILD_VERSION | cut -d "=" -f2`
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "::set-output name=version::$VERSION"
+        echo "name=version::$VERSION" >> $GITHUB_OUTPUT
         cd $GITHUB_WORKSPACE
         ls Gui/opensim/dist
         mv Gui/opensim/dist/OpenSim-$VERSION.pkg $GITHUB_WORKSPACE
@@ -514,7 +514,7 @@ jobs:
       run: |
         cd opensim-core
         opensim_core_commit=$(git rev-parse HEAD)
-        echo "::set-output name=hash::$opensim_core_commit"
+        echo "name=hash::$opensim_core_commit" >> $GITHUB_OUTPUT
 
     - name: Cache opensim-core
       id: cache-core
@@ -548,7 +548,7 @@ jobs:
         VERSION=`cmake -L . | grep OPENSIMGUI_BUILD_VERSION | cut -d "=" -f2`
         echo $VERSION
         echo "name=VERSION::$VERSION" >> $GITHUB_ENV
-        echo "::set-output name=version::$VERSION"
+        echo "name=version::$VERSION" >> $GITHUB_OUTPUT
         cd $GITHUB_WORKSPACE
         ls Gui/opensim/dist
         mv Gui/opensim/dist/OpenSim-$VERSION.tar.gz $GITHUB_WORKSPACE


### PR DESCRIPTION
Fixes issue #1409 and #1411.

### Brief summary of changes

- Substituted set-output commands.
- Updated actions versions.
- Set java distribution to temurin (mandatory after updating setup-java action, I choose this one because is the one we use in build scripts) following  [actions/setup-java distributions](https://github.com/actions/setup-java#supported-distributions).
- Updated notation for Java version following [actions/setup-java version notation](https://github.com/actions/setup-java#supported-version-syntax).
- Added "-mac" suffix to mac artifact.

### Testing I've completed

CI exexuted and artifacts generated.

### CHANGELOG.md (choose one)

- No need to update because this is a CI issue.
