### PR TITLE
WIP - Update build scripts to latest version of libraries. Integrate prebuilt jxbrowser.

### DIFF
--- a/scripts/build/opensim-gui-linux-build-script.sh
+++ b/scripts/build/opensim-gui-linux-build-script.sh
@@ -9,6 +9,7 @@ NUM_JOBS=4
 MOCO="on"
 CORE_BRANCH="main"
 GUI_BRANCH="main"
+VIEWER_BRANCH="dev"
 GENERATOR="Unix Makefiles"
 
 Help() {
@@ -25,13 +26,14 @@ Help() {
     echo "    -s         Simple build without moco (Tropter and Casadi disabled)."
     echo "    -c         Branch for opensim-core repository."
     echo "    -g         Branch for opensim-gui repository."
+    echo "    -v         Branch for opensim-viewer repository."
     echo "    -n         Use the Ninja generator to build opensim-core. If not set, Unix Makefiles is used."
     echo
     exit
 }
 
 # Get flag values if exist.
-while getopts 'j:d:sc:g:n' flag
+while getopts 'j:d:sc:g:v:n' flag
 do
     case "${flag}" in
         j) NUM_JOBS=${OPTARG};;
@@ -39,6 +41,7 @@ do
         s) MOCO="off";;
         c) CORE_BRANCH=${OPTARG};;
         g) GUI_BRANCH=${OPTARG};;
+        v) VIEWER_BRANCH=${OPTARG};;
         n) GENERATOR="Ninja";;
         *) Help;
     esac
@@ -84,22 +87,22 @@ echo
 
 # Install dependencies from package manager.
 echo "LOG: INSTALLING DEPENDENCIES..."
-sudo apt-get update && sudo apt-get install --yes build-essential cmake autotools-dev autoconf pkg-config automake libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-numpy python3-setuptools libpcre3 libpcre3-dev libpcre2-dev byacc git gfortran libtool libssl-dev libffi-dev ninja-build patchelf || ( echo "Installation of dependencies using apt-get failed." && exit )
+sudo apt-get update && sudo apt-get install --yes build-essential cmake autotools-dev autoconf pkg-config automake libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-setuptools libpcre3 libpcre3-dev libpcre2-dev byacc git gfortran libtool libssl-dev libffi-dev ninja-build patchelf libgl1-mesa-dev unzip wget npm || ( echo "Installation of dependencies using apt-get failed." && exit )
 echo
 
-# Debian does not have openjdk-8-jdk available, so install from temurin repo.
-echo "LOG: INSTALLING JDK 8..."
+# Install JDK 17
+echo "LOG: INSTALLING JDK 17..."
 if [[ $OS_NAME == *"Debian"* ]]; then
    sudo apt-get install -y wget apt-transport-https
    sudo mkdir -p /etc/apt/keyrings || true
    wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo tee /etc/apt/keyrings/adoptium.asc
    echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | sudo tee /etc/apt/sources.list.d/adoptium.list
-   sudo apt update # update if you haven't already
-   sudo apt install --yes temurin-8-jdk
+   sudo apt update
+   sudo apt install --yes temurin-17-jdk
    # Export JAVA_HOME variable.
    export JAVA_HOME=$(dirname $(dirname $(readlink -f /usr/bin/java)))
 elif [[ $OS_NAME == *"Ubuntu"* ]]; then
-   sudo apt install --yes openjdk-8-jdk
+   sudo apt install --yes openjdk-17-jdk
 fi
 echo
 
