### PR TITLE
cache netbeans and use presets from core ci on windows

### DIFF
--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -115,7 +115,7 @@ runs:
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
         cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH `
-            -DPython3_ROOT_DIR=$env:pythonLocation
+            -DPython3_ROOT_DIR=$env:pythonLocation  -DSWIG_DOXYGEN=OFF -DBUILD_PYTHON_WRAPPING=OFF
 
         $env:match = cmake -N -L build/ci-msvc-windows-release | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
         $version = $env:match.split('=')[1]
@@ -128,6 +128,6 @@ runs:
     # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
-        cmake --build --preset ci-msvc-windows-release -j 4 -DSWIG_DOXYGEN=OFF -DBUILD_PYTHON_WRAPPING=OFF
+        cmake --build --preset ci-msvc-windows-release -j 4
         cmake --build --preset ci-msvc-windows-release --target doxygen
         cmake --build --preset ci-msvc-windows-release --target install

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -102,6 +102,7 @@ runs:
         path: ${{ inputs.path }}
 
     - name: Build dependencies
+      shell: pwsh
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         chdir $env:GITHUB_WORKSPACE\\dependencies
@@ -109,6 +110,7 @@ runs:
         cmake --build --preset ci-msvc-windows-release -j 4
 
     - name: Configure opensim-core
+      shell: pwsh
       id: configure
       run: |
         cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH `
@@ -121,6 +123,7 @@ runs:
         echo "OPENSIM_DEPENDENCIES_DIR=$env:GITHUB_WORKSPACE\build\dependencies\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
 
     - name: Build opensim-core
+      shell: pwsh
     # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
       run: |
         cmake --build --preset ci-msvc-windows-release -j 4

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -105,7 +105,7 @@ runs:
       shell: pwsh
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        chdir $env:GITHUB_WORKSPACE\\dependencies
+        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH
         cmake --build --preset ci-msvc-windows-release -j 4
 
@@ -113,6 +113,7 @@ runs:
       shell: pwsh
       id: configure
       run: |
