### PR TITLE
Fix typos `contraint`

### DIFF
--- a/Gui/opensim/modeling/src/org/opensim/modeling/Coordinate.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/Coordinate.java
@@ -415,8 +415,8 @@ public class Coordinate extends ModelComponent {
    *         The provided value will be clamped to the coordinate's range if<br>
    *         the coordinate is clamped and enforceConstraints is true.
    */
-  public void setValue(State s, double aValue, boolean enforceContraints) {
-    opensimSimulationJNI.Coordinate_setValue__SWIG_0(swigCPtr, this, State.getCPtr(s), s, aValue, enforceContraints);
+  public void setValue(State s, double aValue, boolean enforceConstraints) {
+    opensimSimulationJNI.Coordinate_setValue__SWIG_0(swigCPtr, this, State.getCPtr(s), s, aValue, enforceConstraints);
   }
 
   /**

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MocoPeriodicityGoal.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MocoPeriodicityGoal.java
@@ -38,18 +38,18 @@ package org.opensim.modeling;
  * {@code 
 periodicGoal = problem.addGoal<MocoPeriodicityGoal>("periodicGoal");
 }<br>
- * Periodic contraint for the pelvis tilt values:<br>
+ * Periodic constraint for the pelvis tilt values:<br>
  * {@code 
 periodicGoal->addStatePair({ "/jointset/ground_pelvis/pelvis_tilt/value"});
 }<br>
- * Periodic contraints for the hip flexion speeds:<br>
+ * Periodic constraints for the hip flexion speeds:<br>
  * {@code 
 periodicGoal->addStatePair({"/jointset/hip_l/hip_flexion_l/speed",
         "/jointset/hip_r/hip_flexion_r/speed"});
 periodicGoal->addStatePair({"/jointset/hip_r/hip_flexion_r/speed",
         "/jointset/hip_l/hip_flexion_l/speed"});
 }<br>
- * Periodic contraints for the hamstrings controls:<br>
+ * Periodic constraints for the hamstrings controls:<br>
  * {@code 
 MocoPeriodicityGoalPair pair_hamstrings1;
 pair_hamstrings1.set_initial_variable("/hamstrings_r");

--- a/Gui/opensim/modeling/src/org/opensim/modeling/MocoStateBoundConstraint.java
+++ b/Gui/opensim/modeling/src/org/opensim/modeling/MocoStateBoundConstraint.java
@@ -9,7 +9,7 @@
 package org.opensim.modeling;
 
 /**
- *  This path contraint allows you to bound any number of state variables<br>
+ *  This path constraint allows you to bound any number of state variables<br>
  * between two time-based functions. It is possible to constrain the state variable<br>
  * to match the value from a provided function; see the equality_with_lower<br>
  * property.<br>


### PR DESCRIPTION
Fixes issue https://github.com/opensim-org/opensim-core/issues/4212

### Brief summary of changes
Fix the `contraint` typos

### Testing I've completed
None, will see the CI. It might fail due to cache.

### CHANGELOG.md (choose one)
- no need to update because it's trivial