@@ -118,7 +121,7 @@ cmake_minor_less=$(( ${cmake_version_split[1]} < ${min_cmake_version_split[1]} )
 if [[ $cmake_major_less == 1 ]] || $( [[ $cmake_major_equal == 1 ]] && [[ $cmake_minor_less == 1 ]] ); then
     mkdir ~/opensim-workspace/cmake-3.23.3-source || true
     cd ~/opensim-workspace/cmake-3.23.3-source
-    wget -nc -q --show-progress https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3.tar.gz 
+    wget -nc -q --show-progress https://github.com/Kitware/CMake/releases/download/v3.23.3/cmake-3.23.3.tar.gz
     tar -zxvf cmake-3.23.3.tar.gz
     cd ~/opensim-workspace/cmake-3.23.3-source/cmake-3.23.3
     ./bootstrap
@@ -159,20 +162,20 @@ mkdir -p ~/opensim-workspace/swig-source || true && cd ~/opensim-workspace/swig-
 wget -nc -q --show-progress https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
 tar xzf v4.1.1.tar.gz && cd swig-4.1.1
 sh autogen.sh && ./configure --prefix=$HOME/swig --disable-ccache
-make && make -j$NUM_JOBS install  
+make && make -j$NUM_JOBS install
 echo
 
-# Download and install NetBeans 12.3.
-echo "LOG: INSTALLING NETBEANS 12.3..."
-mkdir -p ~/opensim-workspace/Netbeans12.3 || true && cd ~/opensim-workspace/Netbeans12.3
-wget -nc -q --show-progress https://archive.apache.org/dist/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bin-linux-x64.sh
-chmod 755 Apache-NetBeans-12.3-bin-linux-x64.sh
-./Apache-NetBeans-12.3-bin-linux-x64.sh --silent
+# Download and install NetBeans 17 (using zip like CI, not installer)
+echo "LOG: INSTALLING NETBEANS 17..."
+cd ~
+wget -q https://archive.apache.org/dist/netbeans/netbeans/17/netbeans-17-bin.zip
+unzip -q -o netbeans-17-bin.zip -d $HOME
+rm netbeans-17-bin.zip
 echo
 
 # Get opensim-core.
 echo "LOG: CLONING OPENSIM-CORE..."
-git -C ~/opensim-workspace/opensim-core-source pull || git clone https://github.com/opensim-org/opensim-core.git ~/opensim-workspace/opensim-core-source
+git -C ~/opensim-workspace/opensim-core-source pull || git clone https://github.com/opensim-org/opensim-core.git ~/opensim-workspace/opensim-core-source || true
 cd ~/opensim-workspace/opensim-core-source
 git checkout $CORE_BRANCH
 echo
@@ -198,19 +201,48 @@ echo
 
 # Get opensim-gui.
 echo "LOG: CLONING OPENSIM-GUI..."
-git -C ~/opensim-workspace/opensim-gui-source pull || git clone https://github.com/opensim-org/opensim-gui.git ~/opensim-workspace/opensim-gui-source
+git -C ~/opensim-workspace/opensim-gui-source pull || git clone https://github.com/opensim-org/opensim-gui.git ~/opensim-workspace/opensim-gui-source || true
 cd ~/opensim-workspace/opensim-gui-source
 git checkout $GUI_BRANCH
-git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/threejs
+git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/opensim-viewer
+cd Gui/opensim/opensim-viewer
+git checkout $VIEWER_BRANCH
+cd -
 echo
 
-# Build opensim-gui.
+# Build opensim-gui
 echo "LOG: BUILDING OPENSIM-GUI..."
 mkdir -p ~/opensim-workspace/opensim-gui-build || true
 cd ~/opensim-workspace/opensim-gui-build
-cmake ~/opensim-workspace/opensim-gui-source -DCMAKE_PREFIX_PATH=~/opensim-core -DAnt_EXECUTABLE=~/netbeans-12.3/netbeans/extide/ant/bin/ant -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=$HOME/netbeans-12.3/netbeans;-Dnbplatform.default.harness.dir=$HOME/netbeans-12.3/netbeans/harness"
+cmake ~/opensim-workspace/opensim-gui-source -DCMAKE_PREFIX_PATH=~/opensim-core -DAnt_EXECUTABLE=~/netbeans/extide/ant/bin/ant -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=$HOME/netbeans;-Dnbplatform.default.harness.dir=$HOME/netbeans/harness"
 make CopyOpenSimCore -j$NUM_JOBS
 make PrepareInstaller -j$NUM_JOBS
+echo
+
+# Add jxbrowser files to installer content
+echo "LOG: ADDING JXBROWSER FILES TO INSTALLER CONTENT..."
+ROOT="$HOME/opensim-workspace"
+NBM_DIR="$ROOT/prebuilt_jxb"
+EXTRACT_DIR="$NBM_DIR/extracted"
+INSTALLER_CONTENT="$ROOT/opensim-gui-source/Gui/opensim/dist/installer/opensim/opensim"
+mkdir -p "$NBM_DIR" # Create prebuilt directory
+# Download the NBM file pinned to version v4.6.0
+wget -O "$NBM_DIR/org-opensim-javabrowser.nbm" \
+     "https://github.com/opensim-org/opensim-visualizer/releases/download/v4.6.0/org-opensim-javabrowser.nbm"
+mkdir -p "$EXTRACT_DIR" # Extract the NBM (nbm is a zip)
+unzip -o "$NBM_DIR/org-opensim-javabrowser.nbm" -d "$EXTRACT_DIR"
+# Create installer modules directories
+mkdir -p "$INSTALLER_CONTENT/modules/"
+mkdir -p "$INSTALLER_CONTENT/modules/ext/"
+# Copy the main JAR
+cp "$EXTRACT_DIR/netbeans/modules/org-opensim-javabrowser.jar" "$INSTALLER_CONTENT/modules/"
+# For Linux, copy all JARs with exact names
+cp "$EXTRACT_DIR/netbeans/modules/ext/jxbrowser-7.44.1.jar" "$INSTALLER_CONTENT/modules/ext/"
+cp "$EXTRACT_DIR/netbeans/modules/ext/jxbrowser-swing-7.44.1.jar" "$INSTALLER_CONTENT/modules/ext/"
+cp "$EXTRACT_DIR/netbeans/modules/ext/jxbrowser-linux64-7.44.1.jar" "$INSTALLER_CONTENT/modules/ext/"
+# Verify files copied
+echo "JAR files now in installer content:"
+find "$INSTALLER_CONTENT" -name "*.jar"
 echo
 
 # Install opensim-gui.

--- a/scripts/build/opensim-gui-linux-build-script.sh
+++ b/scripts/build/opensim-gui-linux-build-script.sh
@@ -7,8 +7,8 @@ set -e
 DEBUG_TYPE="Release"
 NUM_JOBS=4
 MOCO="on"
-CORE_BRANCH="main"
-GUI_BRANCH="main"
+CORE_BRANCH="opensim_46"
+GUI_BRANCH="opensim_46"
 VIEWER_BRANCH="dev"
 GENERATOR="Unix Makefiles"
 
@@ -87,8 +87,14 @@ echo
 
 # Install dependencies from package manager.
 echo "LOG: INSTALLING DEPENDENCIES..."
-sudo apt-get update && sudo apt-get install --yes build-essential cmake autotools-dev autoconf pkg-config automake libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-setuptools libpcre3 libpcre3-dev libpcre2-dev byacc git gfortran libtool libssl-dev libffi-dev ninja-build patchelf libgl1-mesa-dev unzip wget npm || ( echo "Installation of dependencies using apt-get failed." && exit )
+sudo apt-get update && sudo apt-get install --yes build-essential cmake autotools-dev autoconf pkg-config automake libopenblas-dev liblapack-dev freeglut3-dev libxi-dev libxmu-dev doxygen python3 python3-dev python3-setuptools python3-numpy python3-pip libpcre3 libpcre3-dev libpcre2-dev byacc git gfortran libtool libssl-dev libffi-dev ninja-build patchelf libgl1-mesa-dev unzip wget npm || ( echo "Installation of dependencies using apt-get failed." && exit )
 echo
+
+# Install libconf 2.4
+wget http://kr.archive.ubuntu.com/ubuntu/pool/universe/g/gconf/gconf2-common_3.2.6-6ubuntu1_all.deb
+wget http://kr.archive.ubuntu.com/ubuntu/pool/universe/g/gconf/libgconf-2-4_3.2.6-6ubuntu1_amd64.deb
+sudo dpkg -i gconf2-common_3.2.6-6ubuntu1_all.deb
+sudo dpkg -i libgconf-2-4_3.2.6-6ubuntu1_amd64.deb
 
 # Install JDK 17
 echo "LOG: INSTALLING JDK 17..."
@@ -210,15 +216,6 @@ git checkout $VIEWER_BRANCH
 cd -
 echo
 
-# Build opensim-gui
-echo "LOG: BUILDING OPENSIM-GUI..."
-mkdir -p ~/opensim-workspace/opensim-gui-build || true
-cd ~/opensim-workspace/opensim-gui-build
-cmake ~/opensim-workspace/opensim-gui-source -DCMAKE_PREFIX_PATH=~/opensim-core -DAnt_EXECUTABLE=~/netbeans/extide/ant/bin/ant -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=$HOME/netbeans;-Dnbplatform.default.harness.dir=$HOME/netbeans/harness"
-make CopyOpenSimCore -j$NUM_JOBS
-make PrepareInstaller -j$NUM_JOBS
-echo
-
 # Add jxbrowser files to installer content
 echo "LOG: ADDING JXBROWSER FILES TO INSTALLER CONTENT..."
 ROOT="$HOME/opensim-workspace"
@@ -243,6 +240,15 @@ cp "$EXTRACT_DIR/netbeans/modules/ext/jxbrowser-linux64-7.44.1.jar" "$INSTALLER_
 # Verify files copied
 echo "JAR files now in installer content:"
 find "$INSTALLER_CONTENT" -name "*.jar"
+echo
+
+# Build opensim-gui
+echo "LOG: BUILDING OPENSIM-GUI..."
+mkdir -p ~/opensim-workspace/opensim-gui-build || true
+cd ~/opensim-workspace/opensim-gui-build
+cmake ~/opensim-workspace/opensim-gui-source -DCMAKE_PREFIX_PATH=~/opensim-core -DAnt_EXECUTABLE=~/netbeans/extide/ant/bin/ant -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=$HOME/netbeans;-Dnbplatform.default.harness.dir=$HOME/netbeans/harness"
+make CopyOpenSimCore -j$NUM_JOBS
+make PrepareInstaller -j$NUM_JOBS
 echo
 
 # Install opensim-gui.

--- a/scripts/build/opensim-gui-windows-build-script.ps1
+++ b/scripts/build/opensim-gui-windows-build-script.ps1
@@ -79,14 +79,14 @@ choco install cmake.install --version 3.23.3 --installargs '"ADD_CMAKE_TO_PATH=S
 choco install git.install -y
 
 # Install dependencies of opensim-core
-choco install python3  -y
-choco install jdk8  -y
-choco install swig  -y
-choco install nsis  -y
-py -m pip install numpy
+choco install python3 -y
+choco install openjdk11 -y
+choco install swig --version 4.1.1 -y
+choco install nsis -y
+py -m pip install numpy==2.4
 
 # Refresh choco environment so we can use tools from terminal now.
-$env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."   
+$env:ChocolateyInstall = Convert-Path "$((Get-Command choco).Path)\..\.."
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 refreshenv
 
@@ -94,15 +94,15 @@ refreshenv
 $ProgramFilesPath = [Environment]::GetFolderPath("ProgramFiles")
 $ProgramFilesPathx86 = [Environment]::GetFolderPath("ProgramFilesX86")
 
-# Download Netbeans 12.8
-md C:/opensim-workspace/netbeans-12.3/
-chdir C:/opensim-workspace/netbeans-12.3/
+# Download Netbeans 17
+md C:/opensim-workspace/netbeans-17/
+chdir C:/opensim-workspace/netbeans-17/
 $WebClient = New-Object System.Net.WebClient
-$WebClient.DownloadFile("https://archive.apache.org/dist/netbeans/netbeans/12.3/Apache-NetBeans-12.3-bin-windows-x64.exe","C:/opensim-workspace/netbeans-12.3/Apache-NetBeans-12.3-bin-windows-x64.exe")
-$expectedHash = "0695d87d9c72dcf3738672ba83eb273dda02066fa5eee80896cb6ccf79175840367a13d22ab3cb9838dffaa9a219dd1f73aee0e27c085e5310da2e3bbbc92b2c"
-$hashFromFile = Get-FileHash -Algorithm SHA512 -Path C:/opensim-workspace/netbeans-12.3/Apache-NetBeans-12.3-bin-windows-x64.exe
+$WebClient.DownloadFile("https://archive.apache.org/dist/netbeans/netbeans-installers/17/Apache-NetBeans-17-bin-windows-x64.exe","C:/opensim-workspace/netbeans-17/Apache-NetBeans-17-bin-windows-x64.exe")
+$expectedHash = "c3d7a34184c4021486751fbc3878eb2376677674ff8d6d4bf87017fd2434122c8438072aa891e535fa0fa9aeafcb49ad833a61903180772369d99571b073baac"
+$hashFromFile = Get-FileHash -Algorithm SHA512 -Path C:/opensim-workspace/netbeans-17/Apache-NetBeans-17-bin-windows-x64.exe
 if (($hashFromFile.Hash) -ne ($expectedHash)) { Write-Error "Hash doesn't match." }
-C:/opensim-workspace/netbeans-12.3/Apache-NetBeans-12.3-bin-windows-x64.exe --silent | Out-Null # This installer is gregarious.
+C:/opensim-workspace/netbeans-17/Apache-NetBeans-17-bin-windows-x64.exe --silent | Out-Null # This installer is gregarious.
 
 # Clone opensim-core
 chdir C:/opensim-workspace/
@@ -113,7 +113,7 @@ git checkout $CORE_BRANCH
 # Generate dependencies project and build dependencies using superbuild
 md C:/opensim-workspace/opensim-core-dependencies-build
 chdir C:/opensim-workspace/opensim-core-dependencies-build
-cmake C:/opensim-workspace/opensim-core-source/dependencies/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX="C:/opensim-workspace/opensim-core-dependencies-install" -DSUPERBUILD_ezc3d:BOOL=on -DOPENSIM_WITH_CASADI:BOOL=$MOCO -DOPENSIM_WITH_TROPTER:BOOL=$MOCO 
+cmake C:/opensim-workspace/opensim-core-source/dependencies/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_INSTALL_PREFIX="C:/opensim-workspace/opensim-core-dependencies-install" -DSUPERBUILD_ezc3d:BOOL=on -DOPENSIM_WITH_CASADI:BOOL=$MOCO -DOPENSIM_WITH_TROPTER:BOOL=$MOCO
 cmake . -LAH
 cmake --build . --config $DEBUG_TYPE -- /maxcpucount:$NUM_JOBS
 
@@ -130,18 +130,53 @@ cmake --install .
 git clone https://github.com/opensim-org/opensim-gui.git C:/opensim-workspace/opensim-gui-source
 chdir C:/opensim-workspace/opensim-gui-source
 git checkout $GUI_BRANCH
-git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/threejs
+git submodule update --init --recursive -- opensim-models opensim-visualizer
 
 # Build opensim-gui
 md C:/opensim-workspace/opensim-gui-build
 chdir C:/opensim-workspace/opensim-gui-build
 md C:/opensim-gui
-cmake C:/opensim-workspace/opensim-gui-source/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=C:/opensim-core -DAnt_EXECUTABLE="C:\Program Files\NetBeans-12.3\netbeans\extide\ant\bin\ant" -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:\Program Files\NetBeans-12.3\netbeans;-Dnbplatform.default.harness.dir=C:\Program Files\NetBeans-12.3\netbeans\harness"
+cmake C:/opensim-workspace/opensim-gui-source/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=C:/opensim-core -DAnt_EXECUTABLE="C:\Program Files\NetBeans-17\netbeans\extide\ant\bin\ant" -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:\Program Files\NetBeans-17\netbeans;-Dnbplatform.default.harness.dir=C:\Program Files\NetBeans-17\netbeans\harness"
 cmake --build . --target CopyOpenSimCore --config $DEBUG_TYPE
 cmake --build . --target CopyModels --config $DEBUG_TYPE
 cmake --build . --target PrepareInstaller --config $DEBUG_TYPE
 cmake --build . --target CopyJRE --config $DEBUG_TYPE
 cmake --build . --target CopyVisualizer --config $DEBUG_TYPE
+
+# Add jxbrowser files to installer content
+$root = "C:/opensim-workspace"
+$nbmDir = "$root\prebuilt_jxb"
+$extractDir = "$nbmDir\extracted"
+$installerContentPath = "$root\opensim-gui-source\Gui\opensim\dist\installer\opensim\opensim"
+# Create prebuilt directory
+New-Item -ItemType Directory -Force -Path $nbmDir
+# Download the NBM file
+Invoke-WebRequest -Uri "https://github.com/opensim-org/opensim-visualizer/releases/download/v4.6.0/org-opensim-javabrowser.nbm" `
+                  -OutFile "$nbmDir\org-opensim-javabrowser.nbm"
+# Rename to zip to avoid powershell complaining it is not a zip.
+Rename-Item -Path "$nbmDir\org-opensim-javabrowser.nbm" -NewName "org-opensim-javabrowser.zip" -Force
+# Extract the NBM
+Expand-Archive -Path "$nbmDir\org-opensim-javabrowser.zip" -DestinationPath $extractDir -Force
+# Create installer modules directory
+New-Item -ItemType Directory -Force -Path "$installerContentPath/modules/"
+New-Item -ItemType Directory -Force -Path "$installerContentPath/modules/ext/"
+# Copy the main JAR
+Write-Host "Copying org-opensim-javabrowser.jar to installer content..."
+Copy-Item -Path "$extractDir\netbeans\modules\org-opensim-javabrowser.jar" `
+          -Destination "$installerContentPath/modules/" -Force
+# Copy Windows-specific JARs with exact names
+Write-Host "Copying Windows JARs to installer content..."
+Copy-Item -Path "$extractDir\netbeans\modules\ext\jxbrowser-7.44.1.jar" `
+          -Destination "$installerContentPath/modules/ext/" -Force
+Copy-Item -Path "$extractDir\netbeans\modules\ext\jxbrowser-swing-7.44.1.jar" `
+          -Destination "$installerContentPath/modules/ext/" -Force
+Copy-Item -Path "$extractDir\netbeans\modules\ext\jxbrowser-win64-7.44.1.jar" `
+          -Destination "$installerContentPath/modules/ext/" -Force
+
+# Verify files copied
+Write-Host "JAR files now in installer content:"
+Get-ChildItem -Path "$installerContentPath" -Recurse -Filter "*.jar" | Select-Object FullName
+
 # Read the value of the cache variable storing the GUI build version.
 $env:match = &"$ProgramFilesPath\CMake\bin\cmake.exe" -L . | Select-String -Pattern OPENSIMGUI_BUILD_VERSION
 $version = $env:match.split('=')[1]

--- a/scripts/build/opensim-gui-windows-build-script.ps1
+++ b/scripts/build/opensim-gui-windows-build-script.ps1
@@ -3,8 +3,9 @@ param (
   [switch]$s=$false,
   [switch]$h=$false,
   [string]$d="Release",
-  [string]$c="main",
-  [string]$g="main",
+  [string]$c="opensim_46",
+  [string]$g="opensim_46",
+  [string]$v="dev",
   [int]$j=[int]4
 )
 
@@ -12,8 +13,8 @@ param (
 $DEBUG_TYPE="Release"
 $NUM_JOBS=4
 $MOCO="on"
-$CORE_BRANCH="main"
-$GUI_BRANCH="main"
+$CORE_BRANCH="opensim_46"
+$GUI_BRANCH="opensim_46"
 $VIEWER_BRANCH="dev"
 
 function Help {
@@ -29,7 +30,7 @@ function Help {
     Write-Output "    -s        Simple build without moco (Tropter and Casadi disabled)."
     Write-Output "    -c        Branch for opensim-core repository."
     Write-Output "    -g        Branch for opensim-gui repository."
-    Write-Output "    -v         Branch for opensim-viewer repository."
+    Write-Output "    -v        Branch for opensim-viewer repository."
 
     Write-Output ""
     exit
@@ -71,6 +72,9 @@ Write-Output "CORE_BRANCH $CORE_BRANCH"
 Write-Output "GUI_BRANCH $GUI_BRANCH"
 Write-Output "VIEWER_BRANCH $VIEWER_BRANCH"
 
+# Enable long path support
+New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+
 # Install chocolatey
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
@@ -87,7 +91,7 @@ choco install git.install -y
 
 # Install dependencies of opensim-core
 choco install python3 -y
-choco install openjdk11 -y
+choco install openjdk13 -y
 choco install swig --version 4.1.1 -y
 choco install nsis -y
 py -m pip install numpy==2.4
@@ -137,7 +141,7 @@ cmake --install .
 git clone https://github.com/opensim-org/opensim-gui.git C:/opensim-workspace/opensim-gui-source
 chdir C:/opensim-workspace/opensim-gui-source
 git checkout $GUI_BRANCH
-git submodule update --init --recursive -- opensim-models opensim-visualizer
+git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/opensim-viewer
 chdir C:/opensim-workspace/opensim-gui-source/Gui/opensim/opensim-viewer
 git checkout $VIEWER_BRANCH
 chdir C:/opensim-workspace/opensim-gui-source
@@ -147,11 +151,11 @@ md C:/opensim-workspace/opensim-gui-build
 chdir C:/opensim-workspace/opensim-gui-build
 md C:/opensim-gui
 cmake C:/opensim-workspace/opensim-gui-source/ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=C:/opensim-core -DAnt_EXECUTABLE="C:\Program Files\NetBeans-17\netbeans\extide\ant\bin\ant" -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:\Program Files\NetBeans-17\netbeans;-Dnbplatform.default.harness.dir=C:\Program Files\NetBeans-17\netbeans\harness"
-cmake --build . --target CopyOpenSimCore --config $DEBUG_TYPE
-cmake --build . --target CopyModels --config $DEBUG_TYPE
-cmake --build . --target PrepareInstaller --config $DEBUG_TYPE
-cmake --build . --target CopyJRE --config $DEBUG_TYPE
-cmake --build . --target CopyVisualizer --config $DEBUG_TYPE
+cmake --build . --target CopyOpenSimCore --config $DEBUG_TYPE --verbose
+cmake --build . --target CopyModels --config $DEBUG_TYPE --verbose
+cmake --build . --target PrepareInstaller --config $DEBUG_TYPE --verbose
+cmake --build . --target CopyJRE --config $DEBUG_TYPE --verbose
+cmake --build . --target CopyVisualizer --config $DEBUG_TYPE --verbose
 
 # Add jxbrowser files to installer content
 $root = "C:/opensim-workspace"

--- a/scripts/build/opensim-gui-windows-build-script.ps1
+++ b/scripts/build/opensim-gui-windows-build-script.ps1
@@ -13,7 +13,8 @@ $DEBUG_TYPE="Release"
 $NUM_JOBS=4
 $MOCO="on"
 $CORE_BRANCH="main"
-$GUI_BRANCH="master"
+$GUI_BRANCH="main"
+$VIEWER_BRANCH="dev"
 
 function Help {
     Write-Output "This script builds the last available version of OpenSim-Gui in your computer."
@@ -28,6 +29,8 @@ function Help {
     Write-Output "    -s        Simple build without moco (Tropter and Casadi disabled)."
     Write-Output "    -c        Branch for opensim-core repository."
     Write-Output "    -g        Branch for opensim-gui repository."
+    Write-Output "    -v         Branch for opensim-viewer repository."
+
     Write-Output ""
     exit
 }
@@ -51,6 +54,9 @@ if ($c) {
 if ($g) {
     $GUI_BRANCH=$g
 }
+if ($v) {
+    $VIEWER_BRANCH=$v
+}
 if ($j -lt [int]1) {
     Write-Error "Value for parameter -j not valid."
     Help
@@ -63,6 +69,7 @@ Write-Output "NUM_JOBS $NUM_JOBS"
 Write-Output "MOCO $MOCO"
 Write-Output "CORE_BRANCH $CORE_BRANCH"
 Write-Output "GUI_BRANCH $GUI_BRANCH"
+Write-Output "VIEWER_BRANCH $VIEWER_BRANCH"
 
 # Install chocolatey
 Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
@@ -131,6 +138,9 @@ git clone https://github.com/opensim-org/opensim-gui.git C:/opensim-workspace/op
 chdir C:/opensim-workspace/opensim-gui-source
 git checkout $GUI_BRANCH
 git submodule update --init --recursive -- opensim-models opensim-visualizer
+chdir C:/opensim-workspace/opensim-gui-source/Gui/opensim/opensim-viewer
+git checkout $VIEWER_BRANCH
+chdir C:/opensim-workspace/opensim-gui-source
 
 # Build opensim-gui
 md C:/opensim-workspace/opensim-gui-build


### PR DESCRIPTION
### Brief summary of changes

Updating scripts to support latest version of libraries, dependencies, and integrate the prebuilt jxbrowser.

### Testing I've completed

- [ ] Windows 10 - Currently complains about missing json file.
- [ ] Windows 11 - Currently complains about missing json file.
- [ ] Ubuntu 24
- [ ] Ubuntu 26
- [ ] Mac

### CHANGELOG.md (choose one)

- no need to update because internal/dev.
