### PR TITLE
WIP - Updated and tested (linux, windows).

### DIFF
--- a/scripts/build/opensim-gui-linux-build-script.sh
+++ b/scripts/build/opensim-gui-linux-build-script.sh
@@ -84,7 +84,7 @@ echo
 
 # Install dependencies from package manager.
 echo "LOG: INSTALLING DEPENDENCIES..."
-sudo apt-get update && sudo apt-get install --yes build-essential cmake autotools-dev autoconf pkg-config automake libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools libpcre3 libpcre3-dev byacc git gfortran libtool libssl-dev libffi-dev ninja-build patchelf || ( echo "Installation of dependencies using apt-get failed." && exit )
+sudo apt-get update && sudo apt-get install --yes build-essential cmake autotools-dev autoconf pkg-config automake libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools libpcre3 libpcre3-dev libpcre2-dev byacc git gfortran libtool libssl-dev libffi-dev ninja-build patchelf || ( echo "Installation of dependencies using apt-get failed." && exit )
 echo
 
 # Debian does not have openjdk-8-jdk available, so install from temurin repo.
@@ -153,11 +153,11 @@ else
 fi
 echo
 
-# Download and install SWIG 4.0.2.
-echo "LOG: INSTALLING SWIG 4.0.2..."
+# Download and install SWIG 4.1.1.
+echo "LOG: INSTALLING SWIG 4.1.1..."
 mkdir -p ~/opensim-workspace/swig-source || true && cd ~/opensim-workspace/swig-source
-wget -nc -q --show-progress https://github.com/swig/swig/archive/refs/tags/rel-4.0.2.tar.gz
-tar xzf rel-4.0.2.tar.gz && cd swig-rel-4.0.2
+wget -nc -q --show-progress https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+tar xzf v4.1.1.tar.gz && cd swig-4.1.1
 sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
 make && make -j$NUM_JOBS install  
 echo

--- a/scripts/build/opensim-gui-macos-build-script.sh
+++ b/scripts/build/opensim-gui-macos-build-script.sh
@@ -86,11 +86,11 @@ echo $JAVA_HOME
 # Create workspace folder.
 mkdir ~/opensim-workspace || true
 
-# Download and install SWIG 4.0.2.
-echo "LOG: INSTALLING SWIG 4.0.2..."
+# Download and install SWIG 4.1.1.
+echo "LOG: INSTALLING SWIG 4.1.1..."
 mkdir -p ~/opensim-workspace/swig-source || true && cd ~/opensim-workspace/swig-source
-wget -nc -q --show-progress https://github.com/swig/swig/archive/refs/tags/rel-4.0.2.tar.gz
-tar xzf rel-4.0.2.tar.gz && cd swig-rel-4.0.2
+wget -nc -q --show-progress https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
+tar xzf v4.1.1.tar.gz && cd swig-4.1.1
 sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
 make && make -j$NUM_JOBS install  
 echo

--- a/scripts/build/opensim-gui-windows-build-script.ps1
+++ b/scripts/build/opensim-gui-windows-build-script.ps1
@@ -80,16 +80,19 @@ choco install git.install -y
 
 # Install dependencies of opensim-core
 choco install python3  -y
-choco install temurin8 --params="/ADDLOCAL=FeatureMain,FeatureEnvironment,FeatureJavaHome" -y
+choco install jdk8  -y
 choco install swig  -y
 choco install nsis  -y
 py -m pip install numpy
 
-# Java environment variables.
-$JAVA_HOME=$Env:Programfiles + "\Temurin\bin"
-$JAVA_INCLUDE_PATH=$JAVA_HOME + "\include"
-$JAVA_INCLUDE_PATH2=$JAVA_HOME + "\include\win32"
-$JAVA_AWT_INCLUDE_PATH=$JAVA_HOME + "\include"
+# Refresh choco environment so we can use tools from terminal now.
+$env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."   
+Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
+refreshenv
+
+# Program files paths internationalized.
+$ProgramFilesPath = [Environment]::GetFolderPath("ProgramFiles")
+$ProgramFilesPathx86 = [Environment]::GetFolderPath("ProgramFilesX86")
 
 # Download Netbeans 12.8
 md C:/opensim-workspace/netbeans-12.3/
