### PR TITLE
Build on Ubuntu 20.04

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -562,3 +562,124 @@ jobs:
       with:
         name: OpenSim-${{ steps.build-gui.outputs.version }}-linux
         path: OpenSim-${{ steps.build-gui.outputs.version }}.tar.gz
+
+ubuntu20:
+    name: Ubuntu2004
+
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Checkout opensim-gui
+      uses: actions/checkout@v3
+      
+    - name: Checkout opensim-core master
+      uses: actions/checkout@v3
+      with:
+         repository: opensim-org/opensim-core
+         path: 'opensim-core'
+         
+    - name: Install packages
+      run: sudo apt-get update && sudo apt-get install --yes liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools
+     
+    - name: Install SWIG
+      # if: steps.cache-swig.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/swig-source && cd ~/swig-source
+        wget https://github.com/swig/swig/archive/refs/tags/rel-4.0.2.tar.gz
+        tar xzf rel-4.0.2.tar.gz && cd swig-rel-4.0.2
+        sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
+        make && make -j4 install  
+        
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: 8
+
+    - name: Cache Netbeans
+      id: cache-netbeans
+      uses: actions/cache@v3
+      with:
+        path: ~/netbeans-12.3
+        key: netbeans-12.3
+
+    - name: Download and Install Netbeans
+      if: steps.cache-netbeans.outputs.cache-hit != 'true'
+      run: |
+        wget -q https://archive.apache.org/dist/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bin-linux-x64.sh
+        chmod 755 Apache-NetBeans-12.3-bin-linux-x64.sh
+        ./Apache-NetBeans-12.3-bin-linux-x64.sh --silent
+        ls $HOME/netbeans-12.3
+
+    - name: Cache opensim-core-dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        # Every time a cache is created, it's stored with this key.
+        # In subsequent runs, if the key matches the key of an existing cache,
+        # then the cache is used. We chose for this key to depend on the
+        # operating system and a hash of the hashes of all files in the
+        # dependencies directory (non-recursive).
+        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: ${{ runner.os }}-dependencies-${{ hashFiles('opensim-core/dependencies/*') }}
+
+    - name: Build opensim-core-dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      run: |
+        mkdir build_deps
+        cd build_deps
+        cmake ../opensim-core/dependencies -DSUPERBUILD_ezc3d:BOOL=on  -DOPENSIM_WITH_CASADI:BOOL=on -DOPENSIM_WITH_TROPTER:BOOL=on -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install
+        cmake . -LAH
+        cmake --build . --config Release
+        
+    - name: Obtain opensim-core commit
+      id: opensim-core-commit
+      run: |
+        cd opensim-core
+        opensim_core_commit=$(git rev-parse HEAD)
+        echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
+
+    - name: Cache opensim-core
+      id: cache-core
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim-core-install
+        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
+    
+    - name: Build opensim-core
+      if: steps.cache-core.outputs.cache-hit != 'true'
+      run: |
+        mkdir build_core
+        cd build_core
+        cmake ../opensim-core -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_INSTALL_UNIX_FHS=OFF -DSWIG_DIR=~/swig/share/swig -DSWIG_EXECUTABLE=~/swig/bin/swig
+        cmake . -LAH
+        cmake --build . --config Release 
+        cmake --install .
+
+    - name: Update submodules
+      run: git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/threejs
+
+    - name: Build GUI
+      id: build-gui
+      run: |
+        mkdir build
+        cd build
+        cmake ../ -DCMAKE_PREFIX_PATH=~/opensim-core-install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=$HOME/netbeans-12.3/netbeans;-Dnbplatform.default.harness.dir=$HOME/netbeans-12.3/netbeans/harness"
+        make CopyOpenSimCore
+        make PrepareInstaller
+        # Read the value of the cache variable storing the GUI build version.
+        VERSION=`cmake -L . | grep OPENSIMGUI_BUILD_VERSION | cut -d "=" -f2`
+        echo $VERSION
+        echo "name=VERSION::$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        cd $GITHUB_WORKSPACE
+        ls Gui/opensim/dist
+        mv Gui/opensim/dist/OpenSim-$VERSION.tar.gz $GITHUB_WORKSPACE
+
+    - name: Upload GUI installer
+      uses: actions/upload-artifact@v3
+      with:
+        name: OpenSim-${{ steps.build-gui.outputs.version }}-ub20-linux
+        path: OpenSim-${{ steps.build-gui.outputs.version }}.tar.gz

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -563,7 +563,7 @@ jobs:
         name: OpenSim-${{ steps.build-gui.outputs.version }}-linux
         path: OpenSim-${{ steps.build-gui.outputs.version }}.tar.gz
 
-ubuntu20:
+  ubuntu20:
     name: Ubuntu2004
 
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Fixes issue #1388 

### Brief summary of changes
Added build instructions for Ubuntu 20.04 in prep for deprecation of Ubuntu 18.04 from github actions

### Testing I've completed
ci
### CHANGELOG.md (choose one)

- no need to update because internal and we do not distribute linux
