### PR TITLE
build tag 4.5.2 GUI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -56,6 +56,7 @@ jobs:
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
+         ref: '4.5.2'
     
     - name: Cache opensim-core-dependencies
       id: cache-dependencies
@@ -158,7 +159,8 @@ jobs:
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
-         
+         ref: '4.5.2'
+
     - uses: actions/setup-python@v4
       with:
         python-version: '3.10' 
@@ -309,6 +311,7 @@ jobs:
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
+         ref: '4.5.2'
          
     - name: Install Python packages
       uses: actions/setup-python@v4


### PR DESCRIPTION
Fixes issue #0

### Brief summary of changes
This has no code change, only checks out and builds core for tag 4.5.2 and build the stack cross platform in ci

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because...
- updated...
