### PR TITLE
Revert fix to 1357 that caused some tools to disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ v4.4
 - Fix visualization of muscle paths in the presense of ConditionalPathPoints, multiple wrap objects or mixes of them. Fix issues [#1330][#1331].
 - Fix crash deleting external-force in ExternalLoads editing dialog [#1280]
 - Propagate frame changes to all components in the model either owned or connected by sockets to the frame, fix issue [#1340]
-- Fix issue [#1357] Toolbar displaced and non visible after resizing window
 
 
 v4.3

--- a/Gui/opensim/tracking/src/org/opensim/tracking/layer.xml
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/layer.xml
@@ -2,7 +2,7 @@
 <!DOCTYPE filesystem PUBLIC "-//NetBeans//DTD Filesystem 1.1//EN" "http://www.netbeans.org/dtds/filesystem-1_1.dtd">
 <filesystem>
     <folder name="Actions">
-        <folder name="UndoRedo">
+        <folder name="Edit">
             <file name="org-opensim-tracking-tools-AnalyzeToolAction.instance"/>
             <file name="org-opensim-tracking-tools-RRAToolAction.instance"/>
             <file name="org-opensim-tracking-tools-CMCToolAction.instance"/>
@@ -81,5 +81,12 @@
         <file name="O-R.shadow"> 
         <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-tracking-tools-ToolbarRunForwardAction.instance"/> 
         </file> 
+    </folder>
+    <folder name="Toolbars">
+        <folder name="Edit">
+            <file name="org-opensim-tracking-tools-ToolbarSimulationAction.instance">
+                <attr name="position" intvalue="300"/>
+            </file>
+        </folder>
     </folder>
 </filesystem>

--- a/Gui/opensim/view/src/org/opensim/view/layer.xml
+++ b/Gui/opensim/view/src/org/opensim/view/layer.xml
@@ -713,7 +713,7 @@
         <file name="Debug_hidden">
             <attr name="position" intvalue="500"/>
         </file>
-        <folder name="Edit_hidden">
+        <folder name="Edit">
             <attr name="position" intvalue="2200"/>
             <file name="org-openide-actions-CopyAction.instance_hidden">
                 <attr name="position" intvalue="100"/>
@@ -726,12 +726,6 @@
             </file>
             <file name="org-openide-actions-PasteAction.instance_hidden">
                 <attr name="position" intvalue="500"/>
-            </file>
-        </folder>
-        <folder name="UndoRedo">
-            <attr name="position" intvalue="300"/>
-            <file name="org-opensim-tracking-tools-ToolbarSimulationAction.instance">
-                <attr name="position" intvalue="2200"/>
             </file>
             <file name="org-opensim-view-motions-ShowMotionSliderAction.instance" url="org-opensim-view-motions-ShowMotionSliderAction.instance">
                 <attr name="position" intvalue="2400"/>


### PR DESCRIPTION
Fixes issue #1412

### Brief summary of changes
Revert changes in PR fixing 1357 that had the side effect of disappearing some tools from ci builds
### Testing I've completed
Local build has all tools as expected
### CHANGELOG.md (choose one)

- updated...