+        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
         cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH `
             -DPython3_ROOT_DIR=$env:pythonLocation
 

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -128,6 +128,6 @@ runs:
     # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
-        cmake --build --preset ci-msvc-windows-release -j 4
+        cmake --build --preset ci-msvc-windows-release -j 4 -DSWIG_DOXYGEN=OFF
         cmake --build --preset ci-msvc-windows-release --target doxygen
         cmake --build --preset ci-msvc-windows-release --target install

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -128,6 +128,6 @@ runs:
     # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
-        cmake --build --preset ci-msvc-windows-release -j 4 -DSWIG_DOXYGEN=OFF
+        cmake --build --preset ci-msvc-windows-release -j 4 -DSWIG_DOXYGEN=OFF -DBUILD_PYTHON_WRAPPING=OFF
         cmake --build --preset ci-msvc-windows-release --target doxygen
         cmake --build --preset ci-msvc-windows-release --target install

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -67,14 +67,22 @@ runs:
         path: .\Apache-NetBeans-17-bin-windows-x64.exe
         key: netbeans-17
 
-    - name: Install Netbeans 17
+    - name: Download Netbeans 17
       shell: pwsh
-      #if: steps.cache-netbeans.outputs.cache-hit != 'true'
+      if: steps.cache-netbeans.outputs.cache-hit != 'true'
       run: |
         (New-Object System.Net.WebClient).DownloadFile("https://archive.apache.org/dist/netbeans/netbeans-installers/17/Apache-NetBeans-17-bin-windows-x64.exe", "Apache-NetBeans-17-bin-windows-x64.exe")
+
+    - name: Verify Netbeans installer hash
+      shell: pwsh
+      run: |
         $expectedHash = "c3d7a34184c4021486751fbc3878eb2376677674ff8d6d4bf87017fd2434122c8438072aa891e535fa0fa9aeafcb49ad833a61903180772369d99571b073baac"
         $hashFromFile = Get-FileHash -Algorithm SHA512 -Path .\Apache-NetBeans-17-bin-windows-x64.exe
         if (($hashFromFile.Hash) -ne ($expectedHash)) { Write-Error "Hash doesn't match." }
+
+    - name: Install Netbeans 17
+      shell: pwsh
+      run: |
         .\Apache-NetBeans-17-bin-windows-x64.exe --silent --javahome "$env:JAVA_HOME" | Out-Null # This installer is gregarious.
         echo "ANT_HOME=C:\\Program Files\\NetBeans-17.0\\netbeans\\extide\\ant" >> $GITHUB_ENV
 
@@ -93,60 +101,28 @@ runs:
         ref: ${{ inputs.ref }}
         path: ${{ inputs.path }}
 
-    - name: Cache opensim-core-dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        # Every time a cache is created, it's stored with this key.
-        # In subsequent runs, if the key matches the key of an existing cache,
-        # then the cache is used. We chose for this key to depend on the
-        # operating system and a hash of the hashes of all files in the
-        # dependencies directory (non-recursive).
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-dependencies-${{ hashFiles(format('{0}/dependencies/*', inputs.path)) }}
-
-    - name: Build opensim-core-dependencies
-      shell: pwsh
-      #if: steps.cache-dependencies.outputs.cache-hit != 'true'
+    - name: Build dependencies
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        echo $env:GITHUB_WORKSPACE\\build_deps
-        mkdir $env:GITHUB_WORKSPACE\\build_deps
-        chdir $env:GITHUB_WORKSPACE\\build_deps
-        # gci -r $env:GITHUB_WORKSPACE\\opensim-core
-        # /W0 disables warnings. The other flags are copied from CMake's
-        # default CMAKE_CXX_FLAGS.
-        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
-        $env:CXXFLAGS = "/W0 /MD"
-        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies -G"Visual Studio 17 2022" -A x64 -DSUPERBUILD_ezc3d:BOOL=on -DOPENSIM_WITH_CASADI:BOOL=on -DWIG_DIR=C:/ProgramData/chocolatey/lib/swig -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install
-        cmake . -LAH
-        cmake --build . --config Release -- /maxcpucount:2
+        chdir $env:GITHUB_WORKSPACE\\dependencies
+        cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH
+        cmake --build --preset ci-msvc-windows-release -j 4
 
-    - name: Obtain opensim-core commit
-      id: opensim-core-commit
-      shell: pwsh
+    - name: Configure opensim-core
+      id: configure
       run: |
-        cd ${{ inputs.path }}
-        $opensim_core_commit=(git rev-parse HEAD)
-        echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
+        cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH `
+            -DPython3_ROOT_DIR=$env:pythonLocation
 
-    - name: Cache opensim-core
-      id: cache-core
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim-core-install
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
+        $env:match = cmake -N -L build/ci-msvc-windows-release | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
+        $version = $env:match.split('=')[1]
+        echo "version=$version" >> $env:GITHUB_OUTPUT
+        echo "CMAKE_INSTALL_PREFIX=$env:GITHUB_WORKSPACE\build\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
+        echo "OPENSIM_DEPENDENCIES_DIR=$env:GITHUB_WORKSPACE\build\dependencies\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
 
     - name: Build opensim-core
-      shell: pwsh
-      #if: steps.cache-core.outputs.cache-hit != 'true'
+    # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
       run: |
-        echo $env:GITHUB_WORKSPACE\\build_core
-        mkdir $env:GITHUB_WORKSPACE\\build_core
-        chdir $env:GITHUB_WORKSPACE\\build_core
-        $env:CXXFLAGS = "/W0 /MD"
-        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }} -G"Visual Studio 17 2022" -A x64 -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off  -DBUILD_API_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=~/opensim-core-install
-        cmake . -LAH
-        cmake --build . --config Release -- /maxcpucount:2
-        cmake --install .
+        cmake --build --preset ci-msvc-windows-release -j 4
+        cmake --build --preset ci-msvc-windows-release --target doxygen
+        cmake --build --preset ci-msvc-windows-release --target install

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -101,33 +101,60 @@ runs:
         ref: ${{ inputs.ref }}
         path: ${{ inputs.path }}
 
