### PR TITLE
Use preset to build opensim-core within gui build

### DIFF
--- a/.github/workflows/actions/build-gui-installer/action.yml
+++ b/.github/workflows/actions/build-gui-installer/action.yml
@@ -23,6 +23,7 @@ runs:
       run: |
         mkdir build
         cd build
+        # grab install folder from build-opensim-core install step and use below
         cmake ../ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=~/opensim-core-install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:/Program Files/NetBeans-17/netbeans;-Dnbplatform.default.harness.dir=C:/Program Files/NetBeans-17/netbeans/harness;-Dmsvc.redist.exe=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\14.44.35112\vcredist_x64.exe"
         cmake --build . --target CopyOpenSimCore --config Release
         cmake --build . --target CopyModels --config Release

--- a/.github/workflows/actions/build-gui-installer/action.yml
+++ b/.github/workflows/actions/build-gui-installer/action.yml
@@ -23,8 +23,7 @@ runs:
       run: |
         mkdir build
         cd build
-        # grab install folder from build-opensim-core install step and use below
-        cmake ../ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=~/opensim-core-install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:/Program Files/NetBeans-17/netbeans;-Dnbplatform.default.harness.dir=C:/Program Files/NetBeans-17/netbeans/harness;-Dmsvc.redist.exe=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\14.44.35112\vcredist_x64.exe"
+        cmake ../ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/opensim-core/build/install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:/Program Files/NetBeans-17/netbeans;-Dnbplatform.default.harness.dir=C:/Program Files/NetBeans-17/netbeans/harness;-Dmsvc.redist.exe=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\14.44.35112\vcredist_x64.exe"
         cmake --build . --target CopyOpenSimCore --config Release
         cmake --build . --target CopyModels --config Release
         cmake --build . --target PrepareInstaller --config Release

--- a/.github/workflows/actions/build-gui-installer/action.yml
+++ b/.github/workflows/actions/build-gui-installer/action.yml
@@ -23,7 +23,7 @@ runs:
       run: |
         mkdir build
         cd build
-        cmake ../ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/opensim-core/build/install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:/Program Files/NetBeans-17/netbeans;-Dnbplatform.default.harness.dir=C:/Program Files/NetBeans-17/netbeans/harness;-Dmsvc.redist.exe=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\14.44.35112\vcredist_x64.exe"
+        cmake ../ -G"Visual Studio 17 2022" -A x64 -DCMAKE_PREFIX_PATH=${{ github.workspace }}/opensim-core/install -DANT_ARGS="-Dnbplatform.default.netbeans.dest.dir=C:/Program Files/NetBeans-17/netbeans;-Dnbplatform.default.harness.dir=C:/Program Files/NetBeans-17/netbeans/harness;-Dmsvc.redist.exe=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\14.44.35112\vcredist_x64.exe"
         cmake --build . --target CopyOpenSimCore --config Release
         cmake --build . --target CopyModels --config Release
         cmake --build . --target PrepareInstaller --config Release

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -120,7 +120,7 @@ runs:
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
-        cmake --build .  --config Release -j 4
+        cmake --build $env:GITHUB_WORKSPACE/${{ inputs.path }}/../build/dependencies/msvc-dev-gui-default  --config Release -j 4
 
     - name: Obtain opensim-core commit
       id: opensim-core-commit

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -120,7 +120,7 @@ runs:
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
-        cmake --build $env:GITHUB_WORKSPACE/${{ inputs.path }}/../build/dependencies/msvc-dev-gui-default  --config Release -j 4
+        cmake --build $env:GITHUB_WORKSPACE/${{ inputs.path }}/opensim-core/../build/dependencies/msvc-dev-gui-default  --config Release -j 4
 
     - name: Obtain opensim-core commit
       id: opensim-core-commit

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -118,17 +118,8 @@ runs:
       shell: pwsh
       #if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        echo $env:GITHUB_WORKSPACE\\build_deps
