### PR TITLE
Implement heartbeat on timer to keep visualizer alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ GitHub issues or pull requests that
 are related to the items below. If there is no issue or pull
 request related to the change, then we may provide the commit.
 
-v4.4.1
+v4.5
 ======
 - Fix issue [#1378](https://github.com/opensim-org/opensim-gui/issues/1378): In Static Optimization Tool, dialog box has wrong title for "Directory" in output section.
 - Fix issue [#1395](https://github.com/opensim-org/opensim-gui/issues/1395): Where visual selection and properties windows are not in sync.
 - Fix issue [#1357](https://github.com/opensim-org/opensim-gui/issues/1357): Toolbar displaced and non visible after resizing window
 - Fix issue [#1416](https://github.com/opensim-org/opensim-gui/issues/1416): Remove visual offset added to experimental data in "Preview Experimnetal Data".
 - Fix issue [#1426](https://github.com/opensim-org/opensim-gui/issues/1426): Make graphical selection of pathpoints and markers more robust among overlapping objects.
+- Fix issue [#523](https://github.com/opensim-org/opensim-gui/issues/523): Keep visualizer alive through arbitrary long idle time.
 
 v4.4
 ====

--- a/Gui/opensim/visualizationServer/src/org/eclipse/jetty/MyWebSocketHandler.java
+++ b/Gui/opensim/visualizationServer/src/org/eclipse/jetty/MyWebSocketHandler.java
@@ -29,6 +29,10 @@
 package org.eclipse.jetty;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.jetty.websocket.api.Session;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketClose;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketConnect;
@@ -43,6 +47,8 @@ import org.eclipse.jetty.websocket.api.annotations.WebSocket;
 @WebSocket
 public class MyWebSocketHandler {
 
+    private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+    
     @OnWebSocketClose
     public void onClose(int statusCode, String reason) {
         System.out.println("Close: statusCode=" + statusCode + ", reason=" + reason);
@@ -55,6 +61,16 @@ public class MyWebSocketHandler {
 
     @OnWebSocketConnect
     public void onConnect(Session session) {
+        executorService.scheduleAtFixedRate(() -> {
+                    try {
+                        String data = "Ping";
+                        ByteBuffer payload = ByteBuffer.wrap(data.getBytes());
+                        session.getRemote().sendPing(payload);
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                },
+                5, 5, TimeUnit.MINUTES);
         System.out.println("Connect: " + session.getRemoteAddress().getAddress());
         try {
             session.getRemote().sendString("Hello Webbrowser");

--- a/Gui/opensim/visualizationServer/src/org/eclipse/jetty/VisWebSocket.java
+++ b/Gui/opensim/visualizationServer/src/org/eclipse/jetty/VisWebSocket.java
@@ -76,7 +76,7 @@ public class VisWebSocket extends Observable { // Socket to handle incoming traf
                         String data = "Ping";
                         ByteBuffer payload = ByteBuffer.wrap(data.getBytes());
                         peer.getRemote().sendPing(payload);
-                        System.out.println("Sending ping to peer.");
+                        //System.out.println("Sending ping to peer.");
                     } catch (IOException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
Fixes issue #523

### Brief summary of changes
When connecting to the visualizer, start a heartbeat ping signal every minute to keep the connection alive

### Testing I've completed

### CHANGELOG.md (choose one)

- will update once verified fixed.