-    - name: Build dependencies
+    - name: Cache opensim-core-dependencies
+      id: cache-dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim_dependencies_install
+        # Every time a cache is created, it's stored with this key.
+        # In subsequent runs, if the key matches the key of an existing cache,
+        # then the cache is used. We chose for this key to depend on the
+        # operating system and a hash of the hashes of all files in the
+        # dependencies directory (non-recursive).
+        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: ${{ runner.os }}-dependencies-${{ hashFiles(format('{0}/dependencies/*', inputs.path)) }}
+
+    - name: Build opensim-core-dependencies
       shell: pwsh
       #if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
-        cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH
-        cmake --build --preset ci-msvc-windows-release -j 4
+        echo $env:GITHUB_WORKSPACE\\build_deps
+        mkdir $env:GITHUB_WORKSPACE\\build_deps
+        chdir $env:GITHUB_WORKSPACE\\build_deps
+        # gci -r $env:GITHUB_WORKSPACE\\opensim-core
+        # /W0 disables warnings. The other flags are copied from CMake's
+        # default CMAKE_CXX_FLAGS.
+        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
+        $env:CXXFLAGS = "/W0 /MD"
+        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies -G"Visual Studio 17 2022" -A x64 -DSUPERBUILD_ezc3d:BOOL=on -DOPENSIM_WITH_CASADI:BOOL=on -DWIG_DIR=C:/ProgramData/chocolatey/lib/swig -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install
+        cmake . -LAH
+        cmake --build . --config Release -- /maxcpucount:2
 
-    - name: Configure opensim-core
+    - name: Obtain opensim-core commit
+      id: opensim-core-commit
       shell: pwsh
-      id: configure
       run: |
