### PR TITLE
Add caching for Netbeans installer in CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,9 +42,16 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: 8
-
+        
+    - name: Cache Netbeans
+      id: cache-netbeans
+      uses: actions/cache@v3
+      with:
+        path: .\Apache-NetBeans-12.3-bin-windows-x64.exe
+        key: netbeans-12.3
+        
     - name: Install Netbeans 12.3
-      # Make sure the NetBeans installer is not corrupted.
+      if: steps.cache-netbeans.outputs.cache-hit != 'true'
       run: |
         (New-Object System.Net.WebClient).DownloadFile("https://archive.apache.org/dist/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bin-windows-x64.exe", "Apache-NetBeans-12.3-bin-windows-x64.exe")
         $expectedHash = "0695d87d9c72dcf3738672ba83eb273dda02066fa5eee80896cb6ccf79175840367a13d22ab3cb9838dffaa9a219dd1f73aee0e27c085e5310da2e3bbbc92b2c"


### PR DESCRIPTION
Added caching for Netbeans installer to speed up CI process.

Fixes issue #<issue_number>

### Brief summary of changes

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because internal