-        mkdir $env:GITHUB_WORKSPACE\\build_deps
-        chdir $env:GITHUB_WORKSPACE\\build_deps
-        # gci -r $env:GITHUB_WORKSPACE\\opensim-core
-        # /W0 disables warnings. The other flags are copied from CMake's
-        # default CMAKE_CXX_FLAGS.
-        # https://msdn.microsoft.com/en-us/library/19z1t1wy.aspx
-        $env:CXXFLAGS = "/W0 /MD"
-        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies -G"Visual Studio 17 2022" -A x64 -DSUPERBUILD_ezc3d:BOOL=on -DOPENSIM_WITH_CASADI:BOOL=on -DWIG_DIR=C:/ProgramData/chocolatey/lib/swig -DCMAKE_INSTALL_PREFIX=~/opensim_dependencies_install
-        cmake . -LAH
-        cmake --build . --config Release -- /maxcpucount:2
+        cmake -G "Visual Studio 17 2022" $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies --preset msvc-dev-gui-default -LAH
+        cmake --build --preset msvc-dev-gui-default -j 4
 
     - name: Obtain opensim-core commit
       id: opensim-core-commit
@@ -150,11 +141,7 @@ runs:
       shell: pwsh
       #if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
-        echo $env:GITHUB_WORKSPACE\\build_core
-        mkdir $env:GITHUB_WORKSPACE\\build_core
-        chdir $env:GITHUB_WORKSPACE\\build_core
-        $env:CXXFLAGS = "/W0 /MD"
-        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }} -G"Visual Studio 17 2022" -A x64 -DOPENSIM_DEPENDENCIES_DIR=~/opensim_dependencies_install -DBUILD_JAVA_WRAPPING=on -DBUILD_PYTHON_WRAPPING=on -DOPENSIM_C3D_PARSER=ezc3d -DBUILD_TESTING=off  -DBUILD_API_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=~/opensim-core-install
+        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }} -G "Visual Studio 17 2022" --preset msvc-dev-gui-default
         cmake . -LAH
-        cmake --build . --config Release -- /maxcpucount:2
+        cmake --build --preset msvc-dev-gui-default --config Release
         cmake --install .

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -120,7 +120,7 @@ runs:
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
-        cmake --build --preset msvc-dev-gui-default -j 4
+        cmake -build . -j 4
 
     - name: Obtain opensim-core commit
       id: opensim-core-commit
@@ -145,5 +145,5 @@ runs:
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}
         cmake . -G "Visual Studio 17 2022" --preset msvc-dev-gui-default
         cmake . -LAH
-        cmake --build --preset msvc-dev-gui-default --config Release
+        cmake --build . --config Release
         cmake --install .

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -120,7 +120,7 @@ runs:
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
-        cmake -build . -j 4
+        cmake --build .  --config Release -j 4
 
     - name: Obtain opensim-core commit
       id: opensim-core-commit

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -118,7 +118,8 @@ runs:
       shell: pwsh
       #if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        cmake -G "Visual Studio 17 2022" $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies --preset msvc-dev-gui-default -LAH
+        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
+        cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
         cmake --build --preset msvc-dev-gui-default -j 4
 
     - name: Obtain opensim-core commit
@@ -141,7 +142,8 @@ runs:
       shell: pwsh
       #if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
-        cmake $env:GITHUB_WORKSPACE/${{ inputs.path }} -G "Visual Studio 17 2022" --preset msvc-dev-gui-default
+        chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}
+        cmake . -G "Visual Studio 17 2022" --preset msvc-dev-gui-default
         cmake . -LAH
         cmake --build --preset msvc-dev-gui-default --config Release
         cmake --install .

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -120,7 +120,7 @@ runs:
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
-        cmake --build $env:GITHUB_WORKSPACE/${{ inputs.path }}/opensim-core/../build/dependencies/msvc-dev-gui-default  --config Release -j 4
+        cmake --build --preset msvc-dev-gui-default -j 4
 
     - name: Obtain opensim-core commit
       id: opensim-core-commit
@@ -145,5 +145,5 @@ runs:
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}
         cmake . -G "Visual Studio 17 2022" --preset msvc-dev-gui-default
         cmake . -LAH
-        cmake --build . --config Release
+        cmake --build --preset msvc-dev-gui-default --config Release
         cmake --install .

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -101,9 +101,16 @@ runs:
         ref: ${{ inputs.ref }}
         path: ${{ inputs.path }}
 
+    - name: Cache opensim-core-dependencies
+      id: cache-dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/${{ inputs.path }}/build/dependencies
+        key: ${{ runner.os }}-deps-msvc-dev-gui-default-${{ inputs.swig-version }}-${{ hashFiles(format('{0}/dependencies/CMakeLists.txt', inputs.path), format('{0}/dependencies/**/CMakeLists.txt', inputs.path), format('{0}/CMakePresets.json', inputs.path)) }}
+
     - name: Build opensim-core-dependencies
       shell: pwsh
