### PR TITLE
Update continuous-integration.yml

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -380,7 +380,7 @@ jobs:
         key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
     
     - name: Build opensim-core
-      if: steps.cache-core.outputs.cache-hit != 'true'
+      # if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         mkdir build_core
         cd build_core


### PR DESCRIPTION
ci build on ubuntu without caching, should not last 2 hrs and timeout

Fixes issue #<issue_number>

### Brief summary of changes

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
