### PR TITLE
Fixed paths to missing tools. Fix #1412.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ v4.4.1
 ======
 - Fix issue [#1378](https://github.com/opensim-org/opensim-gui/issues/1378): In Static Optimization Tool, dialog box has wrong title for "Directory" in output section.
 - Fix issue [#1395](https://github.com/opensim-org/opensim-gui/issues/1395) where visual selection and properties windows are not in sync.
-
+- Fix issue [#1412](https://github.com/opensim-org/opensim-gui/issues/1412): Missing Tools in Tools Menu.
 
 v4.4
 ====

--- a/Gui/opensim/tracking/src/org/opensim/tracking/layer.xml
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/layer.xml
@@ -43,27 +43,27 @@
                 <attr name="position" intvalue="200"/>
             </file>
             <file name="org-opensim-tracking-tools-InverseDynamicsToolAction.shadow">
-                <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-tracking-tools-InverseDynamicsToolAction.instance"/>
+                <attr name="originalFile" stringvalue="Actions/UndoRedo/org-opensim-tracking-tools-InverseDynamicsToolAction.instance"/>
                 <attr name="position" intvalue="300"/>
             </file>
             <file name="org-opensim-tracking-tools-StaticOptimizationAction.shadow">
-                <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-tracking-tools-StaticOptimizationAction.instance"/>
+                <attr name="originalFile" stringvalue="Actions/UndoRedo/org-opensim-tracking-tools-StaticOptimizationAction.instance"/>
                 <attr name="position" intvalue="400"/>
             </file>
             <file name="org-opensim-tracking-tools-ForwardToolAction.shadow">
-                <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-tracking-tools-ForwardToolAction.instance"/>
+                <attr name="originalFile" stringvalue="Actions/UndoRedo/org-opensim-tracking-tools-ForwardToolAction.instance"/>
                 <attr name="position" intvalue="700"/>
             </file>
             <file name="org-opensim-tracking-tools-RRAToolAction.shadow">
-                <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-tracking-tools-RRAToolAction.instance"/>
+                <attr name="originalFile" stringvalue="Actions/UndoRedo/org-opensim-tracking-tools-RRAToolAction.instance"/>
                 <attr name="position" intvalue="500"/>
             </file>
             <file name="org-opensim-tracking-tools-CMCToolAction.shadow">
-                <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-tracking-tools-CMCToolAction.instance"/>
+                <attr name="originalFile" stringvalue="Actions/UndoRedo/org-opensim-tracking-tools-CMCToolAction.instance"/>
                 <attr name="position" intvalue="600"/>
             </file>
             <file name="org-opensim-tracking-tools-AnalyzeToolAction.shadow">
-                <attr name="originalFile" stringvalue="Actions/Edit/org-opensim-tracking-tools-AnalyzeToolAction.instance"/>
+                <attr name="originalFile" stringvalue="Actions/UndoRedo/org-opensim-tracking-tools-AnalyzeToolAction.instance"/>
                 <attr name="position" intvalue="800"/>
             </file>
             <file name="org-opensim-tracking-tools-separatorAfter.instance">


### PR DESCRIPTION
Fixes issue #1412 

### Brief summary of changes

In 913b3a2946dc40d12a138dbb562cd6f9905b25fc, I changed the toolbar from *Edit* to *UndoRedo*, since *UndoRedo* automatically hides when the window is too small (when the toolbar was *Edit*, it was not visible/usable). However, I forgot to change the paths of the Tools. I have changed the paths here and it works now.

### Testing I've completed

Local build, checking if the tools are available.
We should make sure nothing else was broken in that commit.

### CHANGELOG.md (choose one)

- Updated.