@@ -103,47 +106,47 @@ C:/opensim-workspace/netbeans-12.3/Apache-NetBeans-12.3-bin-windows-x64.exe --si
 
 # Clone opensim-core
 chdir C:/opensim-workspace/
-&"$Env:Programfiles\Git\bin\git.exe" clone https://github.com/opensim-org/opensim-core.git C:/opensim-workspace/opensim-core-source
+git clone https://github.com/opensim-org/opensim-core.git C:/opensim-workspace/opensim-core-source
 chdir C:/opensim-workspace/opensim-core-source
-&"$Env:Programfiles\Git\bin\git.exe" checkout $CORE_BRANCH
+git checkout $CORE_BRANCH
 
 # Generate dependencies project and build dependencies using superbuild
 md C:/opensim-workspace/opensim-core-dependencies-build
 chdir C:/opensim-workspace/opensim-core-dependencies-build
-&"$Env:Programfiles\CMake\bin\cmake.exe" C:/opensim-workspace/opensim-core-source/dependencies/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX="C:/opensim-workspace/opensim-core-dependencies-install" -DSUPERBUILD_ezc3d:BOOL=on -DOPENSIM_WITH_CASADI:BOOL=$MOCO -DOPENSIM_WITH_TROPTER:BOOL=$MOCO 
-&"$Env:Programfiles\CMake\bin\cmake.exe" . -LAH
-&"$Env:Programfiles\CMake\bin\cmake.exe" --build . --config $DEBUG_TYPE -- /maxcpucount:$NUM_JOBS
+cmake C:/opensim-workspace/opensim-core-source/dependencies/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX="C:/opensim-workspace/opensim-core-dependencies-install" -DSUPERBUILD_ezc3d:BOOL=on -DOPENSIM_WITH_CASADI:BOOL=$MOCO -DOPENSIM_WITH_TROPTER:BOOL=$MOCO 
+cmake . -LAH
+cmake --build . --config $DEBUG_TYPE -- /maxcpucount:$NUM_JOBS
 
 # Generate opensim-core build and build it
 md C:/opensim-workspace/opensim-core-build -Force
 chdir C:/opensim-workspace/opensim-core-build
 $env:CXXFLAGS = "/W0"
-&"$Env:Programfiles\CMake\bin\cmake.exe" C:/opensim-workspace/opensim-core-source/ -G"Visual Studio 17 2022" -A x64 -DOPENSIM_DEPENDENCIES_DIR="C:/opensim-workspace/opensim-core-dependencies-install" -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX="C:/opensim-core" -DOPENSIM_WITH_CASADI:BOOL=$MOCO -DOPENSIM_WITH_TROPTER:BOOL=$MOCO -DJAVA_HOME=$JAVA_HOME -DJAVA_INCLUDE_PATH=$JAVA_INCLUDE_PATH -DJAVA_INCLUDE_PATH2=$JAVA_INCLUDE_PATH2 -DJAVA_AWT_INCLUDE_PATH=$JAVA_AWT_INCLUDE_PATH
-&"$Env:Programfiles\CMake\bin\cmake.exe" . -LAH
-&"$Env:Programfiles\CMake\bin\cmake.exe" --build . --config $DEBUG_TYPE -- /maxcpucount:$NUM_JOBS
-&"$Env:Programfiles\CMake\bin\cmake.exe" --install .
+cmake C:/opensim-workspace/opensim-core-source/ -G"Visual Studio 17 2022" -A x64 -DOPENSIM_DEPENDENCIES_DIR="C:/opensim-workspace/opensim-core-dependencies-install" -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off -DCMAKE_INSTALL_PREFIX="C:/opensim-core" -DOPENSIM_WITH_CASADI:BOOL=$MOCO -DOPENSIM_WITH_TROPTER:BOOL=$MOCO
+cmake . -LAH
+cmake --build . --config $DEBUG_TYPE -- /maxcpucount:$NUM_JOBS
+cmake --install .
 
 # Clone opensim-gui and submodules