-        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
-        cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH `
-            -DPython3_ROOT_DIR=$env:pythonLocation  -DSWIG_DOXYGEN=OFF -DBUILD_PYTHON_WRAPPING=OFF
+        cd ${{ inputs.path }}
+        $opensim_core_commit=(git rev-parse HEAD)
+        echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
 
-        $env:match = cmake -N -L build/ci-msvc-windows-release | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
-        $version = $env:match.split('=')[1]
-        echo "version=$version" >> $env:GITHUB_OUTPUT
-        echo "CMAKE_INSTALL_PREFIX=$env:GITHUB_WORKSPACE\${{ inputs.path }}\build\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
-        echo "OPENSIM_DEPENDENCIES_DIR=$env:GITHUB_WORKSPACE\${{ inputs.path }}\build\dependencies\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
+    - name: Cache opensim-core
+      id: cache-core
+      uses: actions/cache@v3
+      with:
+        path: ~/opensim-core-install
+        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
 
     - name: Build opensim-core
       shell: pwsh
-    # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
+      #if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
-        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
-        cmake --build --preset ci-msvc-windows-release -j 4
-        cmake --build --preset ci-msvc-windows-release --target doxygen
-        cmake --build --preset ci-msvc-windows-release --target install
+        echo $env:GITHUB_WORKSPACE\\build_core
+        mkdir $env:GITHUB_WORKSPACE\\build_core
+        chdir $env:GITHUB_WORKSPACE\\build_core
+        $env:CXXFLAGS = "/W0 /MD"
+        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }} -G"Visual Studio 17 2022" -A x64 -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off  -DBUILD_API_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=~/opensim-core-install
+        cmake . -LAH
+        cmake --build . --config Release -- /maxcpucount:2
+        cmake --install .

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -103,7 +103,7 @@ runs:
 
     - name: Build dependencies
       shell: pwsh
-      if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      #if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH
@@ -120,13 +120,14 @@ runs:
         $env:match = cmake -N -L build/ci-msvc-windows-release | Select-String -Pattern OPENSIM_QUALIFIED_VERSION
         $version = $env:match.split('=')[1]
         echo "version=$version" >> $env:GITHUB_OUTPUT
-        echo "CMAKE_INSTALL_PREFIX=$env:GITHUB_WORKSPACE\build\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
-        echo "OPENSIM_DEPENDENCIES_DIR=$env:GITHUB_WORKSPACE\build\dependencies\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
+        echo "CMAKE_INSTALL_PREFIX=$env:GITHUB_WORKSPACE\${{ inputs.path }}\build\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
+        echo "OPENSIM_DEPENDENCIES_DIR=$env:GITHUB_WORKSPACE\${{ inputs.path }}\build\dependencies\ci-msvc-windows-release\install" >> $env:GITHUB_OUTPUT
 
     - name: Build opensim-core
       shell: pwsh
     # Install now to avoid building bindings twice (TODO: still an issue with Visual Studio 2022).
       run: |
+        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }} 
         cmake --build --preset ci-msvc-windows-release -j 4
         cmake --build --preset ci-msvc-windows-release --target doxygen
         cmake --build --preset ci-msvc-windows-release --target install

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -105,7 +105,7 @@ runs:
       shell: pwsh
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        chdir $env:GITHUB_WORKSPACE\\dependencies
+        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH
         cmake --build --preset ci-msvc-windows-release -j 4
 
@@ -113,7 +113,7 @@ runs:
       shell: pwsh
       id: configure
       run: |
-        cmake -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH `
+        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }} -G "Visual Studio 17 2022" . --preset ci-msvc-windows-release -LAH `
             -DPython3_ROOT_DIR=$env:pythonLocation
 
         $env:match = cmake -N -L build/ci-msvc-windows-release | Select-String -Pattern OPENSIM_QUALIFIED_VERSION

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Build GUI installer
         uses: ./.github/workflows/actions/build-gui-installer
 
-
   mac:
     name: Mac
 
@@ -104,23 +103,26 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v3
       with:
-        path: ~/opensim_dependencies_install
+        # Matches the dependencies preset's installDir:
+        # ${sourceDir}/../build/dependencies/${presetName}/install, where
+        # sourceDir is opensim-core/dependencies.
+        path: opensim-core/build/dependencies/ci-make-macos-release/install
         # Every time a cache is created, it's stored with this key.
         # In subsequent runs, if the key matches the key of an existing cache,
         # then the cache is used. We chose for this key to depend on the
-        # operating system and a hash of the hashes of all files in the
-        # dependencies directory (non-recursive).
+        # operating system, the preset, and a hash of the hashes of all files
+        # in the dependencies directory (non-recursive).
         # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('opensim-core/dependencies/*') }}
+        key: ${{ runner.os }}-dependencies-ci-make-macos-release-${{ hashFiles('opensim-core/dependencies/*') }}
         
     - name: Build opensim-core-dependencies
-      #if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        mkdir build_deps
-        cd build_deps
-        cmake ../opensim-core/dependencies -DSUPERBUILD_ezc3d:BOOL=on  -DOPENSIM_WITH_CASADI:BOOL=on -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install -DCMAKE_BUILD_TYPE=Release
-        cmake . -LAH
-        cmake --build . --config Release
+        cd opensim-core/dependencies
+        # SUPERBUILD_ezc3d and OPENSIM_WITH_CASADI are already on via the
+        # dependencies preset's "default" config.
+        cmake . --preset ci-make-macos-release -LAH
+        cmake --build --preset ci-make-macos-release -j 4
         
     - name: Obtain opensim-core commit
       id: opensim-core-commit
@@ -133,8 +135,9 @@ jobs:
       id: cache-core
       uses: actions/cache@v3
       with:
-        path: ~/opensim-core-install
-        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
+        # Matches the root preset's installDir: ${sourceDir}/build/${presetName}/install.
+        path: opensim-core/build/ci-make-macos-release/install
+        key: ${{ runner.os }}-ci-make-macos-release-${{ steps.opensim-core-commit.outputs.hash }}
         
     - name: Install SWIG
       run: |
@@ -145,13 +148,18 @@ jobs:
         make && make -j4 install
 
     - name: Build opensim-core
+      if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
-        mkdir build_core
-        cd build_core
-        cmake ../opensim-core -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DSWIG_EXECUTABLE=~/swig/bin/swig -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off  -DBUILD_API_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_INSTALL_UNIX_FHS=OFF -DOPENSIM_DISABLE_LOG_FILE=ON
-        cmake . -LAH
-        cmake --build . --config Release 
-        cmake --install .
+        cd opensim-core
+        # OPENSIM_DEPENDENCIES_DIR is already set by the preset to
+        # build/dependencies/ci-make-macos-release/install (built above).
+        # BUILD_JAVA_WRAPPING / BUILD_PYTHON_WRAPPING / BUILD_API_EXAMPLES /
+        # OPENSIM_C3D_PARSER / OPENSIM_INSTALL_UNIX_FHS / OPENSIM_DISABLE_LOG_FILE
+        # are already set via the "default"/"ci" presets. SWIG_EXECUTABLE is
+        # environment-specific, and BUILD_TESTING isn't set by any preset.
+        cmake . --preset ci-make-macos-release -LAH -DSWIG_EXECUTABLE=~/swig/bin/swig -DBUILD_TESTING=off
+        cmake --build --preset ci-make-macos-release -j 4
+        cmake --build --preset ci-make-macos-release --target install
 
     - name: Update submodules
       run: git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/opensim-viewer
@@ -161,7 +169,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ../ -DCMAKE_PREFIX_PATH=~/opensim-core-install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=/Applications/NetBeans/Apache NetBeans 17.app/Contents/Resources/NetBeans/netbeans;-Dnbplatform.default.harness.dir=/Applications/NetBeans/Apache NetBeans 17.app/Contents/Resources/NetBeans/netbeans/harness"
+        cmake ../ -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/opensim-core/build/ci-make-macos-release/install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=/Applications/NetBeans/Apache NetBeans 17.app/Contents/Resources/NetBeans/netbeans;-Dnbplatform.default.harness.dir=/Applications/NetBeans/Apache NetBeans 17.app/Contents/Resources/NetBeans/netbeans/harness"
         make CopyOpenSimCore
         make PrepareInstaller
         # Read the value of the cache variable storing the GUI build version.
@@ -268,23 +276,26 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v3
       with:
-        path: ~/opensim_dependencies_install
+        # Matches the dependencies preset's installDir:
+        # ${sourceDir}/../build/dependencies/${presetName}/install, where
+        # sourceDir is opensim-core/dependencies.
+        path: opensim-core/build/dependencies/ci-make-linux-release/install
         # Every time a cache is created, it's stored with this key.
         # In subsequent runs, if the key matches the key of an existing cache,
         # then the cache is used. We chose for this key to depend on the
-        # operating system and a hash of the hashes of all files in the
-        # dependencies directory (non-recursive).
+        # operating system, the preset, and a hash of the hashes of all files
+        # in the dependencies directory (non-recursive).
         # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-dependencies-${{ hashFiles('opensim-core/dependencies/*') }}
+        key: ${{ runner.os }}-dependencies-ci-make-linux-release-${{ hashFiles('opensim-core/dependencies/*') }}
 
     - name: Build opensim-core-dependencies
-      #if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        mkdir build_deps
-        cd build_deps
-        cmake ../opensim-core/dependencies -DSUPERBUILD_ezc3d:BOOL=on  -DOPENSIM_WITH_CASADI:BOOL=on -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install
-        cmake . -LAH
-        cmake --build . --config Release
+        cd opensim-core/dependencies
+        # SUPERBUILD_ezc3d and OPENSIM_WITH_CASADI are already on via the
+        # dependencies preset's "default" config.
+        cmake . --preset ci-make-linux-release -LAH
+        cmake --build --preset ci-make-linux-release -j 4
         
     - name: Obtain opensim-core commit
       id: opensim-core-commit
@@ -297,23 +308,27 @@ jobs:
       id: cache-core
       uses: actions/cache@v3
       with:
-        path: ~/opensim-core-install
-        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
+        # Matches the root preset's installDir: ${sourceDir}/build/${presetName}/install.
+        path: opensim-core/build/ci-make-linux-release/install
+        key: ${{ runner.os }}-ci-make-linux-release-${{ steps.opensim-core-commit.outputs.hash }}
     
     - name: Build opensim-core
-      #if: steps.cache-core.outputs.cache-hit != 'true'
+      if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
-        mkdir build_core
-        cd build_core
-        cmake ../opensim-core -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off  -DBUILD_API_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=~/opensim-core-install -DOPENSIM_INSTALL_UNIX_FHS=OFF -DSWIG_DIR=~/swig/share/swig -DSWIG_EXECUTABLE=~/swig/bin/swig
-        cmake . -LAH
-        cmake --build . --config Release 
-        cmake --install .
+        cd opensim-core
+        # OPENSIM_DEPENDENCIES_DIR is already set by the preset to
+        # build/dependencies/ci-make-linux-release/install (built above).
+        # BUILD_JAVA_WRAPPING / BUILD_PYTHON_WRAPPING / BUILD_API_EXAMPLES /
+        # OPENSIM_C3D_PARSER / OPENSIM_INSTALL_UNIX_FHS are already set via
+        # the "default"/"ci" presets. SWIG_DIR/SWIG_EXECUTABLE are
+        # environment-specific, and BUILD_TESTING isn't set by any preset.
+        cmake . --preset ci-make-linux-release -LAH -DSWIG_DIR=~/swig/share/swig -DSWIG_EXECUTABLE=~/swig/bin/swig -DBUILD_TESTING=off
+        cmake --build --preset ci-make-linux-release -j 4
+        cmake --build --preset ci-make-linux-release --target install
 
-    - name: Remove opensim-core and swig
+    - name: Remove swig source
       run: |
         rm -rf ~/swig-source
-        rm -rf ~/work/opensim-gui/opensim-gui/build_core
       
     - name: Update submodules
       run: git submodule update --init --recursive -- opensim-models opensim-visualizer Gui/opensim/opensim-viewer
@@ -323,7 +338,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake ../ -DCMAKE_PREFIX_PATH=~/opensim-core-install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=$HOME/netbeans;-Dnbplatform.default.harness.dir=$HOME/netbeans/harness"
+        cmake ../ -DCMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/opensim-core/build/ci-make-linux-release/install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=$HOME/netbeans;-Dnbplatform.default.harness.dir=$HOME/netbeans/harness"
         make CopyOpenSimCore
         make PrepareInstaller
         # Read the value of the cache variable storing the GUI build version.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,9 +67,6 @@ jobs:
         distribution: 'zulu'
         java-version: 8
 
-    # - name: Setup tmate session to debug the workflow through SSH.
-    #   uses: mxschmitt/action-tmate@v2
-        
     - name: Install NetBeans 17
       # `brew cask install netbeans-java-se` requires sudo but brew won't allow sudo,
       # so we install NetBeans ourselves.
@@ -103,24 +100,13 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v3
       with:
-        # Matches the dependencies preset's installDir:
-        # ${sourceDir}/../build/dependencies/${presetName}/install, where
-        # sourceDir is opensim-core/dependencies.
         path: opensim-core/build/dependencies/ci-make-macos-release/install
-        # Every time a cache is created, it's stored with this key.
-        # In subsequent runs, if the key matches the key of an existing cache,
-        # then the cache is used. We chose for this key to depend on the
-        # operating system, the preset, and a hash of the hashes of all files
-        # in the dependencies directory (non-recursive).
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
         key: ${{ runner.os }}-dependencies-ci-make-macos-release-${{ hashFiles('opensim-core/dependencies/*') }}
         
     - name: Build opensim-core-dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         cd opensim-core/dependencies
-        # SUPERBUILD_ezc3d and OPENSIM_WITH_CASADI are already on via the
-        # dependencies preset's "default" config.
         cmake . --preset ci-make-macos-release -LAH
         cmake --build --preset ci-make-macos-release -j 4
         
@@ -135,7 +121,6 @@ jobs:
       id: cache-core
       uses: actions/cache@v3
       with:
-        # Matches the root preset's installDir: ${sourceDir}/build/${presetName}/install.
         path: opensim-core/build/ci-make-macos-release/install
         key: ${{ runner.os }}-ci-make-macos-release-${{ steps.opensim-core-commit.outputs.hash }}
         
@@ -151,12 +136,6 @@ jobs:
       if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         cd opensim-core
-        # OPENSIM_DEPENDENCIES_DIR is already set by the preset to
-        # build/dependencies/ci-make-macos-release/install (built above).
-        # BUILD_JAVA_WRAPPING / BUILD_PYTHON_WRAPPING / BUILD_API_EXAMPLES /
-        # OPENSIM_C3D_PARSER / OPENSIM_INSTALL_UNIX_FHS / OPENSIM_DISABLE_LOG_FILE
-        # are already set via the "default"/"ci" presets. SWIG_EXECUTABLE is
-        # environment-specific, and BUILD_TESTING isn't set by any preset.
         cmake . --preset ci-make-macos-release -LAH -DSWIG_EXECUTABLE=~/swig/bin/swig -DBUILD_TESTING=off
         cmake --build --preset ci-make-macos-release -j 4
         cmake --build --preset ci-make-macos-release --target install
@@ -276,24 +255,13 @@ jobs:
       id: cache-dependencies
       uses: actions/cache@v3
       with:
-        # Matches the dependencies preset's installDir:
-        # ${sourceDir}/../build/dependencies/${presetName}/install, where
-        # sourceDir is opensim-core/dependencies.
         path: opensim-core/build/dependencies/ci-make-linux-release/install
-        # Every time a cache is created, it's stored with this key.
-        # In subsequent runs, if the key matches the key of an existing cache,
-        # then the cache is used. We chose for this key to depend on the
-        # operating system, the preset, and a hash of the hashes of all files
-        # in the dependencies directory (non-recursive).
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
         key: ${{ runner.os }}-dependencies-ci-make-linux-release-${{ hashFiles('opensim-core/dependencies/*') }}
 
     - name: Build opensim-core-dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         cd opensim-core/dependencies
-        # SUPERBUILD_ezc3d and OPENSIM_WITH_CASADI are already on via the
-        # dependencies preset's "default" config.
         cmake . --preset ci-make-linux-release -LAH
         cmake --build --preset ci-make-linux-release -j 4
         
@@ -308,7 +276,6 @@ jobs:
       id: cache-core
       uses: actions/cache@v3
       with:
-        # Matches the root preset's installDir: ${sourceDir}/build/${presetName}/install.
         path: opensim-core/build/ci-make-linux-release/install
         key: ${{ runner.os }}-ci-make-linux-release-${{ steps.opensim-core-commit.outputs.hash }}
     
@@ -316,12 +283,6 @@ jobs:
       if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         cd opensim-core
-        # OPENSIM_DEPENDENCIES_DIR is already set by the preset to
-        # build/dependencies/ci-make-linux-release/install (built above).
-        # BUILD_JAVA_WRAPPING / BUILD_PYTHON_WRAPPING / BUILD_API_EXAMPLES /
-        # OPENSIM_C3D_PARSER / OPENSIM_INSTALL_UNIX_FHS are already set via
-        # the "default"/"ci" presets. SWIG_DIR/SWIG_EXECUTABLE are
-        # environment-specific, and BUILD_TESTING isn't set by any preset.
         cmake . --preset ci-make-linux-release -LAH -DSWIG_DIR=~/swig/share/swig -DSWIG_EXECUTABLE=~/swig/bin/swig -DBUILD_TESTING=off
         cmake --build --preset ci-make-linux-release -j 4
         cmake --build --preset ci-make-linux-release --target install

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,6 +26,7 @@ jobs:
         uses: ./.github/workflows/actions/build-opensim-core
         with:
           repository: opensim-org/opensim-core
+          ref: main
 
       - name: Build GUI installer
         uses: ./.github/workflows/actions/build-gui-installer
@@ -34,7 +35,7 @@ jobs:
   mac:
     name: Mac
 
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: Checkout opensim-gui
@@ -45,6 +46,7 @@ jobs:
       with:
          repository: opensim-org/opensim-core
          path: 'opensim-core'
+         ref: main
         
     - uses: actions/setup-python@v4
       with:
@@ -135,7 +137,6 @@ jobs:
         key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
         
     - name: Install SWIG
-      if: steps.cache-swig.outputs.cache-hit != 'true'
       run: |
         mkdir ~/swig-source && cd ~/swig-source
         wget https://github.com/swig/swig/archive/refs/tags/v4.1.1.tar.gz
@@ -144,7 +145,6 @@ jobs:
         make && make -j4 install
 
     - name: Build opensim-core
-      #if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         mkdir build_core
         cd build_core


### PR DESCRIPTION
Fixes issue #1668

### Brief summary of changes
use presets to build opensim-core and dependencies on ci. This works on osx, linux but fails on windows due to excessively long path names making swig generated files inaccessible. Will need to add a preset on core to force short pathnames (instead of ci-msvc......) in the hope resulting file names are usable.

### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because internal
