### PR TITLE
Add locale requirements to linux build script

### DIFF
--- a/scripts/build/opensim-gui-linux-build-script.sh
+++ b/scripts/build/opensim-gui-linux-build-script.sh
@@ -82,6 +82,15 @@ else
 fi
 echo
 
+# Set UTF-8 locale and en_US locale for numeric formatting.
+echo "LOG: CHECKING AND SETTING LOCALE..."
+sudo apt update && sudo apt install --yes locales
+sudo locale-gen en_US.UTF-8
+sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+export LANG=en_US.UTF-8
+locale
+echo
+
 # Install dependencies from package manager.
 echo "LOG: INSTALLING DEPENDENCIES..."
 sudo apt-get update && sudo apt-get install --yes build-essential cmake autotools-dev autoconf pkg-config automake libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools libpcre3 libpcre3-dev libpcre2-dev byacc git gfortran libtool libssl-dev libffi-dev ninja-build patchelf || ( echo "Installation of dependencies using apt-get failed." && exit )


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-core/issues/3924

### Brief summary of changes

Added locale changes into the build script so numeric formatting is correct when using TimeSeriesTable.h

### Testing I've completed

Tested locally with a separate shell script. A restart after locale changes is recommended if locale changes have been applied due to different settings instead of directly using OpenSim after installation.

### Looking for feedback on...

/

### CHANGELOG.md (choose one)

- no need to update because the change only affects the build script