### PR TITLE
Add title to file browser cascade dialog in Id output directory selec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ v4.6
 ======
 - Fix issue [#1494](https://github.com/opensim-org/opensim-gui/issues/1494): Changing muscle path color throws exception.
 - Fix issue [#1493](https://github.com/opensim-org/opensim-gui/issues/1493): Rotating experimental data fails or results an unusable file.
-- Fix issue [#1516](https://github.com/opensim-org/opensim-gui/issues/1516): Chains of Physical offset frames ignored when displaying GeometryPath 
+- Fix issue [#1516](https://github.com/opensim-org/opensim-gui/issues/1516): Chains of Physical offset frames ignored when displaying GeometryPath
+- Fix issue [#1519](https://github.com/opensim-org/opensim-gui/issues/1519): Exception thrown when browsing for output folder in Inverse Dynamics Tool dialog
 
 v4.5
 ======

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.form
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.form
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8" ?>
+<?xml version="1.0" encoding="UTF-8" ?>
 
 <Form version="1.3" maxVersion="1.3" type="org.netbeans.modules.form.forminfo.JPanelFormInfo">
   <NonVisualComponents>

--- a/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
+++ b/Gui/opensim/tracking/src/org/opensim/tracking/InverseDynamicsToolPanel.java
@@ -96,6 +96,7 @@ public class InverseDynamicsToolPanel extends BaseToolPanel implements Observer 
       outputDirectory.setIncludeOpenButton(true);
       outputDirectory.setDirectoriesOnly(true);
       outputDirectory.setCheckIfFileExists(false);
+      outputDirectory.setDialogTitle("Output Directory");
 
       setSettingsFileDescription("Settings file for "+modeName);
 

--- a/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
+++ b/Gui/opensim/utils/src/org/opensim/utils/FileUtils.java
@@ -264,7 +264,7 @@ public final class FileUtils {
         
 	dlog.resetChoosableFileFilters();
 		
-        if(!description.equals("")) {
+        if(description != null && !description.equals("")) {
             dlog.setDialogTitle(description);
         }
         


### PR DESCRIPTION
…tion, and safeguard against null description elsewhere

Fixes issue #1519
### Brief summary of changes
Filebrowser was throwing because description was passed to it as null due to upstream changes. Guarded against null description and provided an actual description for ID tool output folder browser.

### Testing I've completed

### CHANGELOG.md (choose one)
- updated...