-&"$Env:Programfiles\Git\bin\git.exe" clone https://github.com/opensim-org/opensim-gui.git C:/opensim-workspace/opensim-gui-source
+git clone https://github.com/opensim-org/opensim-gui.git C:/opensim-workspace/opensim-gui-source
 chdir C:/opensim-workspace/opensim-gui-source
-&"$Env:Programfiles\Git\bin\git.exe" checkout $GUI_BRANCH
-&"$Env:Programfiles\Git\bin\git.exe" submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/threejs
+git checkout $GUI_BRANCH
+git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/threejs
 
 # Build opensim-gui
 md C:/opensim-workspace/opensim-gui-build
 chdir C:/opensim-workspace/opensim-gui-build
 md C:/opensim-gui
-&"$Env:Programfiles\CMake\bin\cmake.exe" C:/opensim-workspace/opensim-gui-source/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=C:/opensim-core -DAnt_EXECUTABLE="C:\Program Files\NetBeans-12.3\netbeans\extide\ant\bin\ant" -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:\Program Files\NetBeans-12.3\netbeans;-Dnbplatform.default.harness.dir=C:\Program Files\NetBeans-12.3\netbeans\harness"
-&"$Env:Programfiles\CMake\bin\cmake.exe" --build . --target CopyOpenSimCore --config $DEBUG_TYPE
-&"$Env:Programfiles\CMake\bin\cmake.exe" --build . --target CopyModels --config $DEBUG_TYPE
-&"$Env:Programfiles\CMake\bin\cmake.exe" --build . --target PrepareInstaller --config $DEBUG_TYPE
-&"$Env:Programfiles\CMake\bin\cmake.exe" --build . --target CopyJRE --config $DEBUG_TYPE
-&"$Env:Programfiles\CMake\bin\cmake.exe" --build . --target CopyVisualizer --config $DEBUG_TYPE
+cmake C:/opensim-workspace/opensim-gui-source/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=C:/opensim-core -DAnt_EXECUTABLE="C:\Program Files\NetBeans-12.3\netbeans\extide\ant\bin\ant" -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:\Program Files\NetBeans-12.3\netbeans;-Dnbplatform.default.harness.dir=C:\Program Files\NetBeans-12.3\netbeans\harness"
+cmake --build . --target CopyOpenSimCore --config $DEBUG_TYPE
+cmake --build . --target CopyModels --config $DEBUG_TYPE
+cmake --build . --target PrepareInstaller --config $DEBUG_TYPE
+cmake --build . --target CopyJRE --config $DEBUG_TYPE
+cmake --build . --target CopyVisualizer --config $DEBUG_TYPE
 # Read the value of the cache variable storing the GUI build version.
-$env:match = &"$Env:Programfiles\CMake\bin\cmake.exe" -L . | Select-String -Pattern OPENSIMGUI_BUILD_VERSION
+$env:match = &"$ProgramFilesPath\CMake\bin\cmake.exe" -L . | Select-String -Pattern OPENSIMGUI_BUILD_VERSION
 $version = $env:match.split('=')[1]
 echo $version
 
 # Create installer.
 cd C:/opensim-workspace/opensim-gui-source/Gui/opensim/dist/installer
-&"$Env:ProgramFiles (x86)\NSIS\makensis.exe" make_installer.nsi
+&"$ProgramFilesPathx86\NSIS\makensis.exe" make_installer.nsi


### PR DESCRIPTION
Fixes issue #1451

### Brief summary of changes

- Changed scripts to work with swig 4.1.1.
- Fixed issue with the `Program Files` folder name in other language windows distributions.
- Fixed `refreshenv` for choco in windows.
- Fixed issue `jni.h not found` in windows.
- Updated links to build scripts in Wiki.

### Testing I've completed

Tested in:

- [x] Ubuntu 18, 20 and 22.
- [x] Debian 10 and 11.
- [x] Windows 10 and 11.
- [x] Mac 11

### CHANGELOG.md (choose one)

- no need to update because build scripts.
