### PR TITLE
Handle property name change from GeometryPath to path in visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ GitHub issues or pull requests that
 are related to the items below. If there is no issue or pull
 request related to the change, then we may provide the commit.
 
+v4.6
+======
+- Fix issue [#1494](https://github.com/opensim-org/opensim-gui/issues/1494): Changing muscle path color throws exception.
+
 v4.5
 ======
 - Fix issue [#1378](https://github.com/opensim-org/opensim-gui/issues/1378): In Static Optimization Tool, dialog box has wrong title for "Directory" in output section.

--- a/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
+++ b/Gui/opensim/view/src/org/opensim/threejs/ModelVisualizationJson.java
@@ -1407,7 +1407,7 @@ public class ModelVisualizationJson extends JSONObject {
         else {
             JSONObject pathpointCommand = (JSONObject) lastCommand.clone();
             if (force.hasVisualPath()){
-                GeometryPath gPath = GeometryPath.safeDownCast(force.getPropertyByName("GeometryPath").getValueAsObject());
+                GeometryPath gPath = GeometryPath.safeDownCast(force.getPropertyByName("path").getValueAsObject());
 
                 pathpointCommand.put("objectUuid", getFirstPathPointUUID4GeometryPath(gPath).toString());
                 commands.add(pathpointCommand);


### PR DESCRIPTION
Fixes issue #1494 

### Brief summary of changes
Missed  spot when replacing Property GeometryPath changing name to "path" in 4.5 stream.

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
