### PR TITLE
 INSTALL script not installing java in Debian 

### DIFF
--- a/Gui/opensim/installer_files/Linux/INSTALL
+++ b/Gui/opensim/installer_files/Linux/INSTALL
@@ -106,6 +106,16 @@ if ( [[ $OS == *"Ubuntu"* ]] && (( $MIN_UBUNTU_VER <= $VER_MAJOR )) ) || ( [[ $O
     if [[ $OS == *"Ubuntu"* ]]; then
         [[ $v == 1 ]] && echo "Installing Java..."
         sudo apt install -qqqq -y openjdk-8-jre
+    else
+        [[ $v == 1 ]] && echo "Installing Java..."
+        sudo apt-get install -y wget apt-transport-https
+        sudo mkdir -p /etc/apt/keyrings || true
+        wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /etc/apt/keyrings/adoptium.asc
+        echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
+        sudo apt update # update if you haven't already
+        sudo apt install --yes temurin-8-jdk
+        # Export JAVA_HOME variable.
+        export JAVA_HOME=$(dirname $(dirname $(readlink -f /usr/bin/java)))
     fi
     
     [[ $v == 1 ]] && echo "Testing for system LAPACK/BLAS..."


### PR DESCRIPTION
Installing java for Debian in Linux installer.

Fixes issue #1420

### Brief summary of changes

The installer was not installing Java in Debian. Not it installs it.

### Testing I've completed

Tested locally in Debian 11.

### CHANGELOG.md (choose one)

- no need to update because this is an installer issue.