-      #if: steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
@@ -117,6 +124,17 @@ runs:
         cd ${{ inputs.path }}
         $opensim_core_commit=(git rev-parse HEAD)
         echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
+
+    - name: Cache opensim-core build
+      id: cache-core
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ github.workspace }}/${{ inputs.path }}/build
+          !${{ github.workspace }}/${{ inputs.path }}/build/dependencies
+        key: ${{ runner.os }}-core-msvc-dev-gui-default-${{ steps.opensim-core-commit.outputs.hash }}
+        restore-keys: |
+          ${{ runner.os }}-core-msvc-dev-gui-default-
 
     - name: Build opensim-core
       shell: pwsh

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -145,5 +145,5 @@ runs:
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}
         cmake . -G "Visual Studio 17 2022" --preset msvc-dev-gui-default
         cmake . -LAH
-        cmake --build --preset msvc-dev-gui-default --config Release
+        cmake --build --preset msvc-dev-gui-default
         cmake --install .

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -101,25 +101,13 @@ runs:
         ref: ${{ inputs.ref }}
         path: ${{ inputs.path }}
 
-    - name: Cache opensim-core-dependencies
-      id: cache-dependencies
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim_dependencies_install
-        # Every time a cache is created, it's stored with this key.
-        # In subsequent runs, if the key matches the key of an existing cache,
-        # then the cache is used. We chose for this key to depend on the
-        # operating system and a hash of the hashes of all files in the
-        # dependencies directory (non-recursive).
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-dependencies-${{ hashFiles(format('{0}/dependencies/*', inputs.path)) }}
-
     - name: Build opensim-core-dependencies
       shell: pwsh
       #if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}/dependencies
         cmake . -G "Visual Studio 17 2022"  --preset msvc-dev-gui-default -LAH
+        # dependencies are installed into $env:GITHUB_WORKSPACE/${{ inputs.path }}/build/dependencies/msvc-dev-gui-default/install
         cmake --build --preset msvc-dev-gui-default -j 4
 
     - name: Obtain opensim-core commit
@@ -130,20 +118,11 @@ runs:
         $opensim_core_commit=(git rev-parse HEAD)
         echo "hash=$opensim_core_commit" >> $GITHUB_OUTPUT
 
-    - name: Cache opensim-core
-      id: cache-core
-      uses: actions/cache@v3
-      with:
-        path: ~/opensim-core-install
-        # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: ${{ runner.os }}-${{ steps.opensim-core-commit.outputs.hash }}
-
     - name: Build opensim-core
       shell: pwsh
       #if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}
-        cmake . -G "Visual Studio 17 2022" --preset msvc-dev-gui-default
-        cmake . -LAH
+        cmake . -G "Visual Studio 17 2022" --preset msvc-dev-gui-default  -DSIMBODY_HOME=$env:GITHUB_WORKSPACE/${{ inputs.path }}/build/dependencies/msvc-dev-gui-default/install/simbody/cmake
         cmake --build --preset msvc-dev-gui-default
         cmake --install .

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -17,7 +17,7 @@ inputs:
   java-version:
     description: 'JDK version (Temurin)'
     required: false
-    default: '11'
+    default: '17'
   repository:
     description: 'opensim-core repository to check out'
     required: false

--- a/.github/workflows/actions/build-opensim-core/action.yml
+++ b/.github/workflows/actions/build-opensim-core/action.yml
@@ -123,6 +123,6 @@ runs:
       #if: steps.cache-core.outputs.cache-hit != 'true'
       run: |
         chdir $env:GITHUB_WORKSPACE/${{ inputs.path }}
-        cmake . -G "Visual Studio 17 2022" --preset msvc-dev-gui-default  -DSIMBODY_HOME=$env:GITHUB_WORKSPACE/${{ inputs.path }}/build/dependencies/msvc-dev-gui-default/install/simbody/cmake
-        cmake --build --preset msvc-dev-gui-default
-        cmake --install .
+        cmake . --preset msvc-dev-gui-default -LAH -DCMAKE_PREFIX_PATH="${{ github.workspace }}/opensim-core/build/dependencies/msvc-dev-gui-default/install"
+        cmake --build --preset msvc-dev-gui-default -j 4 
+        cmake --build --preset msvc-dev-gui-default --target install


### PR DESCRIPTION
Fixes issue #1668 

### Brief summary of changes
use preset custom made for gui on windows (shortpath) in ci build script on windows
### Testing I've completed

### CHANGELOG.md (choose one)

- no need to update because internal