### PR TITLE
Replace Array.rfindIndex with findIndex to work around bug with Array

### DIFF
--- a/Gui/opensim/plotter/src/org/opensim/plotter/PlotCurve.java
+++ b/Gui/opensim/plotter/src/org/opensim/plotter/PlotCurve.java
@@ -110,7 +110,7 @@ public class PlotCurve {
        int startIndex=xArray.findIndex(plotCurveSettings.getXMin());
        if (startIndex ==-1) // Cut to bounds with data
            startIndex=0;
-       int endIndex=xArray.rfindIndex(plotCurveSettings.getXMax());
+       int endIndex=xArray.findIndex(plotCurveSettings.getXMax());
        if (endIndex ==-1) // Cut to bounds with data
            endIndex=xArray.getSize()-1;
        double[] yFiltered = applyFilters(plotCurveSettings.getFilters(), yArray, startIndex, endIndex);
@@ -252,7 +252,7 @@ public class PlotCurve {
       int startIndex=xArray.findIndex(plotCurveSettings.getXMin());
       if (startIndex ==-1) // Cut to bounds with data
          startIndex=0;
-      int endIndex=xArray.rfindIndex(plotCurveSettings.getXMax());
+      int endIndex=xArray.findIndex(plotCurveSettings.getXMax());
       if (endIndex ==-1) // Cut to bounds with data
          endIndex=yArray.getSize()-1;
       


### PR DESCRIPTION
Fixes issue #1496 
### Brief summary of changes

The new Array implementation returns incorrect/different index for rfindIndex than the legacy code. While the call site has been updated the funtion rfindIndex should be fixed for backward compatibility for possible use in client code elsewhere.

### Testing I've completed
Plots in the GUI

### CHANGELOG.md (choose one)

- Will update after core issue is resolved
